### PR TITLE
refactor: 对publish_content工具中的content描述增加细节

### DIFF
--- a/streamable_http.go
+++ b/streamable_http.go
@@ -176,7 +176,7 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 					},
 					"content": map[string]interface{}{
 						"type":        "string",
-						"description": "正文内容",
+						"description": "正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可",
 					},
 					"images": map[string]interface{}{
 						"type":        "array",


### PR DESCRIPTION
对publish_content工具中的content描述增加细节，避免有时候大模型在内容中会生成#标签，导致看上去好像标签功能失效的问题。