### PR TITLE
docs: 添加 Docker Pulls 徽章到 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![已捐赠](https://img.shields.io/badge/Donated-CNY%20200.00-brightgreen?style=flat-square)](./DONATIONS.md)
 [![获得赞赏](https://img.shields.io/badge/Received-CNY%20179.92-blue?style=flat-square)](./DONATIONS.md)
+[![Docker Pulls](https://img.shields.io/docker/pulls/xpzouying/xiaohongshu-mcp?style=flat-square&logo=docker)](https://hub.docker.com/r/xpzouying/xiaohongshu-mcp)
 
 MCP for 小红书/xiaohongshu.com。
 


### PR DESCRIPTION
## 概述

在 README 顶部添加 Docker Hub 下载次数徽章，方便用户查看项目的使用热度。

## 变更内容

### 添加徽章
```markdown
[![Docker Pulls](https://img.shields.io/docker/pulls/xpzouying/xiaohongshu-mcp?style=flat-square&logo=docker)](https://hub.docker.com/r/xpzouying/xiaohongshu-mcp)
```

### 徽章位置
- 放置在捐赠徽章之后
- 项目介绍之前
- 与其他徽章保持统一的 flat-square 风格

### 徽章功能
- ✅ 显示镜像的总下载次数
- ✅ 包含 Docker logo 图标
- ✅ 点击跳转到 Docker Hub 仓库页面
- ✅ 自动更新下载数据

## 效果预览

徽章将显示类似：`pulls 1.2k` 或 `pulls 523` 等格式

## 影响范围

- 仅修改 README.md
- 纯文档变更，不影响任何功能代码

🤖 Generated with [Claude Code](https://claude.com/claude-code)