### PR TITLE
fix: 修复 GitHub Actions Release 403 权限错误

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - 'go.sum'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 问题描述

GitHub Actions 在创建 Release 时出现 403 权限错误：
```
⚠️ GitHub release failed with status: 403
```

## 解决方案

添加明确的权限配置，允许 GitHub Actions 写入内容（创建 releases 和上传文件）：

```yaml
permissions:
  contents: write
```

## 修改内容

- 在 workflow 文件顶层添加 `permissions: contents: write` 配置
- 这将授予 GITHUB_TOKEN 创建 releases 和上传文件的权限

## 测试方法

1. 合并此 PR
2. 手动触发 GitHub Actions 工作流
3. 验证是否成功创建 Release 并上传所有二进制文件

🤖 Generated with [Claude Code](https://claude.ai/code)