### PR TITLE
feat: Add video publish workflow + MCP tool entry

### DIFF
--- a/configs/video.go
+++ b/configs/video.go
@@ -1,0 +1,15 @@
+package configs
+
+import (
+    "os"
+    "path/filepath"
+)
+
+const (
+    VideosDir = "xiaohongshu_videos"
+)
+
+func GetVideosPath() string {
+    return filepath.Join(os.TempDir(), VideosDir)
+}
+

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -130,6 +130,51 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 	}
 }
 
+// handlePublishVideo 处理发布视频
+func (s *AppServer) handlePublishVideo(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+    logrus.Info("MCP: 发布视频内容")
+
+    title, _ := args["title"].(string)
+    content, _ := args["content"].(string)
+    video, _ := args["video"].(string)
+    tagsInterface, _ := args["tags"].([]interface{})
+
+    var tags []string
+    for _, tag := range tagsInterface {
+        if tagStr, ok := tag.(string); ok {
+            tags = append(tags, tagStr)
+        }
+    }
+
+    logrus.Infof("MCP: 发布视频 - 标题: %s, 标签数量: %d", title, len(tags))
+
+    req := &PublishVideoRequest{
+        Title:   title,
+        Content: content,
+        Video:   video,
+        Tags:    tags,
+    }
+
+    result, err := s.xiaohongshuService.PublishVideo(ctx, req)
+    if err != nil {
+        return &MCPToolResult{
+            Content: []MCPContent{{
+                Type: "text",
+                Text: "发布视频失败: " + err.Error(),
+            }},
+            IsError: true,
+        }
+    }
+
+    resultText := fmt.Sprintf("视频发布成功: %+v", result)
+    return &MCPToolResult{
+        Content: []MCPContent{{
+            Type: "text",
+            Text: resultText,
+        }},
+    }
+}
+
 // handleListFeeds 处理获取Feeds列表
 func (s *AppServer) handleListFeeds(ctx context.Context) *MCPToolResult {
 	logrus.Info("MCP: 获取Feeds列表")

--- a/pkg/downloader/video.go
+++ b/pkg/downloader/video.go
@@ -1,0 +1,106 @@
+package downloader
+
+import (
+    "crypto/sha256"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "os"
+    "path/filepath"
+    "strings"
+    "time"
+
+    "github.com/h2non/filetype"
+    "github.com/pkg/errors"
+)
+
+// VideoDownloader 视频下载器
+type VideoDownloader struct {
+    savePath   string
+    httpClient *http.Client
+}
+
+// NewVideoDownloader 创建视频下载器
+func NewVideoDownloader(savePath string) *VideoDownloader {
+    if err := os.MkdirAll(savePath, 0755); err != nil {
+        panic(fmt.Sprintf("failed to create save path: %v", err))
+    }
+    return &VideoDownloader{
+        savePath: savePath,
+        httpClient: &http.Client{
+            Timeout: 60 * time.Second,
+        },
+    }
+}
+
+// DownloadVideo 下载视频并返回本地路径
+func (d *VideoDownloader) DownloadVideo(videoURL string) (string, error) {
+    if !d.isValidVideoURL(videoURL) {
+        return "", errors.New("invalid video URL format")
+    }
+
+    resp, err := d.httpClient.Get(videoURL)
+    if err != nil {
+        return "", errors.Wrap(err, "failed to download video")
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return "", fmt.Errorf("download failed with status: %d", resp.StatusCode)
+    }
+
+    data, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return "", errors.Wrap(err, "failed to read video data")
+    }
+
+    kind, err := filetype.Match(data)
+    if err != nil {
+        return "", errors.Wrap(err, "failed to detect file type")
+    }
+
+    if !filetype.IsVideo(data) {
+        return "", errors.New("downloaded file is not a valid video")
+    }
+
+    fileName := d.generateFileName(videoURL, kind.Extension)
+    filePath := filepath.Join(d.savePath, fileName)
+
+    if _, err := os.Stat(filePath); err == nil {
+        return filePath, nil
+    }
+
+    if err := os.WriteFile(filePath, data, 0644); err != nil {
+        return "", errors.Wrap(err, "failed to save video")
+    }
+
+    return filePath, nil
+}
+
+func (d *VideoDownloader) isValidVideoURL(rawURL string) bool {
+    if !strings.HasPrefix(strings.ToLower(rawURL), "http://") &&
+        !strings.HasPrefix(strings.ToLower(rawURL), "https://") {
+        return false
+    }
+    parsedURL, err := url.Parse(rawURL)
+    if err != nil {
+        return false
+    }
+    return parsedURL.Scheme != "" && parsedURL.Host != ""
+}
+
+func (d *VideoDownloader) generateFileName(videoURL, extension string) string {
+    hash := sha256.Sum256([]byte(videoURL))
+    hashStr := fmt.Sprintf("%x", hash)
+    shortHash := hashStr[:16]
+    timestamp := time.Now().Unix()
+    return fmt.Sprintf("vid_%s_%d.%s", shortHash, timestamp, extension)
+}
+
+// IsVideoURL 判断是否为视频URL
+func IsVideoURL(path string) bool {
+    return strings.HasPrefix(strings.ToLower(path), "http://") ||
+        strings.HasPrefix(strings.ToLower(path), "https://")
+}
+

--- a/pkg/downloader/video_processor.go
+++ b/pkg/downloader/video_processor.go
@@ -1,0 +1,35 @@
+package downloader
+
+import (
+    "fmt"
+
+    "github.com/xpzouying/xiaohongshu-mcp/configs"
+)
+
+// VideoProcessor 视频处理器
+type VideoProcessor struct {
+    downloader *VideoDownloader
+}
+
+// NewVideoProcessor 创建视频处理器
+func NewVideoProcessor() *VideoProcessor {
+    return &VideoProcessor{
+        downloader: NewVideoDownloader(configs.GetVideosPath()),
+    }
+}
+
+// ProcessVideo 处理单个视频，返回本地文件路径
+// 支持两种输入：
+// 1. URL（http/https）- 自动下载保存
+// 2. 本地绝对路径 - 直接返回
+func (p *VideoProcessor) ProcessVideo(video string) (string, error) {
+    if IsVideoURL(video) {
+        return p.downloader.DownloadVideo(video)
+    }
+    if video == "" {
+        return "", fmt.Errorf("empty video path")
+    }
+    // Assume local path exists; upstream will validate on upload
+    return video, nil
+}
+

--- a/streamable_http.go
+++ b/streamable_http.go
@@ -206,6 +206,35 @@ func (s *AppServer) processToolsList(request *JSONRPCRequest) *JSONRPCResponse {
 			},
 		},
 		{
+			"name":        "publish_video",
+			"description": "发布小红书视频内容（仅支持单个视频）",
+			"inputSchema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"title": map[string]interface{}{
+						"type":        "string",
+						"description": "内容标题（小红书限制：最多20个中文字或英文单词）",
+					},
+					"content": map[string]interface{}{
+						"type":        "string",
+						"description": "正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可",
+					},
+					"video": map[string]interface{}{
+						"type":        "string",
+						"description": "视频路径或URL（仅支持一个）。支持两种方式：1. HTTP/HTTPS视频链接（自动下载）；2. 本地视频绝对路径（推荐）",
+					},
+					"tags": map[string]interface{}{
+						"type":        "array",
+						"description": "话题标签列表（可选）",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+				"required": []string{"title", "content", "video"},
+			},
+		},
+		{
 			"name":        "list_feeds",
 			"description": "获取用户发布的内容列表",
 			"inputSchema": map[string]interface{}{
@@ -323,6 +352,8 @@ func (s *AppServer) processToolCall(ctx context.Context, request *JSONRPCRequest
 		result = s.handleGetLoginQrcode(ctx)
 	case "publish_content":
 		result = s.handlePublishContent(ctx, toolArgs)
+	case "publish_video":
+		result = s.handlePublishVideo(ctx, toolArgs)
 	case "list_feeds":
 		result = s.handleListFeeds(ctx)
 	case "search_feeds":

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -1,0 +1,160 @@
+package xiaohongshu
+
+import (
+    "context"
+    "log/slog"
+    "os"
+    "time"
+
+    "github.com/go-rod/rod"
+    "github.com/go-rod/rod/lib/proto"
+    "github.com/pkg/errors"
+)
+
+// PublishVideoContent 发布视频内容
+type PublishVideoContent struct {
+    Title     string
+    Content   string
+    Tags      []string
+    VideoPath string
+}
+
+// NewPublishVideoAction 进入发布页并选择“上传视频”
+func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
+    pp := page.Timeout(60 * time.Second)
+
+    pp.MustNavigate(urlOfPublic)
+    pp.MustElement(`div.upload-content`).MustWaitVisible()
+    slog.Info("wait for upload-content visible success")
+
+    time.Sleep(1 * time.Second)
+
+    createElems := pp.MustElements("div.creator-tab")
+    var visibleElems []*rod.Element
+    for _, elem := range createElems {
+        if isElementVisible(elem) {
+            visibleElems = append(visibleElems, elem)
+        }
+    }
+    if len(visibleElems) == 0 {
+        return nil, errors.New("没有找到上传视频元素")
+    }
+    for _, elem := range visibleElems {
+        text, err := elem.Text()
+        if err != nil {
+            slog.Error("获取元素文本失败", "error", err)
+            continue
+        }
+        if text == "上传视频" {
+            if err := elem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+                slog.Error("点击元素失败", "error", err)
+                continue
+            }
+            break
+        }
+    }
+
+    time.Sleep(1 * time.Second)
+
+    return &PublishAction{page: pp}, nil
+}
+
+// PublishVideo 执行上传和提交
+func (p *PublishAction) PublishVideo(ctx context.Context, content PublishVideoContent) error {
+    if content.VideoPath == "" {
+        return errors.New("视频不能为空")
+    }
+    if _, err := os.Stat(content.VideoPath); os.IsNotExist(err) {
+        return errors.Wrapf(err, "视频文件不存在: %s", content.VideoPath)
+    }
+
+    page := p.page.Context(ctx)
+    if err := uploadVideo(page, content.VideoPath); err != nil {
+        return errors.Wrap(err, "小红书上传视频失败")
+    }
+
+    // 等待一段时间确保视频处理完成，按钮可点击
+    time.Sleep(20 * time.Second)
+
+    if err := submitPublish(page, content.Title, content.Content, content.Tags); err != nil {
+        return errors.Wrap(err, "小红书发布失败")
+    }
+    return nil
+}
+
+func uploadVideo(page *rod.Page, videoPath string) error {
+    pp := page.Timeout(5 * time.Minute)
+
+    // 等待上传输入框出现
+    // 与图文一致的上传控件选择器，通常为 .upload-input
+    uploadInput, err := pp.Element(".upload-input")
+    if err != nil || uploadInput == nil {
+        // fallback：查找 file input
+        uploadInput, err = pp.Element(`input[type="file"]`)
+        if err != nil || uploadInput == nil {
+            return errors.New("未找到视频上传输入框")
+        }
+    }
+
+    uploadInput.MustSetFiles(videoPath)
+
+    return waitForVideoUploadComplete(pp)
+}
+
+// waitForVideoUploadComplete 等待视频上传完成
+func waitForVideoUploadComplete(page *rod.Page) error {
+    maxWait := 5 * time.Minute
+    interval := 1 * time.Second
+    start := time.Now()
+
+    slog.Info("开始等待视频上传完成（cover-container: analyze -> uploading -> preview-new(reupload)）")
+
+    for time.Since(start) < maxWait {
+        // 定位封面容器
+        container, _ := page.Element(".cover-container")
+        if container == nil {
+            // 容器还没出现，继续等待
+            time.Sleep(interval)
+            continue
+        }
+
+        // 成功条件：出现 preview-new，且其内部包含 .reupload
+        previews, _ := container.Elements(".preview-new")
+        if len(previews) > 0 {
+            for _, pv := range previews {
+                if pv == nil {
+                    continue
+                }
+                if child, _ := pv.Element(".reupload"); child != nil {
+                    slog.Info("检测到 preview-new 内的 reupload，视频上传已完成")
+                    return nil
+                }
+            }
+            // 预览已出现但未见 reupload，继续等待
+            slog.Debug("preview-new 存在但未检测到 reupload，继续等待")
+        }
+
+        // 进行中条件：存在 uploading
+        uploading, _ := container.Elements(".uploading")
+        if len(uploading) > 0 {
+            slog.Debug("视频正在上传中 (uploading 存在)")
+            time.Sleep(interval)
+            continue
+        }
+
+        // 进行中条件：存在 analyze
+        analyzing, _ := container.Elements(".analyze")
+        if len(analyzing) > 0 {
+            // 仍在分析/上传中
+            slog.Debug("视频仍在上传/分析中 (analyze 存在)")
+            time.Sleep(interval)
+            continue
+        }
+
+        // 若既无 preview-new 也无 analyze，则可能DOM尚未更新或选择器变化，继续轮询
+        slog.Debug("未检测到 analyze 或 preview-new，继续等待")
+        time.Sleep(interval)
+    }
+
+    return errors.New("上传视频超时（未出现 preview-new），请检查网络或视频大小")
+}


### PR DESCRIPTION
Description:
- Adds end-to-end "publish with video" support mirroring the existing image flow:
  - If video is an HTTP/HTTPS link, download and save locally before upload.
  - Navigate to the creator page, select “上传视频”, upload the single video, fill title/content/tags, and submit.
  - Wait for video readiness using cover-container states: analyze → uploading → preview-new (with reupload).
- Exposes a new MCP tool `publish_video`.

What’s Included:
- New MCP tool:
  - Name: `publish_video`
  - Args:
    - `title` string (required)
    - `content` string (required)
    - `video` string (required, URL or local path; only one video)
    - `tags` string[] (optional)
- Video processing and download:
  - `configs/video.go` provides `GetVideosPath()` temp directory for videos.
  - `pkg/downloader/video.go` downloads and validates video type.
  - `pkg/downloader/video_processor.go` handles URL vs local path.
- Browser automation:
  - `xiaohongshu/publish_video.go`:
    - Selects “上传视频” tab.
    - Uploads via `.upload-input` (fallback input[type="file"]).
    - Wait logic: waits on `.cover-container` for:
      - in-progress: `.analyze` or `.uploading`
      - success: `.preview-new` containing `.reupload`
    - Reuses existing submit flow (title/content/tags + submit) from image action.
- Service and handlers:
    - `service.go` adds:
        - `PublishVideoRequest`, `PublishVideoResponse`
        - `PublishVideo, `publishVideo`, and `processVideo`
    - `mcp_handlers.go` adds `handlePublishVideo``
    - `streamable_http.go`:
        - Adds `publish_video` tool to tools list
        - Routes tool calls to the handler

Files Changed:
- `configs/video.go`
- `pkg/downloader/video.go`
- `pkg/downloader/video_processor.go`
- `xiaohongshu/publish_video.go`
- `service.go`
- `mcp_handlers.go`
- `streamable_http.go`