### PR TITLE
docs: 优化README中的图片显示尺寸

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ claude mcp add --transport http xiaohongshu-mcp http://localhost:18060/mcp
 
 **发布结果：**
 
-![xiaohongshu-mcp 发布结果](./assets/publish_result.jpeg)
+<img src="./assets/publish_result.jpeg" alt="xiaohongshu-mcp 发布结果" width="400">


### PR DESCRIPTION
## Summary
- 优化README中发布结果截图的显示尺寸
- 将原始大尺寸图片(1170x3941)限制为宽度400px
- 改善GitHub页面上的阅读体验

## Changes
- 使用HTML `<img>` 标签替代Markdown图片语法
- 设置图片宽度为400px，高度自动等比例缩放
- 保持原图片文件不变，仅修改显示方式

## Test plan
- [x] 在GitHub上预览README效果
- [x] 确认图片能正常显示
- [x] 验证图片大小合适，不影响阅读

🤖 Generated with [Claude Code](https://claude.ai/code)