### PR TITLE
fix: 修复 GitHub Actions release workflow 权限问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Build and Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [ main ]
   workflow_dispatch:
 
@@ -12,8 +11,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # 只在 PR 被合并时运行，或手动触发
-    if: (github.event.pull_request.merged == true) || (github.event_name == 'workflow_dispatch')
+    # 只在推送到 main 时运行，或手动触发
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## 问题描述

当外部贡献者（从 fork 的仓库）提交 PR 并被合并时，release workflow 会因为权限限制失败，报错 403。

## 原因分析

- 来自 fork 的 PR 在合并时触发的 workflow 使用的 `GITHUB_TOKEN` 权限是只读的
- 即使在 workflow 中设置了 `permissions: contents: write`，对于来自 fork 的 PR，这个权限也不会生效
- 因此创建 release 时会返回 403 错误

## 解决方案

将触发事件从 `pull_request` (closed) 改为 `push` 到 main 分支：
- 确保 workflow 在代码真正合并到 main 分支后才运行
- 此时有完整的 contents:write 权限来创建 release

## 更改内容

1. 触发条件：从 `pull_request` (types: closed) 改为 `push` (branches: main)
2. 条件判断：相应调整为 push 事件的判断逻辑

🤖 Generated with [Claude Code](https://claude.ai/code)