### PR TITLE
feat: add like and favorite functionality for feeds

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -391,6 +391,40 @@ func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) 
 	}
 }
 
+// handleLikeFeed 处理点赞
+func (s *AppServer) handleLikeFeed(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	feedID, ok := args["feed_id"].(string)
+	if !ok || feedID == "" {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: 缺少feed_id参数"}}, IsError: true}
+	}
+	xsecToken, ok := args["xsec_token"].(string)
+	if !ok || xsecToken == "" {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: 缺少xsec_token参数"}}, IsError: true}
+	}
+	res, err := s.xiaohongshuService.LikeFeed(ctx, feedID, xsecToken)
+	if err != nil {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: " + err.Error()}}, IsError: true}
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("点赞成功 - Feed ID: %s", res.FeedID)}}}
+}
+
+// handleFavoriteFeed 处理收藏
+func (s *AppServer) handleFavoriteFeed(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	feedID, ok := args["feed_id"].(string)
+	if !ok || feedID == "" {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: 缺少feed_id参数"}}, IsError: true}
+	}
+	xsecToken, ok := args["xsec_token"].(string)
+	if !ok || xsecToken == "" {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: 缺少xsec_token参数"}}, IsError: true}
+	}
+	res, err := s.xiaohongshuService.FavoriteFeed(ctx, feedID, xsecToken)
+	if err != nil {
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: " + err.Error()}}, IsError: true}
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("收藏成功 - Feed ID: %s", res.FeedID)}}}
+}
+
 // handlePostComment 处理发表评论到Feed
 func (s *AppServer) handlePostComment(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 发表评论到Feed")

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -391,38 +391,76 @@ func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) 
 	}
 }
 
-// handleLikeFeed 处理点赞
+// handleLikeFeed 处理点赞/取消点赞
 func (s *AppServer) handleLikeFeed(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	feedID, ok := args["feed_id"].(string)
 	if !ok || feedID == "" {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: 缺少feed_id参数"}}, IsError: true}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "操作失败: 缺少feed_id参数"}}, IsError: true}
 	}
 	xsecToken, ok := args["xsec_token"].(string)
 	if !ok || xsecToken == "" {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: 缺少xsec_token参数"}}, IsError: true}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "操作失败: 缺少xsec_token参数"}}, IsError: true}
 	}
-	res, err := s.xiaohongshuService.LikeFeed(ctx, feedID, xsecToken)
+	unlike, _ := args["unlike"].(bool)
+	
+	var res *ActionResult
+	var err error
+	
+	if unlike {
+		res, err = s.xiaohongshuService.UnlikeFeed(ctx, feedID, xsecToken)
+	} else {
+		res, err = s.xiaohongshuService.LikeFeed(ctx, feedID, xsecToken)
+	}
+	
 	if err != nil {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "点赞失败: " + err.Error()}}, IsError: true}
+		action := "点赞"
+		if unlike {
+			action = "取消点赞"
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: action + "失败: " + err.Error()}}, IsError: true}
 	}
-	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("点赞成功 - Feed ID: %s", res.FeedID)}}}
+	
+	action := "点赞"
+	if unlike {
+		action = "取消点赞"
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("%s成功 - Feed ID: %s", action, res.FeedID)}}}
 }
 
-// handleFavoriteFeed 处理收藏
+// handleFavoriteFeed 处理收藏/取消收藏
 func (s *AppServer) handleFavoriteFeed(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	feedID, ok := args["feed_id"].(string)
 	if !ok || feedID == "" {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: 缺少feed_id参数"}}, IsError: true}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "操作失败: 缺少feed_id参数"}}, IsError: true}
 	}
 	xsecToken, ok := args["xsec_token"].(string)
 	if !ok || xsecToken == "" {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: 缺少xsec_token参数"}}, IsError: true}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "操作失败: 缺少xsec_token参数"}}, IsError: true}
 	}
-	res, err := s.xiaohongshuService.FavoriteFeed(ctx, feedID, xsecToken)
+	unfavorite, _ := args["unfavorite"].(bool)
+	
+	var res *ActionResult
+	var err error
+	
+	if unfavorite {
+		res, err = s.xiaohongshuService.UnfavoriteFeed(ctx, feedID, xsecToken)
+	} else {
+		res, err = s.xiaohongshuService.FavoriteFeed(ctx, feedID, xsecToken)
+	}
+	
 	if err != nil {
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "收藏失败: " + err.Error()}}, IsError: true}
+		action := "收藏"
+		if unfavorite {
+			action = "取消收藏"
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: action + "失败: " + err.Error()}}, IsError: true}
 	}
-	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("收藏成功 - Feed ID: %s", res.FeedID)}}}
+	
+	action := "收藏"
+	if unfavorite {
+		action = "取消收藏"
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("%s成功 - Feed ID: %s", action, res.FeedID)}}}
 }
 
 // handlePostComment 处理发表评论到Feed

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -50,6 +50,12 @@ type PostCommentArgs struct {
 	Content   string `json:"content" jsonschema:"评论内容"`
 }
 
+// LikeFavoriteArgs 点赞/收藏参数
+type LikeFavoriteArgs struct {
+	FeedID    string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
+	XsecToken string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -208,7 +214,39 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	logrus.Infof("Registered %d MCP tools", 9)
+	// 工具 10: 点赞笔记
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "like_feed",
+			Description: "为指定笔记点赞（如已点赞将跳过）",
+		},
+		func(ctx context.Context, req *mcp.CallToolRequest, args LikeFavoriteArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"feed_id":    args.FeedID,
+				"xsec_token": args.XsecToken,
+			}
+			result := appServer.handleLikeFeed(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		},
+	)
+
+	// 工具 11: 收藏笔记
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "favorite_feed",
+			Description: "收藏指定笔记（如已收藏将跳过）",
+		},
+		func(ctx context.Context, req *mcp.CallToolRequest, args LikeFavoriteArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"feed_id":    args.FeedID,
+				"xsec_token": args.XsecToken,
+			}
+			result := appServer.handleFavoriteFeed(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		},
+	)
+
+	logrus.Infof("Registered %d MCP tools", 11)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -50,10 +50,18 @@ type PostCommentArgs struct {
 	Content   string `json:"content" jsonschema:"评论内容"`
 }
 
-// LikeFavoriteArgs 点赞/收藏参数
-type LikeFavoriteArgs struct {
+// LikeFeedArgs 点赞参数
+type LikeFeedArgs struct {
 	FeedID    string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
 	XsecToken string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	Unlike    bool   `json:"unlike,omitempty" jsonschema:"是否取消点赞，true为取消点赞，false或未设置则为点赞"`
+}
+
+// FavoriteFeedArgs 收藏参数
+type FavoriteFeedArgs struct {
+	FeedID    string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
+	XsecToken string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
 // InitMCPServer 初始化 MCP Server
@@ -218,12 +226,13 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "like_feed",
-			Description: "为指定笔记点赞（如已点赞将跳过）",
+			Description: "为指定笔记点赞或取消点赞（如已点赞将跳过点赞，如未点赞将跳过取消点赞）",
 		},
-		func(ctx context.Context, req *mcp.CallToolRequest, args LikeFavoriteArgs) (*mcp.CallToolResult, any, error) {
+		func(ctx context.Context, req *mcp.CallToolRequest, args LikeFeedArgs) (*mcp.CallToolResult, any, error) {
 			argsMap := map[string]interface{}{
 				"feed_id":    args.FeedID,
 				"xsec_token": args.XsecToken,
+				"unlike":     args.Unlike,
 			}
 			result := appServer.handleLikeFeed(ctx, argsMap)
 			return convertToMCPResult(result), nil, nil
@@ -234,12 +243,13 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "favorite_feed",
-			Description: "收藏指定笔记（如已收藏将跳过）",
+			Description: "收藏指定笔记或取消收藏（如已收藏将跳过收藏，如未收藏将跳过取消收藏）",
 		},
-		func(ctx context.Context, req *mcp.CallToolRequest, args LikeFavoriteArgs) (*mcp.CallToolResult, any, error) {
+		func(ctx context.Context, req *mcp.CallToolRequest, args FavoriteFeedArgs) (*mcp.CallToolResult, any, error) {
 			argsMap := map[string]interface{}{
 				"feed_id":    args.FeedID,
 				"xsec_token": args.XsecToken,
+				"unfavorite": args.Unfavorite,
 			}
 			result := appServer.handleFavoriteFeed(ctx, argsMap)
 			return convertToMCPResult(result), nil, nil

--- a/service.go
+++ b/service.go
@@ -20,13 +20,6 @@ import (
 // XiaohongshuService 小红书业务服务
 type XiaohongshuService struct{}
 
-// ActionResult 通用动作响应（点赞/收藏等）
-type ActionResult struct {
-    FeedID  string `json:"feed_id"`
-    Success bool   `json:"success"`
-    Message string `json:"message"`
-}
-
 // NewXiaohongshuService 创建小红书服务实例
 func NewXiaohongshuService() *XiaohongshuService {
 	return &XiaohongshuService{}
@@ -405,6 +398,21 @@ func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken str
 	return &ActionResult{FeedID: feedID, Success: true, Message: "点赞成功或已点赞"}, nil
 }
 
+// UnlikeFeed 取消点赞笔记
+func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewLikeFavoriteAction(page)
+	if err := action.Unlike(ctx, feedID, xsecToken); err != nil {
+		return nil, err
+	}
+	return &ActionResult{FeedID: feedID, Success: true, Message: "取消点赞成功或未点赞"}, nil
+}
+
 // FavoriteFeed 收藏笔记
 func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
 	b := newBrowser()
@@ -418,6 +426,21 @@ func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken
 		return nil, err
 	}
 	return &ActionResult{FeedID: feedID, Success: true, Message: "收藏成功或已收藏"}, nil
+}
+
+// UnfavoriteFeed 取消收藏笔记
+func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewLikeFavoriteAction(page)
+	if err := action.Unfavorite(ctx, feedID, xsecToken); err != nil {
+		return nil, err
+	}
+	return &ActionResult{FeedID: feedID, Success: true, Message: "取消收藏成功或未收藏"}, nil
 }
 
 func newBrowser() *headless_browser.Browser {

--- a/service.go
+++ b/service.go
@@ -391,7 +391,7 @@ func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken str
 	page := b.NewPage()
 	defer page.Close()
 
-	action := xiaohongshu.NewLikeFavoriteAction(page)
+	action := xiaohongshu.NewLikeAction(page)
 	if err := action.Like(ctx, feedID, xsecToken); err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken s
 	page := b.NewPage()
 	defer page.Close()
 
-	action := xiaohongshu.NewLikeFavoriteAction(page)
+	action := xiaohongshu.NewLikeAction(page)
 	if err := action.Unlike(ctx, feedID, xsecToken); err != nil {
 		return nil, err
 	}
@@ -421,7 +421,7 @@ func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken
 	page := b.NewPage()
 	defer page.Close()
 
-	action := xiaohongshu.NewLikeFavoriteAction(page)
+	action := xiaohongshu.NewFavoriteAction(page)
 	if err := action.Favorite(ctx, feedID, xsecToken); err != nil {
 		return nil, err
 	}
@@ -436,7 +436,7 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 	page := b.NewPage()
 	defer page.Close()
 
-	action := xiaohongshu.NewLikeFavoriteAction(page)
+	action := xiaohongshu.NewFavoriteAction(page)
 	if err := action.Unfavorite(ctx, feedID, xsecToken); err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -63,3 +63,10 @@ type UserProfileRequest struct {
 	UserID    string `json:"user_id" binding:"required"`
 	XsecToken string `json:"xsec_token" binding:"required"`
 }
+
+// ActionResult 通用动作响应（点赞/收藏等）
+type ActionResult struct {
+	FeedID  string `json:"feed_id"`
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -18,6 +18,12 @@ type ActionResult struct {
 	Message string `json:"message"`
 }
 
+// 选择器常量
+const (
+	SelectorLikeButton    = ".interact-container .left .like-lottie"
+	SelectorCollectButton = ".interact-container .left .reds-icon.collect-icon"
+)
+
 // LikeFavoriteAction 点赞/收藏 动作
 // 提供在笔记详情页执行点赞和收藏的能力，并在可能的情况下避免重复点击
 // 通过读取 window.__INITIAL_STATE__ 判断当前状态
@@ -41,73 +47,89 @@ const (
 	actionUnfavorite   interactActionType = "取消收藏"
 )
 
+// getValidationFunc 根据动作类型获取验证函数
+func getValidationFunc(actionType interactActionType) func(bool, bool) bool {
+	switch actionType {
+	case actionLike:
+		return func(l, c bool) bool { return l }
+	case actionFavorite:
+		return func(l, c bool) bool { return c }
+	case actionUnlike:
+		return func(l, c bool) bool { return !l }
+	case actionUnfavorite:
+		return func(l, c bool) bool { return !c }
+	default:
+		return func(l, c bool) bool { return false }
+	}
+}
+
+// skipMessage 根据动作类型生成跳过消息
+func skipMessage(actionType interactActionType, feedID string) string {
+	if actionType == actionLike || actionType == actionFavorite {
+		return fmt.Sprintf("feed %s already %sd, skip clicking", feedID, actionType)
+	}
+	return fmt.Sprintf("feed %s not %sd yet, skip clicking", feedID, string(actionType)[2:])
+}
+
+// performClick 执行点击操作
+func (a *LikeFavoriteAction) performClick(page *rod.Page, selector string) {
+	elem := page.MustElement(selector)
+	elem.MustClick()
+}
+
+// interactConfig 交互动作配置
+type interactConfig struct {
+	feedID      string
+	xsecToken   string
+	actionType  interactActionType
+	selector    string
+	shouldSkip  func(bool, bool) bool
+}
+
 // performInteractAction 执行交互动作的通用方法
-func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, feedID, xsecToken string, actionType interactActionType, selector string, getStateFunc func(bool, bool) bool) error {
+func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, config interactConfig) error {
 	page := a.page.Context(ctx).Timeout(60 * time.Second)
-	url := makeFeedDetailURL(feedID, xsecToken)
-	logrus.Infof("Opening feed detail page for %s: %s", actionType, url)
+	url := makeFeedDetailURL(config.feedID, config.xsecToken)
+	logrus.Infof("Opening feed detail page for %s: %s", config.actionType, url)
 
 	page.MustNavigate(url)
 	page.MustWaitDOMStable()
 	time.Sleep(1 * time.Second)
 
-	liked, collected, err := a.getInteractState(page, feedID)
+	// 检查当前状态
+	liked, collected, err := a.getInteractState(page, config.feedID)
 	if err != nil {
 		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
-	} else if getStateFunc(liked, collected) {
-		// 根据动作类型显示不同的跳过信息
-		if actionType == actionLike || actionType == actionFavorite {
-			logrus.Infof("feed %s already %sd, skip clicking", feedID, actionType)
-		} else {
-			logrus.Infof("feed %s not %sd yet, skip clicking", feedID, string(actionType)[2:]) // 去掉"取消"前缀
-		}
+	} else if config.shouldSkip(liked, collected) {
+		logrus.Infof(skipMessage(config.actionType, config.feedID))
 		return nil
 	}
 
-	// 点击按钮
-	elem := page.MustElement(selector)
-	elem.MustClick()
+	// 执行点击
+	a.performClick(page, config.selector)
+	time.Sleep(3 * time.Second)
 
-	time.Sleep(3 * time.Second) // 增加等待时间，确保状态更新
-
-	// 定义验证函数
-	var isSuccess func(bool, bool) bool
-	switch actionType {
-	case actionLike:
-		isSuccess = func(l, c bool) bool { return l }
-	case actionFavorite:
-		isSuccess = func(l, c bool) bool { return c }
-	case actionUnlike:
-		isSuccess = func(l, c bool) bool { return !l }
-	case actionUnfavorite:
-		isSuccess = func(l, c bool) bool { return !c }
-	}
-
-	// 验证是否成功
-	newLiked, newCollected, err := a.getInteractState(page, feedID)
+	// 验证结果
+	isSuccess := getValidationFunc(config.actionType)
+	newLiked, newCollected, err := a.getInteractState(page, config.feedID)
 	if err == nil && isSuccess(newLiked, newCollected) {
-		logrus.Infof("feed %s %s成功", feedID, actionType)
+		logrus.Infof("feed %s %s成功", config.feedID, config.actionType)
 		return nil
 	}
 
+	// 失败重试
 	if err != nil {
-		logrus.Warnf("验证%s状态失败: %v", actionType, err)
+		logrus.Warnf("验证%s状态失败: %v", config.actionType, err)
 	} else {
-		logrus.Warnf("feed %s %s可能未成功，状态未变化，尝试再次点击", feedID, actionType)
-		// 如果第一次点击失败，尝试再次点击
-		elem := page.MustElement(selector)
-		elem.MustClick()
-		{
-			time.Sleep(2 * time.Second)
-			finalLiked, finalCollected, err2 := a.getInteractState(page, feedID)
-			if err2 == nil && isSuccess(finalLiked, finalCollected) {
-				logrus.Infof("feed %s 第二次点击%s成功", feedID, actionType)
-				return nil
-			} else if err2 == nil && actionType == actionLike && !finalLiked {
-				logrus.Warnf("feed %s 第二次点击后取消了点赞，这是正常行为", feedID)
-				return nil
-			} 
-		}
+		logrus.Warnf("feed %s %s可能未成功，状态未变化，尝试再次点击", config.feedID, config.actionType)
+		a.performClick(page, config.selector)
+		time.Sleep(2 * time.Second)
+		
+		finalLiked, finalCollected, err2 := a.getInteractState(page, config.feedID)
+		if err2 == nil && isSuccess(finalLiked, finalCollected) {
+			logrus.Infof("feed %s 第二次点击%s成功", config.feedID, config.actionType)
+			return nil
+		} 
 	}
 
 	return nil
@@ -115,16 +137,50 @@ func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, feedID, 
 
 // Like 点赞指定笔记，如果已点赞则直接返回
 func (a *LikeFavoriteAction) Like(ctx context.Context, feedID, xsecToken string) error {
-	return a.performInteractAction(ctx, feedID, xsecToken, actionLike, ".left > :first-child", func(liked, collected bool) bool {
-		return liked
-	})
+	config := interactConfig{
+		feedID:     feedID,
+		xsecToken:  xsecToken,
+		actionType: actionLike,
+		selector:   SelectorLikeButton,
+		shouldSkip: func(liked, collected bool) bool { return liked },
+	}
+	return a.performInteractAction(ctx, config)
 }
 
 // Favorite 收藏指定笔记，如果已收藏则直接返回
 func (a *LikeFavoriteAction) Favorite(ctx context.Context, feedID, xsecToken string) error {
-	return a.performInteractAction(ctx, feedID, xsecToken, actionFavorite, ".collect-wrapper > :last-child", func(liked, collected bool) bool {
-		return collected
-	})
+	config := interactConfig{
+		feedID:     feedID,
+		xsecToken:  xsecToken,
+		actionType: actionFavorite,
+		selector:   SelectorCollectButton,
+		shouldSkip: func(liked, collected bool) bool { return collected },
+	}
+	return a.performInteractAction(ctx, config)
+}
+
+// Unlike 取消点赞指定笔记，如果未点赞则直接返回
+func (a *LikeFavoriteAction) Unlike(ctx context.Context, feedID, xsecToken string) error {
+	config := interactConfig{
+		feedID:     feedID,
+		xsecToken:  xsecToken,
+		actionType: actionUnlike,
+		selector:   SelectorLikeButton,
+		shouldSkip: func(liked, collected bool) bool { return !liked },
+	}
+	return a.performInteractAction(ctx, config)
+}
+
+// Unfavorite 取消收藏指定笔记，如果未收藏则直接返回
+func (a *LikeFavoriteAction) Unfavorite(ctx context.Context, feedID, xsecToken string) error {
+	config := interactConfig{
+		feedID:     feedID,
+		xsecToken:  xsecToken,
+		actionType: actionUnfavorite,
+		selector:   SelectorCollectButton,
+		shouldSkip: func(liked, collected bool) bool { return !collected },
+	}
+	return a.performInteractAction(ctx, config)
 }
 
 // getInteractState 从 __INITIAL_STATE__ 读取笔记的点赞/收藏状态
@@ -162,16 +218,3 @@ func (a *LikeFavoriteAction) getInteractState(page *rod.Page, feedID string) (li
 	return detail.Note.InteractInfo.Liked, detail.Note.InteractInfo.Collected, nil
 }
 
-// Unlike 取消点赞指定笔记，如果未点赞则直接返回
-func (a *LikeFavoriteAction) Unlike(ctx context.Context, feedID, xsecToken string) error {
-	return a.performInteractAction(ctx, feedID, xsecToken, actionUnlike, ".like-wrapper > :last-child", func(liked, collected bool) bool {
-		return !liked // 如果未点赞，则跳过
-	})
-}
-
-// Unfavorite 取消收藏指定笔记，如果未收藏则直接返回
-func (a *LikeFavoriteAction) Unfavorite(ctx context.Context, feedID, xsecToken string) error {
-	return a.performInteractAction(ctx, feedID, xsecToken, actionUnfavorite, ".collect-wrapper > :last-child", func(liked, collected bool) bool {
-		return !collected // 如果未收藏，则跳过
-	})
-}

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -11,6 +11,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ActionResult 通用动作响应（点赞/收藏等）
+type ActionResult struct {
+	FeedID  string `json:"feed_id"`
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
 // LikeFavoriteAction 点赞/收藏 动作
 // 提供在笔记详情页执行点赞和收藏的能力，并在可能的情况下避免重复点击
 // 通过读取 window.__INITIAL_STATE__ 判断当前状态
@@ -28,8 +35,10 @@ func NewLikeFavoriteAction(page *rod.Page) *LikeFavoriteAction {
 type interactActionType string
 
 const (
-	actionLike     interactActionType = "点赞"
-	actionFavorite interactActionType = "收藏"
+	actionLike         interactActionType = "点赞"
+	actionFavorite     interactActionType = "收藏"
+	actionUnlike       interactActionType = "取消点赞"
+	actionUnfavorite   interactActionType = "取消收藏"
 )
 
 // performInteractAction 执行交互动作的通用方法
@@ -46,7 +55,12 @@ func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, feedID, 
 	if err != nil {
 		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
 	} else if getStateFunc(liked, collected) {
-		logrus.Infof("feed %s already %sd, skip clicking", feedID, actionType)
+		// 根据动作类型显示不同的跳过信息
+		if actionType == actionLike || actionType == actionFavorite {
+			logrus.Infof("feed %s already %sd, skip clicking", feedID, actionType)
+		} else {
+			logrus.Infof("feed %s not %sd yet, skip clicking", feedID, string(actionType)[2:]) // 去掉"取消"前缀
+		}
 		return nil
 	}
 
@@ -56,9 +70,22 @@ func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, feedID, 
 
 	time.Sleep(3 * time.Second) // 增加等待时间，确保状态更新
 
+	// 定义验证函数
+	var isSuccess func(bool, bool) bool
+	switch actionType {
+	case actionLike:
+		isSuccess = func(l, c bool) bool { return l }
+	case actionFavorite:
+		isSuccess = func(l, c bool) bool { return c }
+	case actionUnlike:
+		isSuccess = func(l, c bool) bool { return !l }
+	case actionUnfavorite:
+		isSuccess = func(l, c bool) bool { return !c }
+	}
+
 	// 验证是否成功
 	newLiked, newCollected, err := a.getInteractState(page, feedID)
-	if err == nil && getStateFunc(newLiked, newCollected) {
+	if err == nil && isSuccess(newLiked, newCollected) {
 		logrus.Infof("feed %s %s成功", feedID, actionType)
 		return nil
 	}
@@ -73,8 +100,11 @@ func (a *LikeFavoriteAction) performInteractAction(ctx context.Context, feedID, 
 		{
 			time.Sleep(2 * time.Second)
 			finalLiked, finalCollected, err2 := a.getInteractState(page, feedID)
-			if err2 == nil && getStateFunc(finalLiked, finalCollected) {
+			if err2 == nil && isSuccess(finalLiked, finalCollected) {
 				logrus.Infof("feed %s 第二次点击%s成功", feedID, actionType)
+				return nil
+			} else if err2 == nil && actionType == actionLike && !finalLiked {
+				logrus.Warnf("feed %s 第二次点击后取消了点赞，这是正常行为", feedID)
 				return nil
 			} 
 		}
@@ -130,4 +160,18 @@ func (a *LikeFavoriteAction) getInteractState(page *rod.Page, feedID string) (li
 		return false, false, fmt.Errorf("feed %s not in noteDetailMap", feedID)
 	}
 	return detail.Note.InteractInfo.Liked, detail.Note.InteractInfo.Collected, nil
+}
+
+// Unlike 取消点赞指定笔记，如果未点赞则直接返回
+func (a *LikeFavoriteAction) Unlike(ctx context.Context, feedID, xsecToken string) error {
+	return a.performInteractAction(ctx, feedID, xsecToken, actionUnlike, ".like-wrapper > :last-child", func(liked, collected bool) bool {
+		return !liked // 如果未点赞，则跳过
+	})
+}
+
+// Unfavorite 取消收藏指定笔记，如果未收藏则直接返回
+func (a *LikeFavoriteAction) Unfavorite(ctx context.Context, feedID, xsecToken string) error {
+	return a.performInteractAction(ctx, feedID, xsecToken, actionUnfavorite, ".collect-wrapper > :last-child", func(liked, collected bool) bool {
+		return !collected // 如果未收藏，则跳过
+	})
 }

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -1,0 +1,332 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// LikeFavoriteAction 点赞/收藏 动作
+// 提供在笔记详情页执行点赞和收藏的能力，并在可能的情况下避免重复点击
+// 通过读取 window.__INITIAL_STATE__ 判断当前状态
+// 并尽量采用多种选择器/文案做回退，避免因页面样式变更导致失败
+// 注意：该实现依赖页面 DOM，可能随页面升级而变化
+
+type LikeFavoriteAction struct {
+	page *rod.Page
+}
+
+func NewLikeFavoriteAction(page *rod.Page) *LikeFavoriteAction {
+	return &LikeFavoriteAction{page: page}
+}
+
+// Like 点赞指定笔记，如果已点赞则直接返回
+func (a *LikeFavoriteAction) Like(ctx context.Context, feedID, xsecToken string) error {
+	page := a.page.Context(ctx).Timeout(60 * time.Second)
+	url := makeFeedDetailURL(feedID, xsecToken)
+	logrus.Infof("Opening feed detail page for like: %s", url)
+
+	page.MustNavigate(url)
+	page.MustWaitDOMStable()
+	time.Sleep(1 * time.Second)
+
+	liked, _, err := a.getInteractState(page, feedID)
+	if err != nil {
+		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
+	} else if liked {
+		logrus.Infof("feed %s already liked, skip clicking", feedID)
+		return nil
+	}
+
+	// 依次尝试多种选择器或按文案匹配
+	selectors := []string{
+		"span.like-lottie",          // 页面提供的喜欢图标容器 (根据您提供的HTML)
+		".like-lottie",              // 页面提供的喜欢图标容器
+		"button.like",               // 常见按钮类名
+		"div.interaction-bar .like", // 交互区域 like
+		"div.footer .like",          // 底部工具栏
+		".side-action .like",        // 侧边操作栏
+		".like-wrapper",             // 包裹元素
+		".interactions .like",       // 通用交互区
+	}
+	// 同时尝试 SVG use 的 like 图标
+	selectors = append(selectors,
+		"svg.like-icon", "use[href='#like']", "use[xlink\\:href='#like']",
+	)
+	textCandidates := []string{"点赞", "赞", "喜欢"}
+	if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+		return errors.Wrap(err, "点击点赞按钮失败")
+	}
+
+	time.Sleep(3 * time.Second) // 增加等待时间，确保状态更新
+	
+	// 验证点赞是否成功
+	newLiked, _, err := a.getInteractState(page, feedID)
+	if err == nil && newLiked {
+		logrus.Infof("feed %s 点赞成功", feedID)
+		return nil
+	}
+	
+	if err != nil {
+		logrus.Warnf("验证点赞状态失败: %v", err)
+	} else {
+		logrus.Warnf("feed %s 点赞可能未成功，状态未变化，尝试再次点击", feedID)
+		// 如果第一次点击失败，尝试再次点击
+		if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+			logrus.Warnf("第二次点击点赞按钮也失败: %v", err)
+		} else {
+			time.Sleep(2 * time.Second)
+			newLiked2, _, err2 := a.getInteractState(page, feedID)
+			if err2 == nil && newLiked2 {
+				logrus.Infof("feed %s 第二次点击点赞成功", feedID)
+				return nil
+			} else if err2 == nil && !newLiked2 {
+				logrus.Warnf("feed %s 第二次点击后取消了点赞，这是正常行为", feedID)
+				return nil
+			}
+		}
+	}
+	
+	return nil
+}
+
+// Favorite 收藏指定笔记，如果已收藏则直接返回
+func (a *LikeFavoriteAction) Favorite(ctx context.Context, feedID, xsecToken string) error {
+	page := a.page.Context(ctx).Timeout(60 * time.Second)
+	url := makeFeedDetailURL(feedID, xsecToken)
+	logrus.Infof("Opening feed detail page for favorite: %s", url)
+
+	page.MustNavigate(url)
+	page.MustWaitDOMStable()
+	time.Sleep(1 * time.Second)
+
+	_, collected, err := a.getInteractState(page, feedID)
+	if err != nil {
+		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
+	} else if collected {
+		logrus.Infof("feed %s already favorited, skip clicking", feedID)
+		return nil
+	}
+
+	selectors := []string{
+		"#note-page-collect-board-guide",           // 直接通过ID点击收藏按钮容器
+		".collect-wrapper",                         // 收藏按钮的包裹容器
+		".collect-wrapper svg",                     // 容器内的SVG
+		".collect-wrapper .reds-icon.collect-icon", // 容器内的收藏图标
+		".collect-wrapper use",                     // 容器内的use元素
+		"use[xlink:href='#collect']",               // 直接点击SVG内部的use元素
+		"use[href='#collect']",                      // 备用use选择器
+		"svg.reds-icon.collect-icon use",            // SVG内部的use元素
+		"svg.reds-icon.collect-icon",                // SVG容器（可能需要点击父容器）
+		".reds-icon.collect-icon use",               // 类组合的use元素
+		".reds-icon.collect-icon",                   // 类组合的容器
+		"svg.collect-icon use",                      // 通用SVG收藏图标内部的use
+		"svg.collect-icon",                          // 通用SVG收藏图标
+		".collect-icon",                             // 通用收藏图标类
+		"button.collect",                            // 常见按钮类名（收藏/收藏夹）
+		"button.favorite",
+		"div.interaction-bar .collect",
+		"div.footer .collect",
+		".side-action .collect",
+		".interactions .collect",
+	}
+	textCandidates := []string{"收藏", "收藏夹", "喜欢"}
+	if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+		return errors.Wrap(err, "点击收藏按钮失败")
+	}
+
+	time.Sleep(3 * time.Second) // 增加等待时间，确保状态更新
+	
+	// 验证收藏是否成功
+	_, newCollected, err := a.getInteractState(page, feedID)
+	if err == nil && newCollected {
+		logrus.Infof("feed %s 收藏成功", feedID)
+		return nil
+	}
+	
+	if err != nil {
+		logrus.Warnf("验证收藏状态失败: %v", err)
+	} else {
+		logrus.Warnf("feed %s 收藏可能未成功，状态未变化，尝试再次点击", feedID)
+		// 如果第一次点击失败，尝试再次点击
+		if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+			logrus.Warnf("第二次点击收藏按钮也失败: %v", err)
+		} else {
+			time.Sleep(2 * time.Second)
+			_, newCollected2, err2 := a.getInteractState(page, feedID)
+			if err2 == nil && newCollected2 {
+				logrus.Infof("feed %s 第二次点击收藏成功", feedID)
+				return nil
+			}
+		}
+	}
+	
+	return nil
+}
+
+// getInteractState 从 __INITIAL_STATE__ 读取笔记的点赞/收藏状态
+func (a *LikeFavoriteAction) getInteractState(page *rod.Page, feedID string) (liked bool, collected bool, err error) {
+	result := page.MustEval(`() => {
+		if (window.__INITIAL_STATE__) {
+			return JSON.stringify(window.__INITIAL_STATE__);
+		}
+		return "";
+	}`).String()
+	if result == "" {
+		return false, false, fmt.Errorf("__INITIAL_STATE__ not found")
+	}
+
+	var state struct {
+		Note struct {
+			NoteDetailMap map[string]struct {
+				Note struct {
+					InteractInfo struct {
+						Liked     bool `json:"liked"`
+						Collected bool `json:"collected"`
+					} `json:"interactInfo"`
+				} `json:"note"`
+			} `json:"noteDetailMap"`
+		} `json:"note"`
+	}
+	if err := json.Unmarshal([]byte(result), &state); err != nil {
+		return false, false, errors.Wrap(err, "unmarshal __INITIAL_STATE__ failed")
+	}
+
+	detail, ok := state.Note.NoteDetailMap[feedID]
+	if !ok {
+		return false, false, fmt.Errorf("feed %s not in noteDetailMap", feedID)
+	}
+	return detail.Note.InteractInfo.Liked, detail.Note.InteractInfo.Collected, nil
+}
+
+// clickFirstMatch 依次尝试选择器点击；若失败，尝试按按钮/链接文本模糊匹配
+func clickFirstMatch(page *rod.Page, selectors []string, textCandidates []string) error {
+	// 1) 尝试按选择器查找多个元素并点击（优先点击最后一个，即笔记的点赞按钮）
+	for _, sel := range selectors {
+		if els, err := page.Elements(sel); err == nil && len(els) > 0 {
+			// 从最后一个元素开始尝试（笔记的点赞按钮通常在评论区之前）
+			for i := len(els) - 1; i >= 0; i-- {
+				if tryClickChain(els[i]) {
+					return nil
+				}
+			}
+		}
+		// 单个元素回退
+		if el, err := page.Element(sel); err == nil && el != nil {
+			if tryClickChain(el) {
+				return nil
+			}
+		}
+	}
+	// 2) 文案匹配：在按钮/链接/容器中查找包含文案的元素
+	for _, txt := range textCandidates {
+		if els, err := page.Elements("button, a, div, span, svg, use"); err == nil && len(els) > 0 {
+			// 从最后一个元素开始尝试匹配文本
+			for i := len(els) - 1; i >= 0; i-- {
+				text, _ := els[i].Text()
+				if strings.Contains(strings.ToLower(text), strings.ToLower(txt)) {
+					if tryClickChain(els[i]) {
+						return nil
+					}
+				}
+			}
+		}
+		// 单个元素回退
+		if el, err := page.ElementR("button, a, div, span, svg, use", fmt.Sprintf("(?i)%s", regexpEscape(txt))); err == nil && el != nil {
+			if tryClickChain(el) {
+				return nil
+			}
+		}
+	}
+	return errors.New("no clickable element matched for selectors/text")
+}
+
+// tryClickChain 对元素自身及其若干父级尝试点击（scrollIntoView + js click + rod click）
+func tryClickChain(el *rod.Element) bool {
+	current := el
+	for i := 0; i < 6 && current != nil; i++ {
+		if clickElement(current) {
+			return true
+		}
+		parent, _ := current.Parent()
+		current = parent
+	}
+	return false
+}
+
+func clickElement(el *rod.Element) bool {
+	defer func() { _ = recover() }()
+	// 滚动到可见区域
+	_, _ = el.Eval(`() => { try { this.scrollIntoView({block: "center", inline: "center", behavior: "instant"}); } catch (e) {} return true }`)
+	
+	// 检查元素类型，对SVG元素使用特殊处理 - 简化处理，直接尝试所有方法
+	// 不检查元素类型，直接尝试多种点击方式
+	
+	// 1. 尝试触发MouseEvent（对SVG元素特别有效）
+	_, jsErr := el.Eval(`() => { 
+		try { 
+			const event = new MouseEvent('click', {
+				view: window,
+				bubbles: true,
+				cancelable: true
+			});
+			this.dispatchEvent(event);
+			return true; 
+		} catch (e) { 
+			console.error('MouseEvent click error:', e);
+			return false; 
+		} 
+	}`)
+	if jsErr == nil {
+		return true
+	}
+	
+	// 优先尝试标准 JS click
+	_, jsErr2 := el.Eval(`() => { 
+		try { 
+			this.click(); 
+			return true; 
+		} catch (e) { 
+			console.error('JS click error:', e);
+			return false; 
+		} 
+	}`)
+	if jsErr2 == nil {
+		return true
+	}
+	
+	// 再尝试 rod 的 Click
+	if err := el.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return false
+	}
+	
+	return true
+}
+
+// regexpEscape 对用户文案做正则转义，避免特殊字符
+func regexpEscape(s string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		".", "\\.",
+		"+", "\\+",
+		"*", "\\*",
+		"?", "\\?",
+		"(", "\\(",
+		")", "\\)",
+		"[", "\\[",
+		"]", "\\]",
+		"{", "\\{",
+		"}", "\\}",
+		"^", "\\^",
+		"$", "\\$",
+		"|", "\\|",
+	)
+	return replacer.Replace(s)
+}

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
-	"github.com/go-rod/rod/lib/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -16,7 +14,6 @@ import (
 // LikeFavoriteAction 点赞/收藏 动作
 // 提供在笔记详情页执行点赞和收藏的能力，并在可能的情况下避免重复点击
 // 通过读取 window.__INITIAL_STATE__ 判断当前状态
-// 并尽量采用多种选择器/文案做回退，避免因页面样式变更导致失败
 // 注意：该实现依赖页面 DOM，可能随页面升级而变化
 
 type LikeFavoriteAction struct {
@@ -45,23 +42,9 @@ func (a *LikeFavoriteAction) Like(ctx context.Context, feedID, xsecToken string)
 		return nil
 	}
 
-	// 依次尝试多种选择器或按文案匹配
-	selectors := []string{
-		"span.like-lottie",          // 页面提供的喜欢图标容器 (根据您提供的HTML)
-		".like-lottie",              // 页面提供的喜欢图标容器
-		"button.like",               // 常见按钮类名
-		"div.interaction-bar .like", // 交互区域 like
-		"div.footer .like",          // 底部工具栏
-		".side-action .like",        // 侧边操作栏
-		".like-wrapper",             // 包裹元素
-		".interactions .like",       // 通用交互区
-	}
-	// 同时尝试 SVG use 的 like 图标
-	selectors = append(selectors,
-		"svg.like-icon", "use[href='#like']", "use[xlink\\:href='#like']",
-	)
-	textCandidates := []string{"点赞", "赞", "喜欢"}
-	if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+
+	// 尝试点击点赞按钮
+	if err := clickLastMatch(page, []string{".like-lottie"}); err != nil {
 		return errors.Wrap(err, "点击点赞按钮失败")
 	}
 
@@ -79,7 +62,7 @@ func (a *LikeFavoriteAction) Like(ctx context.Context, feedID, xsecToken string)
 	} else {
 		logrus.Warnf("feed %s 点赞可能未成功，状态未变化，尝试再次点击", feedID)
 		// 如果第一次点击失败，尝试再次点击
-		if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+		if err := clickLastMatch(page, []string{".like-lottie"}); err != nil {
 			logrus.Warnf("第二次点击点赞按钮也失败: %v", err)
 		} else {
 			time.Sleep(2 * time.Second)
@@ -115,30 +98,7 @@ func (a *LikeFavoriteAction) Favorite(ctx context.Context, feedID, xsecToken str
 		return nil
 	}
 
-	selectors := []string{
-		"#note-page-collect-board-guide",           // 直接通过ID点击收藏按钮容器
-		".collect-wrapper",                         // 收藏按钮的包裹容器
-		".collect-wrapper svg",                     // 容器内的SVG
-		".collect-wrapper .reds-icon.collect-icon", // 容器内的收藏图标
-		".collect-wrapper use",                     // 容器内的use元素
-		"use[xlink:href='#collect']",               // 直接点击SVG内部的use元素
-		"use[href='#collect']",                      // 备用use选择器
-		"svg.reds-icon.collect-icon use",            // SVG内部的use元素
-		"svg.reds-icon.collect-icon",                // SVG容器（可能需要点击父容器）
-		".reds-icon.collect-icon use",               // 类组合的use元素
-		".reds-icon.collect-icon",                   // 类组合的容器
-		"svg.collect-icon use",                      // 通用SVG收藏图标内部的use
-		"svg.collect-icon",                          // 通用SVG收藏图标
-		".collect-icon",                             // 通用收藏图标类
-		"button.collect",                            // 常见按钮类名（收藏/收藏夹）
-		"button.favorite",
-		"div.interaction-bar .collect",
-		"div.footer .collect",
-		".side-action .collect",
-		".interactions .collect",
-	}
-	textCandidates := []string{"收藏", "收藏夹", "喜欢"}
-	if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+	if err := clickLastMatch(page, []string{"#collect"}); err != nil {
 		return errors.Wrap(err, "点击收藏按钮失败")
 	}
 
@@ -156,7 +116,7 @@ func (a *LikeFavoriteAction) Favorite(ctx context.Context, feedID, xsecToken str
 	} else {
 		logrus.Warnf("feed %s 收藏可能未成功，状态未变化，尝试再次点击", feedID)
 		// 如果第一次点击失败，尝试再次点击
-		if err := clickFirstMatch(page, selectors, textCandidates); err != nil {
+		if err := clickLastMatch(page, []string{"#collect"}); err != nil {
 			logrus.Warnf("第二次点击收藏按钮也失败: %v", err)
 		} else {
 			time.Sleep(2 * time.Second)
@@ -206,127 +166,22 @@ func (a *LikeFavoriteAction) getInteractState(page *rod.Page, feedID string) (li
 	return detail.Note.InteractInfo.Liked, detail.Note.InteractInfo.Collected, nil
 }
 
-// clickFirstMatch 依次尝试选择器点击；若失败，尝试按按钮/链接文本模糊匹配
-func clickFirstMatch(page *rod.Page, selectors []string, textCandidates []string) error {
-	// 1) 尝试按选择器查找多个元素并点击（优先点击最后一个，即笔记的点赞按钮）
+// clickLastMatch 点击选择器匹配的最后一个元素
+func clickLastMatch(page *rod.Page, selectors []string) error {
 	for _, sel := range selectors {
 		if els, err := page.Elements(sel); err == nil && len(els) > 0 {
-			// 从最后一个元素开始尝试（笔记的点赞按钮通常在评论区之前）
-			for i := len(els) - 1; i >= 0; i-- {
-				if tryClickChain(els[i]) {
-					return nil
-				}
+			// 直接点击最后一个元素
+			lastEl := els[len(els)-1]
+			if err := lastEl.Click("left", 1); err == nil {
+				return nil
 			}
 		}
 		// 单个元素回退
 		if el, err := page.Element(sel); err == nil && el != nil {
-			if tryClickChain(el) {
+			if err := el.Click("left", 1); err == nil {
 				return nil
 			}
 		}
 	}
-	// 2) 文案匹配：在按钮/链接/容器中查找包含文案的元素
-	for _, txt := range textCandidates {
-		if els, err := page.Elements("button, a, div, span, svg, use"); err == nil && len(els) > 0 {
-			// 从最后一个元素开始尝试匹配文本
-			for i := len(els) - 1; i >= 0; i-- {
-				text, _ := els[i].Text()
-				if strings.Contains(strings.ToLower(text), strings.ToLower(txt)) {
-					if tryClickChain(els[i]) {
-						return nil
-					}
-				}
-			}
-		}
-		// 单个元素回退
-		if el, err := page.ElementR("button, a, div, span, svg, use", fmt.Sprintf("(?i)%s", regexpEscape(txt))); err == nil && el != nil {
-			if tryClickChain(el) {
-				return nil
-			}
-		}
-	}
-	return errors.New("no clickable element matched for selectors/text")
-}
-
-// tryClickChain 对元素自身及其若干父级尝试点击（scrollIntoView + js click + rod click）
-func tryClickChain(el *rod.Element) bool {
-	current := el
-	for i := 0; i < 6 && current != nil; i++ {
-		if clickElement(current) {
-			return true
-		}
-		parent, _ := current.Parent()
-		current = parent
-	}
-	return false
-}
-
-func clickElement(el *rod.Element) bool {
-	defer func() { _ = recover() }()
-	// 滚动到可见区域
-	_, _ = el.Eval(`() => { try { this.scrollIntoView({block: "center", inline: "center", behavior: "instant"}); } catch (e) {} return true }`)
-	
-	// 检查元素类型，对SVG元素使用特殊处理 - 简化处理，直接尝试所有方法
-	// 不检查元素类型，直接尝试多种点击方式
-	
-	// 1. 尝试触发MouseEvent（对SVG元素特别有效）
-	_, jsErr := el.Eval(`() => { 
-		try { 
-			const event = new MouseEvent('click', {
-				view: window,
-				bubbles: true,
-				cancelable: true
-			});
-			this.dispatchEvent(event);
-			return true; 
-		} catch (e) { 
-			console.error('MouseEvent click error:', e);
-			return false; 
-		} 
-	}`)
-	if jsErr == nil {
-		return true
-	}
-	
-	// 优先尝试标准 JS click
-	_, jsErr2 := el.Eval(`() => { 
-		try { 
-			this.click(); 
-			return true; 
-		} catch (e) { 
-			console.error('JS click error:', e);
-			return false; 
-		} 
-	}`)
-	if jsErr2 == nil {
-		return true
-	}
-	
-	// 再尝试 rod 的 Click
-	if err := el.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return false
-	}
-	
-	return true
-}
-
-// regexpEscape 对用户文案做正则转义，避免特殊字符
-func regexpEscape(s string) string {
-	replacer := strings.NewReplacer(
-		"\\", "\\\\",
-		".", "\\.",
-		"+", "\\+",
-		"*", "\\*",
-		"?", "\\?",
-		"(", "\\(",
-		")", "\\)",
-		"[", "\\[",
-		"]", "\\]",
-		"{", "\\{",
-		"}", "\\}",
-		"^", "\\^",
-		"$", "\\$",
-		"|", "\\|",
-	)
-	return replacer.Replace(s)
+	return errors.New("no clickable element matched for selectors")
 }


### PR DESCRIPTION
fixes https://github.com/xpzouying/xiaohongshu-mcp/issues/146
- Implemented handleLikeFeed and handleFavoriteFeed methods in mcp_handlers.go to manage liking and favoriting feeds.
- Added LikeFavoriteArgs struct in mcp_server.go for handling parameters.
- Registered new MCP tools for liking and favoriting feeds in registerTools function.
- Introduced LikeFeed and FavoriteFeed methods in XiaohongshuService to interact with the respective actions.
- Created LikeFavoriteAction in a new file to encapsulate the logic for liking and favoriting feeds on the Xiaohongshu platform.