### PR TITLE
feat: publish with video

### DIFF
--- a/mcp_server.go
+++ b/mcp_server.go
@@ -18,6 +18,14 @@ type PublishContentArgs struct {
 	Tags    []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
 }
 
+// PublishVideoArgs 发布视频的参数（仅支持本地单个视频文件）
+type PublishVideoArgs struct {
+    Title   string   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
+    Content string   `json:"content" jsonschema:"正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可"`
+    Video   string   `json:"video" jsonschema:"本地视频绝对路径（仅支持单个视频文件，如:/Users/user/video.mp4）"`
+    Tags    []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
+}
+
 // SearchFeedsArgs 搜索内容的参数
 type SearchFeedsArgs struct {
 	Keyword string `json:"keyword" jsonschema:"搜索关键词"`
@@ -182,7 +190,25 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	logrus.Infof("Registered %d MCP tools", 8)
+	// 工具 9: 发布视频（仅本地文件）
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "publish_with_video",
+			Description: "发布小红书视频内容（仅支持本地单个视频文件）",
+		},
+		func(ctx context.Context, req *mcp.CallToolRequest, args PublishVideoArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"title":   args.Title,
+				"content": args.Content,
+				"video":   args.Video,
+				"tags":    convertStringsToInterfaces(args.Tags),
+			}
+			result := appServer.handlePublishVideo(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		},
+	)
+
+	logrus.Infof("Registered %d MCP tools", 9)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -1,0 +1,178 @@
+package xiaohongshu
+
+import (
+    "context"
+    "log/slog"
+    "os"
+    "strings"
+    "time"
+
+    "github.com/go-rod/rod"
+    "github.com/go-rod/rod/lib/proto"
+    "github.com/pkg/errors"
+)
+
+// PublishVideoContent 发布视频内容
+type PublishVideoContent struct {
+    Title     string
+    Content   string
+    Tags      []string
+    VideoPath string
+}
+
+// NewPublishVideoAction 进入发布页并切换到“上传视频”
+func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
+    pp := page.Timeout(60 * time.Second)
+
+    pp.MustNavigate(urlOfPublic)
+
+    pp.MustElement(`div.upload-content`).MustWaitVisible()
+    slog.Info("wait for upload-content visible success (video)")
+
+    time.Sleep(1 * time.Second)
+
+    createElems := pp.MustElements("div.creator-tab")
+
+    // 过滤掉隐藏的元素
+    var visibleElems []*rod.Element
+    for _, elem := range createElems {
+        if isElementVisible(elem) {
+            visibleElems = append(visibleElems, elem)
+        }
+    }
+
+    if len(visibleElems) == 0 {
+        return nil, errors.New("没有找到上传视频元素")
+    }
+
+    // 点击“上传视频”
+    for _, elem := range visibleElems {
+        text, err := elem.Text()
+        if err != nil {
+            slog.Error("获取元素文本失败", "error", err)
+            continue
+        }
+        if text == "上传视频" {
+            if err := elem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+                slog.Error("点击元素失败", "error", err)
+                continue
+            }
+            break
+        }
+    }
+
+    time.Sleep(1 * time.Second)
+
+    return &PublishAction{page: pp}, nil
+}
+
+// PublishVideo 上传视频并提交
+func (p *PublishAction) PublishVideo(ctx context.Context, content PublishVideoContent) error {
+    if content.VideoPath == "" {
+        return errors.New("视频不能为空")
+    }
+
+    page := p.page.Context(ctx)
+
+    if err := uploadVideo(page, content.VideoPath); err != nil {
+        return errors.Wrap(err, "小红书上传视频失败")
+    }
+
+    if err := submitPublishVideo(page, content.Title, content.Content, content.Tags); err != nil {
+        return errors.Wrap(err, "小红书发布失败")
+    }
+    return nil
+}
+
+// uploadVideo 上传单个本地视频
+func uploadVideo(page *rod.Page, videoPath string) error {
+    pp := page.Timeout(5 * time.Minute) // 视频处理耗时更长
+
+    if _, err := os.Stat(videoPath); os.IsNotExist(err) {
+        return errors.Wrapf(err, "视频文件不存在: %s", videoPath)
+    }
+
+    // 寻找文件上传输入框（与图文一致的 class，或退回到 input[type=file]）
+    var fileInput *rod.Element
+    var err error
+    fileInput, err = pp.Element(".upload-input")
+    if err != nil || fileInput == nil {
+        fileInput, err = pp.Element("input[type='file']")
+        if err != nil || fileInput == nil {
+            return errors.New("未找到视频上传输入框")
+        }
+    }
+
+    fileInput.MustSetFiles(videoPath)
+
+    // 对于视频，等待发布按钮变为可点击即表示处理完成
+    btn, err := waitForPublishButtonClickable(pp)
+    if err != nil {
+        return err
+    }
+    slog.Info("视频上传/处理完成，发布按钮可点击", "btn", btn)
+    return nil
+}
+
+// waitForPublishButtonClickable 等待发布按钮可点击
+func waitForPublishButtonClickable(page *rod.Page) (*rod.Element, error) {
+    maxWait := 10 * time.Minute
+    interval := 1 * time.Second
+    start := time.Now()
+    selector := "button.publishBtn"
+
+    slog.Info("开始等待发布按钮可点击(视频)")
+
+    for time.Since(start) < maxWait {
+        btn, err := page.Element(selector)
+        if err == nil && btn != nil {
+            // 可见性
+            vis, verr := btn.Visible()
+            if verr == nil && vis {
+                // 检查 disabled 属性
+                if disabled, _ := btn.Attribute("disabled"); disabled == nil {
+                    // 再通过 class 名粗略判断不在禁用态
+                    if cls, _ := btn.Attribute("class"); cls != nil && !strings.Contains(*cls, "disabled") {
+                        return btn, nil
+                    }
+                    // 即使 class 包含 disabled，只要没有 disabled 属性，也尝试点击一次以确认
+                    return btn, nil
+                }
+            }
+        }
+        time.Sleep(interval)
+    }
+    return nil, errors.New("等待发布按钮可点击超时")
+}
+
+// submitPublishVideo 填写标题、正文、标签并点击发布（等待按钮可点击后再提交）
+func submitPublishVideo(page *rod.Page, title, content string, tags []string) error {
+    // 标题
+    titleElem := page.MustElement("div.d-input input")
+    titleElem.MustInput(title)
+    time.Sleep(1 * time.Second)
+
+    // 正文 + 标签
+    if contentElem, ok := getContentElement(page); ok {
+        contentElem.MustInput(content)
+        inputTags(contentElem, tags)
+    } else {
+        return errors.New("没有找到内容输入框")
+    }
+
+    time.Sleep(1 * time.Second)
+
+    // 等待发布按钮可点击
+    btn, err := waitForPublishButtonClickable(page)
+    if err != nil {
+        return err
+    }
+
+    // 点击发布
+    if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+        return errors.Wrap(err, "点击发布按钮失败")
+    }
+
+    time.Sleep(3 * time.Second)
+    return nil
+}

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -178,16 +178,3 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string) er
     time.Sleep(3 * time.Second)
     return nil
 }
-
-func removePopCover(page *rod.Page) {
-
-	has, elem, err := page.Has("div.d-popover")
-	if err != nil {
-		return
-	}
-
-	if has {
-		elem.MustRemove()
-	}
-
-}

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -22,9 +22,11 @@ type PublishVideoContent struct {
 
 // NewPublishVideoAction 进入发布页并切换到“上传视频”
 func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
-    pp := page.Timeout(60 * time.Second)
+    pp := page.Timeout(300 * time.Second)
 
     pp.MustNavigate(urlOfPublic)
+
+    removePopCover(page) // 移除弹窗封面
 
     pp.MustElement(`div.upload-content`).MustWaitVisible()
     slog.Info("wait for upload-content visible success (video)")
@@ -175,4 +177,17 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string) er
 
     time.Sleep(3 * time.Second)
     return nil
+}
+
+func removePopCover(page *rod.Page) {
+
+	has, elem, err := page.Has("div.d-popover")
+	if err != nil {
+		return
+	}
+
+	if has {
+		elem.MustRemove()
+	}
+
 }


### PR DESCRIPTION
Summary
- Mirror the existing image publish flow to support video posts using a single local file.
- Waits until the “发布” button becomes clickable before submitting (per provided selector).
- Adds an MCP tool entry publish_with_video with title/content/tags parity.

Changes
- New: xiaohongshu/publish_video.go:23 — video action: switch to “上传视频”, upload local file, wait for clickable publish button, submit.
- Robust wait: xiaohongshu/publish_video.go:95 — actively locates file input, preferring accept*='video' with fallbacks.
- Clickable check: xiaohongshu/publish_video.go:117 — visible and not disabled (attribute, aria-disabled, or class).
- Service: service.go:220 — PublishVideo API (validate title, check local file, call video action).
- MCP handler: mcp_handlers.go:133 — handlePublishVideo for request parsing + service call.
- MCP tool: mcp_server.go:193 — register publish_with_video; tool count updated.