### PR TITLE
fix: 修复MCP工具定义与文档描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ https://github.com/user-attachments/assets/76a26130-a216-4371-a6b3-937b8fda092a
 
 </details>
 
+<details>
+<summary><b>6. 发表评论到帖子</b></summary>
+
+支持自动发表评论到小红书帖子。
+
+**功能说明：**
+- 自动定位评论输入框
+- 输入评论内容并发布
+- 支持 HTTP API 和 MCP 工具调用
+
+**⚠️ 重要提示：**
+- 需要先登录才能使用此功能
+- 需要提供帖子ID、xsec_token和评论内容
+- 这些参数可以从Feed列表或搜索结果中获取
+
+**发表评论演示：**
+
+https://github.com/user-attachments/assets/cc385b6c-422c-489b-a5fc-63e92c695b80
+
+</details>
+
 **小红书基础运营知识**
 
 - **标题：（非常重要）小红书要求标题不超过 20个字**
@@ -318,7 +339,7 @@ npx @modelcontextprotocol/inspector
 使用步骤：
 - 使用 MCP Inspector 测试连接
 - 测试 Ping Server 功能验证连接
-- 检查 List Tools 是否返回 4 个工具
+- 检查 List Tools 是否返回 6 个工具
 
 </details>
 
@@ -346,6 +367,8 @@ npx @modelcontextprotocol/inspector
 - `publish_content` - 发布图文内容到小红书（需要：title, content, 可选：images, video）
 - `list_feeds` - 获取小红书首页推荐列表（无参数）
 - `search_feeds` - 搜索小红书内容（需要：keyword）
+- `get_feed_detail` - 获取帖子详情（需要：feed_id, xsec_token）
+- `post_comment_to_feed` - 发表评论到小红书帖子（需要：feed_id, xsec_token, content）
 
 ### 2.4. 使用示例
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ npx @modelcontextprotocol/inspector
 连接成功后，可使用以下 MCP 工具：
 
 - `check_login_status` - 检查小红书登录状态（无参数）
-- `publish_content` - 发布图文内容到小红书（需要：title, content, 可选：images, video）
+- `publish_content` - 发布图文内容到小红书（必需：title, content, images）
 - `list_feeds` - 获取小红书首页推荐列表（无参数）
 - `search_feeds` - 搜索小红书内容（需要：keyword）
 - `get_feed_detail` - 获取帖子详情（需要：feed_id, xsec_token）

--- a/streamable_http.go
+++ b/streamable_http.go
@@ -166,13 +166,13 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 		},
 		{
 			"name":        "publish_content",
-			"description": "发布小红书内容（支持图文或视频）",
+			"description": "发布小红书图文内容",
 			"inputSchema": map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"title": map[string]interface{}{
 						"type":        "string",
-						"description": "内容标题",
+						"description": "内容标题（小红书限制：最多20个中文字或英文单词）",
 					},
 					"content": map[string]interface{}{
 						"type":        "string",
@@ -180,17 +180,14 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 					},
 					"images": map[string]interface{}{
 						"type":        "array",
-						"description": "图片路径列表，支持本地路径或URL",
+						"description": "图片路径列表，支持本地路径或URL（至少需要1张图片）",
 						"items": map[string]interface{}{
 							"type": "string",
 						},
-					},
-					"video": map[string]interface{}{
-						"type":        "string",
-						"description": "视频文件路径（发布视频时使用）",
+						"minItems": 1,
 					},
 				},
-				"required": []string{"title", "content"},
+				"required": []string{"title", "content", "images"},
 			},
 		},
 		{


### PR DESCRIPTION
## 概述
修复MCP工具定义与文档描述不一致的问题，更新README添加评论功能说明。

## 主要更改

### 文档更新
- 添加第6个主要功能：发表评论到帖子
- 添加评论功能的视频演示  
- 更新MCP工具列表，包含所有6个工具

### MCP工具定义修复
- 修正 `publish_content` 参数：images改为必需，删除不存在的video参数
- 更新标题描述：明确"最多20个中文字或英文单词"的限制
- 工具描述更正为"发布小红书图文内容"

## 测试方式
通过MCP Inspector验证工具定义的正确性。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>