### PR TITLE
docs: 增加 Docker Hub 镜像下载方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,17 +254,26 @@ go env -w  GOPROXY=https://goproxy.io,direct
 
 使用 Docker 部署是最简单的方式，无需安装任何开发环境。
 
-**1. 构建镜像**
+**1. 从 Docker Hub 拉取镜像（推荐）**
+
+我们提供了预构建的 Docker 镜像，可以直接从 Docker Hub 拉取使用：
 
 ```bash
-# 在项目根目录运行
-docker build -t xpzouying/xiaohongshu-mcp .
+# 拉取最新镜像
+docker pull xpzouying/xiaohongshu-mcp
 ```
 
-**2. 使用 Docker Compose 启动**
+Docker Hub 地址：[https://hub.docker.com/r/xpzouying/xiaohongshu-mcp](https://hub.docker.com/r/xpzouying/xiaohongshu-mcp)
+
+**2. 使用 Docker Compose 启动（推荐）**
+
+我们提供了配置好的 `docker-compose.yml` 文件，可以直接使用：
 
 ```bash
-# 进入 docker 目录
+# 下载 docker-compose.yml
+wget https://raw.githubusercontent.com/xpzouying/xiaohongshu-mcp/main/docker/docker-compose.yml
+
+# 或者如果已经克隆了项目，进入 docker 目录
 cd docker
 
 # 启动服务
@@ -277,7 +286,14 @@ docker compose logs -f
 docker compose stop
 ```
 
-**3. 配置说明**
+**3. 自己构建镜像（可选）**
+
+```bash
+# 在项目根目录运行
+docker build -t xpzouying/xiaohongshu-mcp .
+```
+
+**4. 配置说明**
 
 Docker 版本会自动：
 - 配置 Chrome 浏览器和中文字体

--- a/README_EN.md
+++ b/README_EN.md
@@ -254,17 +254,26 @@ go env -w  GOPROXY=https://goproxy.io,direct
 
 Using Docker deployment is the simplest method, requiring no development environment installation.
 
-**1. Build Image**
+**1. Pull Image from Docker Hub (Recommended)**
+
+We provide pre-built Docker images that can be directly pulled from Docker Hub:
 
 ```bash
-# Run in project root directory
-docker build -t xpzouying/xiaohongshu-mcp .
+# Pull the latest image
+docker pull xpzouying/xiaohongshu-mcp
 ```
 
-**2. Start with Docker Compose**
+Docker Hub URL: [https://hub.docker.com/r/xpzouying/xiaohongshu-mcp](https://hub.docker.com/r/xpzouying/xiaohongshu-mcp)
+
+**2. Start with Docker Compose (Recommended)**
+
+We provide a pre-configured `docker-compose.yml` file that can be used directly:
 
 ```bash
-# Enter docker directory
+# Download docker-compose.yml
+wget https://raw.githubusercontent.com/xpzouying/xiaohongshu-mcp/main/docker/docker-compose.yml
+
+# Or if you've already cloned the project, enter the docker directory
 cd docker
 
 # Start service
@@ -277,7 +286,16 @@ docker compose logs -f
 docker compose stop
 ```
 
-**3. Configuration Notes**
+**3. Build Image Yourself (Optional)**
+
+If you need to customize or modify the code, you can build the image yourself:
+
+```bash
+# Run in project root directory
+docker build -t xpzouying/xiaohongshu-mcp .
+```
+
+**4. Configuration Notes**
 
 The Docker version automatically:
 - Configures Chrome browser and Chinese fonts

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,9 +7,20 @@
 - 启动后，会产生一个 `images/` 目录，用于存储发布的图片。它会挂载到 Docker 容器里面。
   如果要使用本地图片发布的话，请确保图片拷贝到 `./images/` 目录下，并且让 MCP 在发布的时候，指定文件夹为：`/app/images`，否则一定失败。
 
-## 1. 自己构建镜像
+## 1. 获取 Docker 镜像
 
-可以使用源码自己构建镜像，如下：
+### 1.1 从 Docker Hub 拉取（推荐）
+
+我们提供了预构建的 Docker 镜像，可以直接从 Docker Hub 拉取使用：
+
+```bash
+# 拉取最新镜像
+docker pull xpzouying/xiaohongshu-mcp
+```
+
+Docker Hub 地址：[https://hub.docker.com/r/xpzouying/xiaohongshu-mcp](https://hub.docker.com/r/xpzouying/xiaohongshu-mcp)
+
+### 1.2 自己构建镜像（可选）
 
 在有项目的Dockerfile的目录运行
 


### PR DESCRIPTION
## 变更内容

- 在中英文 README 中增加从 Docker Hub 拉取镜像的说明
- 添加 `docker pull xpzouying/xiaohongshu-mcp` 命令
- 添加 Docker Hub 链接：https://hub.docker.com/r/xpzouying/xiaohongshu-mcp
- 调整 Docker 部署顺序，将 Docker Hub 拉取作为推荐方式
- 更新 docker/README.md，突出推荐从 Docker Hub 下载

## 目的

方便用户直接使用预构建的 Docker 镜像，无需自己构建，降低使用门槛。

🤖 Generated with [Claude Code](https://claude.ai/code)