### PR TITLE
修复不同类型图片提交的情况下排序的问题

### DIFF
--- a/pkg/downloader/processor.go
+++ b/pkg/downloader/processor.go
@@ -22,66 +22,22 @@ func NewImageProcessor() *ImageProcessor {
 // 支持两种输入格式：
 // 1. URL格式 (http/https开头) - 自动下载到本地
 // 2. 本地文件路径 - 直接使用
-// 保持原始图片顺序
+// 保持原始图片顺序，如果下载失败直接返回错误
 func (p *ImageProcessor) ProcessImages(images []string) ([]string, error) {
-	// 记录每个位置的图片类型和URL索引
-	type imageInfo struct {
-		isURL     bool
-		localPath string
-		urlIndex  int // 如果是URL，记录在urlsToDownload中的索引
-	}
+	localPaths := make([]string, 0, len(images))
 
-	imageInfos := make([]imageInfo, 0, len(images))
-	urlsToDownload := make([]string, 0)
-	urlIndexMap := make(map[string]int) // URL -> urlsToDownload中的索引
-
-	// 第一遍遍历：收集URL和本地路径，保持顺序
+	// 按顺序处理每张图片
 	for _, image := range images {
 		if IsImageURL(image) {
-			// 检查URL是否已经存在（去重）
-			if idx, exists := urlIndexMap[image]; exists {
-				imageInfos = append(imageInfos, imageInfo{
-					isURL:    true,
-					urlIndex: idx,
-				})
-			} else {
-				// 新URL，添加到下载列表
-				idx := len(urlsToDownload)
-				urlsToDownload = append(urlsToDownload, image)
-				urlIndexMap[image] = idx
-				imageInfos = append(imageInfos, imageInfo{
-					isURL:    true,
-					urlIndex: idx,
-				})
+			// URL图片：立即下载，失败直接返回错误
+			localPath, err := p.downloader.DownloadImage(image)
+			if err != nil {
+				return nil, fmt.Errorf("下载图片失败 %s: %w", image, err)
 			}
+			localPaths = append(localPaths, localPath)
 		} else {
-			// 本地路径直接记录
-			imageInfos = append(imageInfos, imageInfo{
-				isURL:     false,
-				localPath: image,
-			})
-		}
-	}
-
-	// 批量下载URL图片
-	downloadedPaths := make([]string, len(urlsToDownload))
-	if len(urlsToDownload) > 0 {
-		paths, err := p.downloader.DownloadImages(urlsToDownload)
-		if err != nil {
-			return nil, fmt.Errorf("failed to download images: %w", err)
-		}
-		copy(downloadedPaths, paths)
-	}
-
-	// 按原始顺序组装结果
-	localPaths := make([]string, 0, len(images))
-	for _, info := range imageInfos {
-		if info.isURL {
-			if info.urlIndex < len(downloadedPaths) {
-				localPaths = append(localPaths, downloadedPaths[info.urlIndex])
-			}
-		} else {
-			localPaths = append(localPaths, info.localPath)
+			// 本地路径直接使用
+			localPaths = append(localPaths, image)
 		}
 	}
 


### PR DESCRIPTION
之前的情况遇到的问题是这样的：
1. 链接在前面，本地图片地址在后面，提交发布之后
2. 链接下载图片到本地，重新获取地址加入链接，所以会导致顺序会打乱。

假如第一张是ai生成的封面，就会跳到后面去了