### PR TITLE
fix: 修复 Docker 环境中的僵尸进程问题

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     # image: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp
     container_name: xiaohongshu-mcp
     restart: unless-stopped
+    init: true
     tty: true
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
## 问题描述

Fixes #351

在 Docker 环境中部署时，xiaohongshu-mcp 应用作为 PID 1 运行，产生大量僵尸进程。

## 根本原因

1. **代码层面**：service.go 中所有浏览器操作都正确使用 `defer b.Close()` 关闭浏览器
2. **底层机制**：headless_browser 使用 go-rod 的 launcher 启动 Chrome，Close() 时调用 Kill() 杀死整个进程组
3. **Docker 特性**：在容器中，app 是 PID 1，Chrome 的子进程被杀死后变成孤儿进程，但 PID 1 没有调用 wait() 回收，导致僵尸进程累积

## 解决方案

在 `docker/docker-compose.yml` 中添加 `init: true` 配置：

```yaml
services:
  xiaohongshu-mcp:
    container_name: xiaohongshu-mcp
    restart: unless-stopped
    init: true  # 添加这一行
    tty: true
```

Docker 会使用 tini/dumb-init 作为 init 进程，自动回收僵尸进程。

## 验证

- ✅ 此方案已由 issue 报告者 @ruijzhan 验证有效
- ✅ 这是 Docker 官方推荐的 PID 1 问题解决方案
- ✅ 修改最小化，不需要重新构建镜像

## 影响范围

- 仅影响 Docker 部署方式
- 不影响应用代码
- 不需要重新构建镜像，只需更新 docker-compose.yml

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)