### PR TITLE
feat: 添加 ARM64 架构的 Docker 镜像支持

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,14 +27,28 @@ jobs:
         username: xpzouying
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push Docker image
+    - name: Build and push Docker image (AMD64)
       uses: docker/build-push-action@v5
       with:
         context: .
+        file: ./Dockerfile
         push: true
         platforms: linux/amd64
         tags: |
           xpzouying/xiaohongshu-mcp:${{ github.event.inputs.version }}
           xpzouying/xiaohongshu-mcp:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build and push Docker image (ARM64)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.arm64
+        push: true
+        platforms: linux/arm64
+        tags: |
+          xpzouying/xiaohongshu-mcp:${{ github.event.inputs.version }}-arm64
+          xpzouying/xiaohongshu-mcp:latest-arm64
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,88 @@
+# Dockerfile for ARM64 architecture
+# This Dockerfile uses Chromium (auto-downloaded by go-rod) instead of Google Chrome
+# because Google Chrome does not provide official Linux ARM64 builds.
+
+# ---- build stage ----
+FROM golang:1.24 AS builder
+
+WORKDIR /src
+# 配置 Go 模块代理为国内源
+ENV GOPROXY=https://goproxy.cn,direct
+ENV GOSUMDB=sum.golang.google.cn
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+# 移除 GOARCH 硬编码，让构建系统根据目标平台自动选择架构
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/app .
+
+# ---- run stage ----
+FROM ubuntu:22.04
+
+# 设置时区
+ENV TZ=Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+WORKDIR /app
+
+# 1. 先安装必要工具，然后配置阿里云镜像源
+RUN apt-get update && apt-get install -y ca-certificates wget gnupg && \
+    sed -i 's|http://archive.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list
+
+# 2. 安装 Chromium 运行所需的依赖库
+# 注意：不安装 Google Chrome，因为它不支持 ARM64
+# go-rod 会在首次运行时自动从 Playwright CDN 下载 ARM64 版本的 Chromium
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libgcc1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    lsb-release \
+    wget \
+    xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/app .
+
+# 3. 创建共享目录并设置权限
+RUN mkdir -p /app/images && \
+    chmod 777 /app/images
+
+# 4. 不设置 ROD_BROWSER_BIN 环境变量
+# go-rod 会自动检测并下载适合 ARM64 架构的 Chromium 浏览器
+# Chromium 下载源：https://playwright.azureedge.net/builds/chromium/
+
+EXPOSE 18060
+
+CMD ["./app"]


### PR DESCRIPTION
## 概述

添加对 ARM64 架构的 Docker 镜像支持，与现有 amd64 镜像互不影响。

## 主要变更

### 1. 新建 `Dockerfile.arm64`
- ✅ 使用 Chromium 替代 Google Chrome（因为 Chrome 不支持 Linux ARM64）
- ✅ 移除 `GOARCH=amd64` 硬编码
- ✅ 删除 Google Chrome APT 源和安装步骤
- ✅ 删除 `ROD_BROWSER_BIN` 环境变量
- ✅ go-rod 将自动从 Playwright CDN 下载 ARM64 版 Chromium

### 2. 更新 GitHub Actions 工作流
- 添加独立的 ARM64 构建步骤
- AMD64 镜像标签：`v1.0.0`, `latest`（保持不变）
- ARM64 镜像标签：`v1.0.0-arm64`, `latest-arm64`（新增）

## 技术说明

### 浏览器支持
| 浏览器 | Linux ARM64 支持 |
|--------|-----------------|
| Google Chrome | ❌ 不支持 |
| Chromium | ✅ 支持（via Playwright） |

### 镜像构建策略
- **相互独立**：两个架构的构建步骤完全独立
- **风险隔离**：ARM64 构建失败不影响 AMD64 镜像
- **标签分离**：使用不同的标签区分架构

## 测试计划

- [ ] 手动触发 GitHub Actions workflow
- [ ] 验证 AMD64 镜像构建成功
- [ ] 验证 ARM64 镜像构建成功
- [ ] 在 ARM64 设备上测试镜像运行

## 影响范围

- ✅ **零影响**：现有 amd64 用户完全不受影响
- ✅ **新功能**：为 ARM64 用户（如树莓派、Apple Silicon 服务器）提供支持

🤖 Generated with [Claude Code](https://claude.com/claude-code)