### PR TITLE
feat: add batch get_feed_details with concurrent fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 - `list_feeds` - 获取小红书首页推荐列表（无参数）
 - `search_feeds` - 搜索小红书内容（需要：keyword）
 - `get_feed_detail` - 获取帖子详情（需要：feed_id, xsec_token）
+- `get_feed_details` - 批量获取帖子详情（需要：items；可选：concurrency）
 - `post_comment_to_feed` - 发表评论到小红书帖子（需要：feed_id, xsec_token, content）
 - `user_profile` - 获取用户个人主页信息（需要：user_id, xsec_token）
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -690,6 +690,7 @@ After successful connection, you can use the following MCP tools:
 - `list_feeds` - Get RedNote homepage recommendation list (no parameters)
 - `search_feeds` - Search RedNote content (required: keyword)
 - `get_feed_detail` - Get post details (required: feed_id, xsec_token)
+- `get_feed_details` - Batch get post details (required: items; optional: concurrency)
 - `post_comment_to_feed` - Post comments to RedNote posts (required: feed_id, xsec_token, content)
 - `user_profile` - Get user profile information (required: user_id, xsec_token)
 

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -59,6 +59,17 @@ type FeedDetailArgs struct {
 	ScrollSpeed      string `json:"scroll_speed,omitempty" jsonschema:"【仅当load_all_comments为true时生效】滚动速度slow慢速、normal正常、fast快速"`
 }
 
+// FeedDetailsArgs 批量获取Feed详情的参数
+type FeedDetailsArgs struct {
+	Items            []FeedDetailItem `json:"items" jsonschema:"批量笔记列表，每项包含feed_id和xsec_token"`
+	LoadAllComments  bool             `json:"load_all_comments,omitempty" jsonschema:"是否加载全部评论。false仅返回前10条一级评论（默认），true滚动加载更多评论"`
+	Limit            int              `json:"limit,omitempty" jsonschema:"【仅当load_all_comments为true时生效】限制加载的一级评论数量。例如20表示最多加载20条，默认20"`
+	ClickMoreReplies bool             `json:"click_more_replies,omitempty" jsonschema:"【仅当load_all_comments为true时生效】是否展开二级回复。true展开子评论，false不展开（默认）"`
+	ReplyLimit       int              `json:"reply_limit,omitempty" jsonschema:"【仅当click_more_replies为true时生效】跳过回复数过多的评论。例如10表示跳过超过10条回复的，默认10"`
+	ScrollSpeed      string           `json:"scroll_speed,omitempty" jsonschema:"【仅当load_all_comments为true时生效】滚动速度slow慢速、normal正常、fast快速"`
+	Concurrency      int              `json:"concurrency,omitempty" jsonschema:"并发数，默认3，最大10"`
+}
+
 // UserProfileArgs 获取用户主页的参数
 type UserProfileArgs struct {
 	UserID    string `json:"user_id" jsonschema:"小红书用户ID，从Feed列表获取"`
@@ -297,7 +308,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 8: 获取用户主页
+	// 工具 8: 批量获取Feed详情
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_feed_details",
+			Description: "批量获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据及评论列表（支持并发）。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Feed Details",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_feed_details", func(ctx context.Context, req *mcp.CallToolRequest, args FeedDetailsArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleGetFeedDetails(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 9: 获取用户主页
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "user_profile",

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -411,6 +412,94 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 	}
 
 	return response, nil
+}
+
+// GetFeedDetailsWithConfig 批量获取Feed详情（多浏览器并发）
+func (s *XiaohongshuService) GetFeedDetailsWithConfig(ctx context.Context, items []FeedDetailItem, loadAllComments bool, config xiaohongshu.CommentLoadConfig, concurrency int) (*FeedDetailBatchResponse, error) {
+	if len(items) == 0 {
+		return &FeedDetailBatchResponse{
+			Items:        []FeedDetailBatchItemResult{},
+			Count:        0,
+			SuccessCount: 0,
+			FailureCount: 0,
+		}, nil
+	}
+
+	if concurrency <= 0 {
+		concurrency = 3
+	}
+	if concurrency > 10 {
+		concurrency = 10
+	}
+
+	type job struct {
+		index int
+		item  FeedDetailItem
+	}
+
+	results := make([]FeedDetailBatchItemResult, len(items))
+	jobs := make(chan job)
+	var wg sync.WaitGroup
+
+	worker := func() {
+		defer wg.Done()
+		for j := range jobs {
+			item := j.item
+			if item.FeedID == "" || item.XsecToken == "" {
+				results[j.index] = FeedDetailBatchItemResult{
+					FeedID:  item.FeedID,
+					Success: false,
+					Error:   "缺少feed_id或xsec_token参数",
+				}
+				continue
+			}
+
+			res, err := s.GetFeedDetailWithConfig(ctx, item.FeedID, item.XsecToken, loadAllComments, config)
+			if err != nil {
+				results[j.index] = FeedDetailBatchItemResult{
+					FeedID:  item.FeedID,
+					Success: false,
+					Error:   err.Error(),
+				}
+				continue
+			}
+
+			results[j.index] = FeedDetailBatchItemResult{
+				FeedID:  item.FeedID,
+				Success: true,
+				Data:    res.Data,
+			}
+		}
+	}
+
+	workerCount := concurrency
+	if len(items) < workerCount {
+		workerCount = len(items)
+	}
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	for i, item := range items {
+		jobs <- job{index: i, item: item}
+	}
+	close(jobs)
+	wg.Wait()
+
+	successCount := 0
+	for _, r := range results {
+		if r.Success {
+			successCount++
+		}
+	}
+
+	return &FeedDetailBatchResponse{
+		Items:        results,
+		Count:        len(results),
+		SuccessCount: successCount,
+		FailureCount: len(results) - successCount,
+	}, nil
 }
 
 // UserProfile 获取用户信息

--- a/types.go
+++ b/types.go
@@ -54,6 +54,12 @@ type FeedDetailRequest struct {
 	CommentConfig   *CommentLoadConfig `json:"comment_config,omitempty"`
 }
 
+// FeedDetailItem 批量获取Feed详情的单项
+type FeedDetailItem struct {
+	FeedID    string `json:"feed_id"`
+	XsecToken string `json:"xsec_token"`
+}
+
 type SearchFeedsRequest struct {
 	Keyword string                   `json:"keyword" binding:"required"`
 	Filters xiaohongshu.FilterOption `json:"filters,omitempty"`
@@ -63,6 +69,22 @@ type SearchFeedsRequest struct {
 type FeedDetailResponse struct {
 	FeedID string `json:"feed_id"`
 	Data   any    `json:"data"`
+}
+
+// FeedDetailBatchItemResult 批量获取Feed详情的单项结果
+type FeedDetailBatchItemResult struct {
+	FeedID  string `json:"feed_id"`
+	Success bool   `json:"success"`
+	Data    any    `json:"data,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// FeedDetailBatchResponse 批量获取Feed详情响应
+type FeedDetailBatchResponse struct {
+	Items        []FeedDetailBatchItemResult `json:"items"`
+	Count        int                         `json:"count"`
+	SuccessCount int                         `json:"success_count"`
+	FailureCount int                         `json:"failure_count"`
 }
 
 // PostCommentRequest 发表评论请求


### PR DESCRIPTION
PR 描述
## 背景描述
在使用mcp时，让ai agent去获取笔记详情时候 对于某些agent工具只支持线性调用工具，导致批量获取某些笔记的效率低下。

## Summary
- 新增 MCP 工具 `get_feed_details`，支持批量获取笔记详情
- 支持并发参数（默认3、最大10）与统一评论加载参数
- 返回逐条成功/失败，保持 `get_feed_detail` 不变
- 更新 README / README_EN 文档

  ## Testing
  - 完整测试通过