### PR TITLE
feat: 添加阿里云容器镜像推送 workflow

### DIFF
--- a/.github/workflows/aliyun-docker-release.yml
+++ b/.github/workflows/aliyun-docker-release.yml
@@ -1,0 +1,55 @@
+name: Aliyun Docker Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Aliyun Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com
+        username: ${{ secrets.ALIYUN_REGISTRY_USERNAME }}
+        password: ${{ secrets.ALIYUN_REGISTRY_PASSWORD }}
+
+    - name: Build and push Docker image (AMD64)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        platforms: linux/amd64
+        tags: |
+          crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:${{ github.event.inputs.version }}
+          crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build and push Docker image (ARM64)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.arm64
+        push: true
+        platforms: linux/arm64
+        tags: |
+          crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:${{ github.event.inputs.version }}-arm64
+          crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:latest-arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- 新增阿里云容器镜像服务推送 workflow
- 支持 AMD64 和 ARM64 两种架构
- 使用 `workflow_dispatch` 手动触发，与现有 Docker Hub 推送保持一致

## 配置要求
需要在 GitHub Secrets 中添加：
- `ALIYUN_REGISTRY_USERNAME`
- `ALIYUN_REGISTRY_PASSWORD`

## Test plan
- [ ] 在 GitHub Actions 页面手动触发 workflow
- [ ] 验证镜像成功推送到阿里云 Registry
- [ ] 验证 AMD64 和 ARM64 镜像都能正常拉取

🤖 Generated with [Claude Code](https://claude.com/claude-code)