### PR TITLE
chore: 更新用户名常量为小红书的配置

### DIFF
--- a/configs/username.go
+++ b/configs/username.go
@@ -1,5 +1,5 @@
 package configs
 
 const (
-	Username = "xpzouying"
+	Username = "xiaohongshu-mcp"
 )


### PR DESCRIPTION
- 将用户名常量从 "xpzouying" 修改为 "xiaohongshu-mcp" 以反映最新的配置要求

CLOSE: #17