### PR TITLE
主要修改内容：

### DIFF
--- a/MCP_README.md
+++ b/MCP_README.md
@@ -1,0 +1,183 @@
+# MCP 服务接入指南
+
+本文档介绍如何在各种 AI 客户端中接入小红书 MCP 服务。
+
+## 🚀 快速开始
+
+### 1. 启动 MCP 服务
+
+```bash
+# 启动服务（默认无头模式）
+go run .
+
+# 或者有界面模式
+go run . -headless=false
+```
+
+服务将运行在：`http://localhost:18060/mcp`
+
+### 2. 验证服务状态
+
+```bash
+# 测试 MCP 连接
+curl -X POST http://localhost:18060/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
+```
+
+## 📱 客户端接入
+
+### Claude Code CLI
+
+```bash
+# 添加 HTTP MCP 服务器
+claude mcp add --transport http xiaohongshu-mcp http://localhost:18060/mcp
+```
+
+### Cursor
+
+#### 配置文件的方式
+
+创建或编辑 MCP 配置文件：
+
+**项目级配置**（推荐）：
+在项目根目录创建 `.cursor/mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "xiaohongshu-mcp": {
+      "url": "http://localhost:18060/mcp",
+      "description": "小红书内容发布服务 - MCP Streamable HTTP"
+    }
+  }
+}
+```
+
+**全局配置**：
+在用户目录创建 `~/.cursor/mcp.json` (同样内容)。
+
+#### 使用步骤
+
+1. 确保小红书 MCP 服务正在运行
+2. 保存配置文件后，重启 Cursor
+3. 在 Cursor 聊天中，工具应该自动可用
+4. 可以通过聊天界面的 "Available Tools" 查看已连接的 MCP 工具
+
+**Demo**
+
+插件 MCP 接入：
+
+![cursor_mcp_settings](./assets/cursor_mcp_settings.png)
+
+调用 MCP 工具：（以检查登录状态为例）
+
+![cursor_mcp_check_login](./assets/cursor_mcp_check_login.png)
+
+### VSCode
+
+#### 方法一：使用命令面板配置
+
+1. 按 `Ctrl/Cmd + Shift + P` 打开命令面板
+2. 运行 `MCP: Add Server` 命令
+3. 选择 `HTTP` 方式。
+4. 输入地址： `http://localhost:18060/mcp`，或者修改成对应的 Server 地址。
+5. 输入 MCP 名字： `xiaohongshu-mcp`。
+
+#### 方法二：直接编辑配置文件
+
+**工作区配置**（推荐）：
+在项目根目录创建 `.vscode/mcp.json`：
+
+```json
+{
+  "servers": {
+    "xiaohongshu-mcp": {
+      "url": "http://localhost:18060/mcp",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}
+```
+
+**查看配置**：
+
+![vscode_config](./assets/vscode_mcp_config.png)
+
+1. 确认运行状态。
+2. 查看 `tools` 是否正确检测。
+
+**Demo**
+
+以搜索帖子内容为例：
+
+![vscode_mcp_search](./assets/vscode_search_demo.png)
+
+### 通用 MCP Inspector（调试用）
+
+```bash
+# 启动 MCP Inspector
+npx @modelcontextprotocol/inspector
+
+# 在浏览器中连接到：http://localhost:18060/mcp
+```
+
+## 🛠️ 可用工具
+
+连接成功后，可使用以下 MCP 工具：
+
+- `check_login_status` - 检查小红书登录状态（无参数）
+- `publish_content` - 发布图文内容到小红书（需要：title, content, 可选：images, video）
+- `list_feeds` - 获取小红书首页推荐列表（无参数）
+- `search_feeds` - 搜索小红书内容（需要：keyword）
+
+## 📝 使用示例
+
+### 检查登录状态
+
+```json
+{
+  "name": "check_login_status",
+  "arguments": {}
+}
+```
+
+### 发布内容
+
+```json
+{
+  "name": "publish_content",
+  "arguments": {
+    "title": "标题",
+    "content": "内容描述",
+    "images": ["图片URL或本地路径"]
+  }
+}
+```
+
+### 获取推荐列表
+
+```json
+{
+  "name": "list_feeds",
+  "arguments": {}
+}
+```
+
+### 搜索内容
+
+```json
+{
+  "name": "search_feeds",
+  "arguments": {
+    "keyword": "搜索关键词"
+  }
+}
+```
+
+### MCP Inspector 测试
+
+- 使用 MCP Inspector 测试连接：`npx @modelcontextprotocol/inspector`
+- 测试 Ping Server 功能验证连接
+- 检查 List Tools 是否返回 4 个工具

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -36,7 +36,7 @@ func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 	slog.Info("wait for upload-content visible success")
 
 	// 等待一段时间确保页面完全加载
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	createElems := pp.MustElements("div.creator-tab")
 	slog.Info("foundcreator-tab elements", "count", len(createElems))


### PR DESCRIPTION
完全重写了browser.go文件：
移除了旧的headless_browser依赖
使用go-rod库直接管理Google Chrome
实现了跨平台Google Chrome路径检测
将Linux系统中的/snap/bin/chromium改为/usr/bin/google-chrome-unstable
更新了依赖文件：
从go.mod中移除了github.com/xpzouying/headless_browser依赖
运行了go mod tidy清理不需要的依赖
验证修改结果：
✅ 编译成功，无错误
✅ 确认项目中没有任何Chromium相关引用
✅ Google Chrome路径检测正常工作
✅ 登录功能测试成功