### PR TITLE
修复 Linux GLIBC 依赖问题并添加压缩包发布

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,9 @@
       "mcp__playwright__browser_tab_select",
       "Bash(gh pr merge:*)",
       "Bash(gh release list:*)",
-      "Bash(awk:*)"
+      "Bash(awk:*)",
+      "Bash(CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o test-xiaohongshu-mcp-linux-amd64 .)",
+      "Bash(tar:*)"
     ],
     "deny": []
   }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,21 @@ jobs:
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-mcp-linux-amd64 .
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-login-linux-amd64 ./cmd/login
 
+    - name: Package binaries
+      run: |
+        # 创建压缩包
+        # macOS ARM64
+        tar czf xiaohongshu-mcp-darwin-arm64.tar.gz xiaohongshu-mcp-darwin-arm64 xiaohongshu-login-darwin-arm64
+
+        # macOS Intel
+        tar czf xiaohongshu-mcp-darwin-amd64.tar.gz xiaohongshu-mcp-darwin-amd64 xiaohongshu-login-darwin-amd64
+
+        # Windows x64
+        zip xiaohongshu-mcp-windows-amd64.zip xiaohongshu-mcp-windows-amd64.exe xiaohongshu-login-windows-amd64.exe
+
+        # Linux x64
+        tar czf xiaohongshu-mcp-linux-amd64.tar.gz xiaohongshu-mcp-linux-amd64 xiaohongshu-login-linux-amd64
+
     - name: Clean up old releases
       run: |
         # 获取所有自动构建的 releases (v开头的时间戳格式)
@@ -82,25 +97,29 @@ jobs:
 
           ### 📦 下载说明
 
-          **主程序（MCP 服务）：**
-          - **macOS Apple Silicon**: `xiaohongshu-mcp-darwin-arm64`
-          - **macOS Intel**: `xiaohongshu-mcp-darwin-amd64`
-          - **Windows x64**: `xiaohongshu-mcp-windows-amd64.exe`
-          - **Linux x64**: `xiaohongshu-mcp-linux-amd64`
+          选择适合您系统的压缩包下载：
+          - **macOS Apple Silicon (M1/M2/M3)**: `xiaohongshu-mcp-darwin-arm64.tar.gz`
+          - **macOS Intel**: `xiaohongshu-mcp-darwin-amd64.tar.gz`
+          - **Windows x64**: `xiaohongshu-mcp-windows-amd64.zip`
+          - **Linux x64**: `xiaohongshu-mcp-linux-amd64.tar.gz`
 
-          **登录工具：**
-          - **macOS Apple Silicon**: `xiaohongshu-login-darwin-arm64`
-          - **macOS Intel**: `xiaohongshu-login-darwin-amd64`
-          - **Windows x64**: `xiaohongshu-login-windows-amd64.exe`
-          - **Linux x64**: `xiaohongshu-login-linux-amd64`
+          每个压缩包包含：
+          - `xiaohongshu-mcp-*`: MCP 服务主程序
+          - `xiaohongshu-login-*`: 登录工具
 
           ### 🔧 使用方法
 
           ```bash
-          # 1. 首先运行登录工具
+          # 1. 解压文件（macOS/Linux）
+          tar xzf xiaohongshu-mcp-darwin-arm64.tar.gz
+
+          # 或 Windows
+          # 解压 xiaohongshu-mcp-windows-amd64.zip
+
+          # 2. 运行登录工具
           ./xiaohongshu-login-darwin-arm64
 
-          # 2. 然后启动 MCP 服务
+          # 3. 启动 MCP 服务
           ./xiaohongshu-mcp-darwin-arm64
           ```
 
@@ -110,11 +129,7 @@ jobs:
           - **Branch**: main
           - **Build Time**: ${{ steps.version.outputs.version }}
         files: |
-          xiaohongshu-mcp-darwin-arm64
-          xiaohongshu-mcp-darwin-amd64
-          xiaohongshu-mcp-windows-amd64.exe
-          xiaohongshu-mcp-linux-amd64
-          xiaohongshu-login-darwin-arm64
-          xiaohongshu-login-darwin-amd64
-          xiaohongshu-login-windows-amd64.exe
-          xiaohongshu-login-linux-amd64
+          xiaohongshu-mcp-darwin-arm64.tar.gz
+          xiaohongshu-mcp-darwin-amd64.tar.gz
+          xiaohongshu-mcp-windows-amd64.zip
+          xiaohongshu-mcp-linux-amd64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,21 +37,22 @@ jobs:
     - name: Build for multiple platforms
       run: |
         # 主程序构建
+        # 禁用 CGO 以生成静态链接的二进制文件，避免 GLIBC 依赖问题
         # macOS ARM64 (Apple Silicon)
-        GOOS=darwin GOARCH=arm64 go build -o xiaohongshu-mcp-darwin-arm64 .
-        GOOS=darwin GOARCH=arm64 go build -o xiaohongshu-login-darwin-arm64 ./cmd/login
+        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o xiaohongshu-mcp-darwin-arm64 .
+        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o xiaohongshu-login-darwin-arm64 ./cmd/login
 
         # macOS Intel
-        GOOS=darwin GOARCH=amd64 go build -o xiaohongshu-mcp-darwin-amd64 .
-        GOOS=darwin GOARCH=amd64 go build -o xiaohongshu-login-darwin-amd64 ./cmd/login
+        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o xiaohongshu-mcp-darwin-amd64 .
+        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o xiaohongshu-login-darwin-amd64 ./cmd/login
 
         # Windows x64
-        GOOS=windows GOARCH=amd64 go build -o xiaohongshu-mcp-windows-amd64.exe .
-        GOOS=windows GOARCH=amd64 go build -o xiaohongshu-login-windows-amd64.exe ./cmd/login
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o xiaohongshu-mcp-windows-amd64.exe .
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o xiaohongshu-login-windows-amd64.exe ./cmd/login
 
         # Linux x64
-        GOOS=linux GOARCH=amd64 go build -o xiaohongshu-mcp-linux-amd64 .
-        GOOS=linux GOARCH=amd64 go build -o xiaohongshu-login-linux-amd64 ./cmd/login
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-mcp-linux-amd64 .
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-login-linux-amd64 ./cmd/login
 
     - name: Clean up old releases
       run: |


### PR DESCRIPTION
## 📝 Summary

- 修复 Ubuntu 20.04 等旧系统因 GLIBC 版本问题无法运行的问题
- 将发布文件打包成压缩包，便于用户下载和使用

## 🔧 Changes

### 1. 禁用 CGO 解决 GLIBC 依赖
- 在所有平台的构建命令中添加 `CGO_ENABLED=0`
- 生成纯 Go 的静态链接二进制文件
- 不再依赖系统 GLIBC 版本

### 2. 添加文件压缩打包
- macOS/Linux 使用 `.tar.gz` 格式
- Windows 使用 `.zip` 格式  
- 每个压缩包包含主程序和登录工具
- 更新 Release 说明文档

## 🧪 Test Plan

- [x] 本地测试构建和压缩流程
- [x] 验证压缩包可以正常解压
- [ ] GitHub Actions 自动构建验证

## 💡 Notes

修复了用户反馈的问题：Ubuntu 20.04 LTS 系统无法运行发布的二进制文件，报错 GLIBC 版本不匹配。

🤖 Generated with [Claude Code](https://claude.ai/code)