### PR TITLE
fix: complete product selection modal flow before publish

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -171,7 +171,8 @@ Content-Type: application/json
     "http://example.com/image1.jpg",
     "http://example.com/image2.jpg"
   ],
-  "tags": ["标签1", "标签2"]
+  "tags": ["标签1", "标签2"],
+  "product_keyword": "幼小衔接"
 }
 ```
 
@@ -180,6 +181,7 @@ Content-Type: application/json
 - `content` (string, required): 笔记内容
 - `images` (array, required): 图片URL数组，至少包含一张图片
 - `tags` (array, optional): 标签数组
+- `product_keyword` (string, optional): 店铺商品关键词，传入后会在发布页自动执行“添加商品 -> 搜索 -> 勾选 -> 保存”
 
 **响应**
 ```json

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -134,16 +134,19 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 
 	// 解析定时发布参数
 	scheduleAt, _ := args["schedule_at"].(string)
+	productKeyword, _ := args["product_keyword"].(string)
 
-	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s", title, len(imagePaths), len(tags), scheduleAt)
+	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 商品关键词: %s, 定时: %s",
+		title, len(imagePaths), len(tags), productKeyword, scheduleAt)
 
 	// 构建发布请求
 	req := &PublishRequest{
-		Title:      title,
-		Content:    content,
-		Images:     imagePaths,
-		Tags:       tags,
-		ScheduleAt: scheduleAt,
+		Title:          title,
+		Content:        content,
+		Images:         imagePaths,
+		Tags:           tags,
+		ProductKeyword: productKeyword,
+		ScheduleAt:     scheduleAt,
 	}
 
 	// 执行发布

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -17,11 +17,12 @@ func boolPtr(b bool) *bool { return &b }
 
 // PublishContentArgs 发布内容的参数
 type PublishContentArgs struct {
-	Title      string   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
-	Content    string   `json:"content" jsonschema:"正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可"`
-	Images     []string `json:"images" jsonschema:"图片路径列表（至少需要1张图片）。支持两种方式：1. HTTP/HTTPS图片链接（自动下载）；2. 本地图片绝对路径（推荐，如:/Users/user/image.jpg）"`
-	Tags       []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
-	ScheduleAt string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
+	Title          string   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
+	Content        string   `json:"content" jsonschema:"正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可"`
+	Images         []string `json:"images" jsonschema:"图片路径列表（至少需要1张图片）。支持两种方式：1. HTTP/HTTPS图片链接（自动下载）；2. 本地图片绝对路径（推荐，如:/Users/user/image.jpg）"`
+	Tags           []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
+	ProductKeyword string   `json:"product_keyword,omitempty" jsonschema:"店铺商品关键词（可选）。传入后会在发布页自动打开'添加商品'，搜索关键词并确认保存"`
+	ScheduleAt     string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
 }
 
 // PublishVideoArgs 发布视频的参数（仅支持本地单个视频文件）
@@ -209,11 +210,12 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		withPanicRecovery("publish_content", func(ctx context.Context, req *mcp.CallToolRequest, args PublishContentArgs) (*mcp.CallToolResult, any, error) {
 			// 转换参数格式到现有的 handler
 			argsMap := map[string]interface{}{
-				"title":       args.Title,
-				"content":     args.Content,
-				"images":      convertStringsToInterfaces(args.Images),
-				"tags":        convertStringsToInterfaces(args.Tags),
-				"schedule_at": args.ScheduleAt,
+				"title":           args.Title,
+				"content":         args.Content,
+				"images":          convertStringsToInterfaces(args.Images),
+				"tags":            convertStringsToInterfaces(args.Tags),
+				"product_keyword": args.ProductKeyword,
+				"schedule_at":     args.ScheduleAt,
 			}
 			result := appServer.handlePublishContent(ctx, argsMap)
 			return convertToMCPResult(result), nil, nil

--- a/service.go
+++ b/service.go
@@ -28,11 +28,12 @@ func NewXiaohongshuService() *XiaohongshuService {
 
 // PublishRequest 发布请求
 type PublishRequest struct {
-	Title      string   `json:"title" binding:"required"`
-	Content    string   `json:"content" binding:"required"`
-	Images     []string `json:"images" binding:"required,min=1"`
-	Tags       []string `json:"tags,omitempty"`
-	ScheduleAt string   `json:"schedule_at,omitempty"` // 定时发布时间，ISO8601格式，为空则立即发布
+	Title          string   `json:"title" binding:"required"`
+	Content        string   `json:"content" binding:"required"`
+	Images         []string `json:"images" binding:"required,min=1"`
+	Tags           []string `json:"tags,omitempty"`
+	ProductKeyword string   `json:"product_keyword,omitempty"` // 店铺商品关键词，不为空时会自动尝试添加店铺商品
+	ScheduleAt     string   `json:"schedule_at,omitempty"`     // 定时发布时间，ISO8601格式，为空则立即发布
 }
 
 // LoginStatusResponse 登录状态响应
@@ -207,11 +208,12 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 
 	// 构建发布内容
 	content := xiaohongshu.PublishImageContent{
-		Title:        req.Title,
-		Content:      req.Content,
-		Tags:         req.Tags,
-		ImagePaths:   imagePaths,
-		ScheduleTime: scheduleTime,
+		Title:          req.Title,
+		Content:        req.Content,
+		Tags:           req.Tags,
+		ImagePaths:     imagePaths,
+		ProductKeyword: req.ProductKeyword,
+		ScheduleTime:   scheduleTime,
 	}
 
 	// 执行发布


### PR DESCRIPTION
## 背景
在发布流程中，当配置商品关键词并打开"添加商品"弹窗后，流程会停在商品搜索结果页，未完成"勾选商品 + 保存"，导致商品未真正绑定到笔记。

## 变更内容
- 在 `submitPublish` 中增加可选的商品绑定步骤（通过环境变量 `XHS_PRODUCT_KEYWORD` 开启）。
- 新增商品关键词输入逻辑：优先命中带"搜索/商品/关键词"占位符的输入框，回退到首个可见输入框。
- 新增弹窗内元素点击辅助逻辑：按可见文本点击"添加商品"入口。
- 补齐商品弹窗后续操作：
  - 优先选择包含关键词且包含"商品ID"的商品行；
  - 回退选择第一条可用商品；
  - 找到并点击"保存/确定/完成"按钮提交选择。
- 增加日志输出，便于定位商品添加流程状态。

## 兼容性
- 默认不设置 `XHS_PRODUCT_KEYWORD` 时，发布行为与现有逻辑保持一致。
- 仅在显式配置关键词时触发商品绑定流程。

## 验证
- 在真实发布页面（有头模式）验证：
  - 能打开"选择商品"弹窗并按关键词搜索；
  - 能自动勾选命中商品并点击保存；
  - 返回发布页后可见商品已绑定。
