### PR TITLE
feat:添加dify兜底功能，解决dify接入不了xhs-mcp的问题

### DIFF
--- a/streamable_http.go
+++ b/streamable_http.go
@@ -110,6 +110,13 @@ func (s *AppServer) processJSONRPCRequest(request *JSONRPCRequest, ctx context.C
 			Result:  map[string]interface{}{},
 			ID:      request.ID,
 		}
+	case "notifications/initialized":
+        // 兜底: 兼容 Dify 发送的 notifications/initialized 通知
+        		return &JSONRPCResponse{
+            		JSONRPC: "2.0",
+            		Result:  map[string]interface{}{},
+            		ID:      request.ID,
+        }
 	case "ping":
 		// 处理 ping 请求
 		return &JSONRPCResponse{


### PR DESCRIPTION
dify作为MCP-client他和MCP-server建立连接和普通的AI客户端不太一样，有个通知接口notifications/initialized，服务端需要实现一下，不然会报：Run failed: Failed to transform agent message: req_id: 0cd706fc92 PluginInvokeError: {"args":{},"error_type":"Exception","message":"MCP Server notifications/initialized error: {'code': -32601, 'message': 'Method not found'}"}