### PR TITLE
docs: add Docker deployment instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,48 @@ go env -w  GOPROXY=https://goproxy.io,direct
 
 </details>
 
+**方式三：使用 Docker 容器（最简单）**
+
+<details>
+<summary>Docker 部署详情</summary>
+
+使用 Docker 部署是最简单的方式，无需安装任何开发环境。
+
+**1. 构建镜像**
+
+```bash
+# 在项目根目录运行
+docker build -t xpzouying/xiaohongshu-mcp .
+```
+
+**2. 使用 Docker Compose 启动**
+
+```bash
+# 进入 docker 目录
+cd docker
+
+# 启动服务
+docker compose up -d
+
+# 查看日志
+docker compose logs -f
+
+# 停止服务
+docker compose stop
+```
+
+**3. 配置说明**
+
+Docker 版本会自动：
+- 配置 Chrome 浏览器和中文字体
+- 挂载 `./data` 用于存储 cookies
+- 挂载 `./images` 用于存储发布的图片
+- 暴露 18060 端口供 MCP 连接
+
+详细使用说明请参考：[Docker 部署指南](./docker/README.md)
+
+</details>
+
 Windows 遇到问题首先看这里：[Windows 安装指南](./docs/windows_guide.md)
 
 ### 1.2. 登录

--- a/README_EN.md
+++ b/README_EN.md
@@ -247,6 +247,48 @@ go env -w  GOPROXY=https://goproxy.io,direct
 
 </details>
 
+**Method 3: Using Docker Container (Simplest)**
+
+<details>
+<summary>Docker Deployment Details</summary>
+
+Using Docker deployment is the simplest method, requiring no development environment installation.
+
+**1. Build Image**
+
+```bash
+# Run in project root directory
+docker build -t xpzouying/xiaohongshu-mcp .
+```
+
+**2. Start with Docker Compose**
+
+```bash
+# Enter docker directory
+cd docker
+
+# Start service
+docker compose up -d
+
+# View logs
+docker compose logs -f
+
+# Stop service
+docker compose stop
+```
+
+**3. Configuration Notes**
+
+The Docker version automatically:
+- Configures Chrome browser and Chinese fonts
+- Mounts `./data` for storing cookies
+- Mounts `./images` for storing publish images
+- Exposes port 18060 for MCP connection
+
+For detailed instructions, please refer to: [Docker Deployment Guide](./docker/README.md)
+
+</details>
+
 For Windows issues, check here first: [Windows Installation Guide](./docs/windows_guide.md)
 
 ### 1.2. Login

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,11 @@
 # Docker 使用说明
-<!-- TOC depthFrom:2 -->
 
-- [1. 自己构建镜像](#1-自己构建镜像)
-- [2. 手动 Docker Compose](#2-手动 Docker Compose)
+## 0. 重点注意
+
+写在最前面。
+
+- 启动后，会产生一个 `images/` 目录，用于存储发布的图片。它会挂载到 Docker 容器里面。
+  如果要使用本地图片发布的话，请确保图片拷贝到 `./images/` 目录下，并且让 MCP 在发布的时候，指定文件夹为：`/app/images`，否则一定失败。
 
 ## 1. 自己构建镜像
 
@@ -10,7 +13,9 @@
 
 在有项目的Dockerfile的目录运行
 
-`docker build -t xpzouying/xiaohongshu-mcp .`
+```bash
+docker build -t xpzouying/xiaohongshu-mcp .
+```
 
 `xpzouying/xiaohongshu-mcp`为镜像名称和版本。
 
@@ -18,7 +23,7 @@
 
 ## 2. 手动 Docker Compose
 
-```
+```bash
 # 注意：在 docker-compose.yml 文件的同一个目录，或者手动指定 docker-compose.yml。
 
 # --- 启动 docker 容器 ---


### PR DESCRIPTION
- Added a new section for deploying using Docker in both English and Chinese README files.
- Included detailed steps for building the Docker image, starting services with Docker Compose, and configuration notes.
- Updated the Docker README with important notes regarding image storage and local image usage.