### PR TITLE
feat: 支持返回登录二维码与 Docker 部署

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.idea
+.vscode
+.claude
+.cursor
+.github
+**/*.log
+bin
+dist
+vendor
+Dockerfile
+docker-compose.yml
+docker
+.DS_Store
+
+cookies.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.so
 *.dylib
 
+.idea
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# ---- build stage ----
+FROM golang:1.24 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /out/app .
+
+# ---- run stage ----
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+# 1. 装 Chromium + 依赖（无头模式运行 rod）
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      chromium \
+      ca-certificates \
+      fonts-liberation \
+      fonts-noto-cjk \
+      libasound2 \
+      libatk1.0-0 \
+      libatk-bridge2.0-0 \
+      libcups2 \
+      libdrm2 \
+      libxkbcommon0 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxrandr2 \
+      libgbm1 \
+      libpango-1.0-0 \
+      libnss3 \
+      libxshmfence1 \
+      wget \
+      tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/app .
+
+# 2. 设置默认 Chromium 路径（rod 会用）
+ENV ROD_BROWSER_BIN=/usr/bin/chromium
+
+EXPOSE 18060
+
+CMD ["./app"]
+

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # xiaohongshu-mcp
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 MCP for 小红书/xiaohongshu.com。
 
 - 我的博客文章：[haha.ai/xiaohongshu-mcp](https://www.haha.ai/xiaohongshu-mcp)
-
-**遇到任何问题，务必要先看 [各种疑难杂症](https://github.com/xpzouying/xiaohongshu-mcp/issues/56)**。
 
 ## Star History
 
@@ -647,7 +645,6 @@ npx @modelcontextprotocol/inspector
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/eveyuyi"><img src="https://avatars.githubusercontent.com/u/69026872?v=4?s=100" width="100px;" alt="Eve Yu"/><br /><sub><b>Eve Yu</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=eveyuyi" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/CooperGuo"><img src="https://avatars.githubusercontent.com/u/183056602?v=4?s=100" width="100px;" alt="CooperGuo"/><br /><sub><b>CooperGuo</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=CooperGuo" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://biboyqg.github.io/"><img src="https://avatars.githubusercontent.com/u/125724218?v=4?s=100" width="100px;" alt="Banghao Chi"/><br /><sub><b>Banghao Chi</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=BiboyQG" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/varz1"><img src="https://avatars.githubusercontent.com/u/60377372?v=4?s=100" width="100px;" alt="varz1"/><br /><sub><b>varz1</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=varz1" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -56,6 +56,11 @@ func GetCookiesFilePath() string {
 		return oldPath
 	}
 
+	path := os.Getenv("COOKIES_PATH") // 判断环境变量
+	if path == "" {
+		path = "cookies.json" // fallback，本地调试时用当前目录
+	}
+
 	// 文件不存在，使用新路径（当前目录）
-	return "cookies.json"
+	return path
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# Docker 使用说明
+<!-- TOC depthFrom:2 -->
+
+- [1. 自己构建镜像](#1-自己构建镜像)
+- [2. 手动 Docker Compose](#2-手动 Docker Compose)
+
+## 1. 自己构建镜像
+
+可以使用源码自己构建镜像，如下：
+
+在有项目的Dockerfile的目录运行
+
+`docker build -t xpzouying/xiaohongshu-mcp .`
+
+`xpzouying/xiaohongshu-mcp`为镜像名称和版本，可以自己起个名字
+
+## 2. 手动 Docker Compose
+
+```
+# 启动 docker-compose
+docker compose up -d
+
+# 停止 docker-compose
+docker compose stop
+
+# 查看实时日志
+docker logs -f xpzouying/xiaohongshu-mcp
+
+# 进入容器
+docker exec -it xpzouying/xiaohongshu-mcp /bin/bash
+
+# 手动更新容器
+docker compose pull && docker compose up -d
+```

--- a/docker/sample/docker-compose.yml
+++ b/docker/sample/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  xiaohongshu-mcp:
+    image: xpzouying/xiaohongshu-mcp
+    container_name: xiaohongshu-mcp
+    restart: unless-stopped
+    tty: true
+    volumes:
+      - ./data:/app/data
+    environment:
+      - ROD_BROWSER_BIN=/usr/bin/chromium  # ← 无头浏览器
+      - COOKIES_PATH=/app/data/cookies.json  # ← 程序读取/写入这个路径
+    ports:
+      - "18060:18060"

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -48,6 +48,18 @@ func (s *AppServer) checkLoginStatusHandler(c *gin.Context) {
 	respondSuccess(c, status, "检查登录状态成功")
 }
 
+// loginQrcodeImgHandler 获取登录二维码
+func (s *AppServer) loginQrcodeImgHandler(c *gin.Context) {
+	result, err := s.xiaohongshuService.LoginQrcodeImg(c.Request.Context())
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "STATUS_CHECK_FAILED",
+			"获取登录二维码失败", err.Error())
+		return
+	}
+
+	respondSuccess(c, result, "获取登录二维码成功")
+}
+
 // publishHandler 发布内容
 func (s *AppServer) publishHandler(c *gin.Context) {
 	var req PublishRequest

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
@@ -15,6 +16,10 @@ func main() {
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.Parse()
+
+	if len(binPath) == 0 {
+		binPath = os.Getenv("ROD_BROWSER_BIN")
+	}
 
 	configs.InitHeadless(headless)
 	configs.SetBinPath(binPath)

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -34,6 +34,31 @@ func (s *AppServer) handleCheckLoginStatus(ctx context.Context) *MCPToolResult {
 	}
 }
 
+// handleLoginQrcodeImg 处理获取登录扫码图片
+func (s *AppServer) handleLoginQrcodeImg(ctx context.Context) *MCPToolResult {
+	logrus.Info("MCP: 获取登录扫码图片")
+
+	result, err := s.xiaohongshuService.LoginQrcodeImg(ctx)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "获取登录扫码图片失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handlePublishContent 处理发布内容
 func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 发布内容")

--- a/routes.go
+++ b/routes.go
@@ -29,6 +29,7 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 	api := router.Group("/api/v1")
 	{
 		api.GET("/login/status", appServer.checkLoginStatusHandler)
+		api.GET("/login/qrcodeImg", appServer.loginQrcodeImgHandler)
 		api.POST("/publish", appServer.publishHandler)
 		api.GET("/feeds/list", appServer.listFeedsHandler)
 		api.GET("/feeds/search", appServer.searchFeedsHandler)

--- a/service.go
+++ b/service.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-
 	"github.com/mattn/go-runewidth"
 	"github.com/xpzouying/headless_browser"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
@@ -32,6 +31,12 @@ type PublishRequest struct {
 type LoginStatusResponse struct {
 	IsLoggedIn bool   `json:"is_logged_in"`
 	Username   string `json:"username,omitempty"`
+}
+
+// LoginQrcodeResponse 登录扫码二维码
+type LoginQrcodeResponse struct {
+	Timeout string `json:"timeout"`
+	Img     string `json:"img,omitempty"`
 }
 
 // PublishResponse 发布响应
@@ -74,6 +79,29 @@ func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatus
 	response := &LoginStatusResponse{
 		IsLoggedIn: isLoggedIn,
 		Username:   configs.Username,
+	}
+
+	return response, nil
+}
+
+// LoginQrcodeImg 获取登录的扫码二维码
+func (s *XiaohongshuService) LoginQrcodeImg(ctx context.Context) (*LoginQrcodeResponse, error) {
+	b := newBrowser()
+	//defer b.Close()
+
+	page := b.NewPage()
+	//defer page.Close()
+
+	loginAction := xiaohongshu.NewLogin(page)
+
+	img, timeout, err := loginAction.LoginQrcodeImg(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &LoginQrcodeResponse{
+		Timeout: timeout,
+		Img:     img,
 	}
 
 	return response, nil

--- a/streamable_http.go
+++ b/streamable_http.go
@@ -165,6 +165,14 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 			},
 		},
 		{
+			"name":        "login_qrcode_img",
+			"description": "获取登录扫码图片",
+			"inputSchema": map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
 			"name":        "publish_content",
 			"description": "发布小红书图文内容",
 			"inputSchema": map[string]interface{}{
@@ -311,6 +319,8 @@ func (s *AppServer) processToolCall(ctx context.Context, request *JSONRPCRequest
 	switch toolName {
 	case "check_login_status":
 		result = s.handleCheckLoginStatus(ctx)
+	case "login_qrcode_img":
+		result = s.handleLoginQrcodeImg(ctx)
 	case "publish_content":
 		result = s.handlePublishContent(ctx, toolArgs)
 	case "list_feeds":

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -2,6 +2,10 @@ package xiaohongshu
 
 import (
 	"context"
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/headless_browser"
+	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -54,4 +58,82 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	pp.MustElement(".main-container .user .link-wrapper .channel")
 
 	return nil
+}
+
+func (a *LoginAction) LoginQrcodeImg(ctx context.Context, b *headless_browser.Browser) (string, string, error) {
+	pp := a.page.Context(ctx)
+
+	// 导航到小红书首页，这会触发二维码弹窗
+	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+
+	// 等待一小段时间让页面完全加载
+	time.Sleep(2 * time.Second)
+
+	// 检查是否已经登录
+	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+		// 已经登录，直接返回
+		_ = pp.Close()
+		b.Close()
+		return "已经在登录状态", "0", nil
+	}
+
+	// 获取二维码图片
+	attribute, err := pp.MustElement(".login-container .qrcode-img").Attribute("src")
+	if err != nil || attribute == nil || len(*attribute) == 0 {
+		_ = pp.Close()
+		b.Close()
+		return "", "0", errors.Wrap(err, "login qrcode failed")
+	}
+
+	const timeout = 4 * time.Minute
+	const poll = 750 * time.Millisecond
+
+	// 这里我们用 goroutine 等待登录成功的元素出现，二维码图片直接返回
+	go func() {
+		defer func() { // 防止 rod 的 Must* panic 影响进程
+			if r := recover(); r != nil {
+				logrus.Errorf("[xhs-login] goroutine recovered: %v", r)
+			}
+		}()
+
+		// 单独用 Background，避免调用方 cancel 影响这里
+		p := a.page.Context(context.Background())
+		deadline := time.Now().Add(timeout)
+
+		selector := ".main-container .user .link-wrapper .channel"
+
+		for time.Now().Before(deadline) {
+			// 用带超时的非 Must 查找，避免阻塞 & panic
+			if el, err := p.Timeout(3 * time.Second).Element(selector); err == nil && el != nil {
+				if err := saveCookies(p); err != nil {
+					logrus.Errorf("failed to save cookies: %v", err)
+				}
+				_ = p.Close()
+				b.Close()
+				return
+			}
+			time.Sleep(poll)
+		}
+
+		// 超时
+		_ = p.Close()
+		b.Close()
+	}()
+
+	return *attribute, timeout.String(), nil
+}
+
+func saveCookies(page *rod.Page) error {
+	cks, err := page.Browser().GetCookies()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cks)
+	if err != nil {
+		return err
+	}
+
+	cookieLoader := cookies.NewLoadCookie(cookies.GetCookiesFilePath())
+	return cookieLoader.SaveCookies(data)
 }


### PR DESCRIPTION
### 🔥 本次变更
- feat: 新增返回登录二维码功能
- feat: 支持 Docker 部署方式

### 📌 背景 / 原因
- 需要支持在 Docker 环境下的用户扫码登录功能，提升可用性
- 希望提供 Docker 部署方案，方便一键运行

### ✅ 测试步骤
1. 本地执行 `go fmt ./...` 格式化所有 Go 代码
2. 使用 `docker build` 构建镜像，确认服务能正常启动
3. 通过 `docker compose up` 启动后，访问接口获取登录二维码，验证返回数据正确
4. 登录成功后，检查 `cookies.json` 是否生成并持久化到挂载目录

### ⚠️ 注意事项
- 需要确保容器内挂载了 `cookies.json` 存储目录
- 目前仅支持无头 Chromium，如需 GUI 浏览器需额外调整

### n8n 效果
<img width="1798" height="1125" alt="image" src="https://github.com/user-attachments/assets/cac8855b-c007-4a65-9948-08920c4e2dbf" />

