### PR TITLE
fix: 修复发布流程 context 取消时 panic 问题

### DIFF
--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -132,16 +132,25 @@ func waitForPublishButtonClickable(page *rod.Page) (*rod.Element, error) {
 // submitPublishVideo 填写标题、正文、标签并点击发布（等待按钮可点击后再提交）
 func submitPublishVideo(page *rod.Page, title, content string, tags []string, scheduleTime *time.Time) error {
 	// 标题
-	titleElem := page.MustElement("div.d-input input")
-	titleElem.MustInput(title)
+	titleElem, err := page.Element("div.d-input input")
+	if err != nil {
+		return errors.Wrap(err, "查找标题输入框失败")
+	}
+	if err := titleElem.Input(title); err != nil {
+		return errors.Wrap(err, "输入标题失败")
+	}
 	time.Sleep(1 * time.Second)
 
 	// 正文 + 标签
-	if contentElem, ok := getContentElement(page); ok {
-		contentElem.MustInput(content)
-		inputTags(contentElem, tags)
-	} else {
+	contentElem, ok := getContentElement(page)
+	if !ok {
 		return errors.New("没有找到内容输入框")
+	}
+	if err := contentElem.Input(content); err != nil {
+		return errors.Wrap(err, "输入正文失败")
+	}
+	if err := inputTags(contentElem, tags); err != nil {
+		return err
 	}
 
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Summary
- 将 `inputTag`、`inputTags`、`submitPublish`、`submitPublishVideo` 中的 rod `Must*` 调用替换为带 error 返回的安全版本
- context 取消（客户端断开/超时）时不再 panic，而是正常返回 error
- 仅涉及包内私有函数，无外部接口变动

## Test plan
- [x] 测试 `publish_content`（图文发布）：带标签 / 无标签
- [x] 测试 `publish_with_video`（视频发布）：带标签 / 无标签
- [ ] 测试发布过程中取消请求，确认不再 panic 而是返回错误信息

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)