### PR TITLE
ci(release): add paths-ignore to avoid release on non-code changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,22 @@ name: Build and Release
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'README_EN.md'
+      - 'CLAUDE.md'
+      - '.all-contributorsrc'
+      - '.gitignore'
+      - '.claude/**'
+      - '.cursor/**'
+      - '.github/**'
+      - '.vscode/**'
+      - 'assets/**'
+      - 'configs/**'
+      - 'cookies/**'
+      - 'docs/**'
+      - 'donate/**'
+      - 'examples/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR updates the `release.yml` workflow configuration to avoid unnecessary release runs when only documentation, configs, or metadata files are changed.  

### Changes
- Added `paths-ignore` to skip triggering releases on changes to:
  - Documentation files (`README.md`, `README_EN.md`, `CLAUDE.md`)  
  - Contributor/ignore files (`.all-contributorsrc`, `.gitignore`)  
  - Editor/config folders (`.claude/`, `.cursor/`, `.github/`, `.vscode/`)  
  - Non-code directories (`assets/`, `configs/`, `cookies/`, `docs/`, `donate/`, `examples/`)  

### Why
This reduces unnecessary workflow executions, keeping the release process focused on actual code and dependency changes (e.g., `app_server.go`, `pkg/**`, `cmd/**`, `go.mod`, `go.sum`).  