### PR TITLE
feat: 添加小红书标签功能支持

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -42,6 +42,7 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 	title, _ := args["title"].(string)
 	content, _ := args["content"].(string)
 	imagePathsInterface, _ := args["images"].([]interface{})
+	tagsInterface, _ := args["tags"].([]interface{})
 
 	var imagePaths []string
 	for _, path := range imagePathsInterface {
@@ -50,13 +51,21 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 		}
 	}
 
-	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d", title, len(imagePaths))
+	var tags []string
+	for _, tag := range tagsInterface {
+		if tagStr, ok := tag.(string); ok {
+			tags = append(tags, tagStr)
+		}
+	}
+
+	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d", title, len(imagePaths), len(tags))
 
 	// 构建发布请求
 	req := &PublishRequest{
 		Title:   title,
 		Content: content,
 		Images:  imagePaths,
+		Tags:    tags,
 	}
 
 	// 执行发布

--- a/service.go
+++ b/service.go
@@ -24,6 +24,7 @@ type PublishRequest struct {
 	Title   string   `json:"title" binding:"required"`
 	Content string   `json:"content" binding:"required"`
 	Images  []string `json:"images" binding:"required,min=1"`
+	Tags    []string `json:"tags,omitempty"`
 }
 
 // LoginStatusResponse 登录状态响应
@@ -89,6 +90,7 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 	content := xiaohongshu.PublishImageContent{
 		Title:      req.Title,
 		Content:    req.Content,
+		Tags:       req.Tags,
 		ImagePaths: imagePaths,
 	}
 

--- a/streamable_http.go
+++ b/streamable_http.go
@@ -176,7 +176,7 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 					},
 					"content": map[string]interface{}{
 						"type":        "string",
-						"description": "正文内容，支持话题标签",
+						"description": "正文内容",
 					},
 					"images": map[string]interface{}{
 						"type":        "array",
@@ -185,6 +185,13 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 							"type": "string",
 						},
 						"minItems": 1,
+					},
+					"tags": map[string]interface{}{
+						"type":        "array",
+						"description": "话题标签列表（可选），如 [\"美食\", \"旅行\", \"生活\"]",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
 					},
 				},
 				"required": []string{"title", "content", "images"},


### PR DESCRIPTION
## 功能说明
为小红书发布功能添加标签(tags)支持

## 主要更改
- 支持发布内容时添加标签
- 实现标签自动关联（通过点击联想下拉框）
- MCP 和 HTTP API 均支持 tags 参数

## API 示例
```json
{
  "title": "标题",
  "content": "内容",
  "images": ["image.jpg"],
  "tags": ["美食", "旅行"]
}
```

## 测试
- [x] 标签输入和关联功能正常
- [x] API 接口测试通过