### PR TITLE
feat: 添加 Linux ARM64 Release 支持

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,10 @@ jobs:
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-mcp-linux-amd64 .
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o xiaohongshu-login-linux-amd64 ./cmd/login
 
+        # Linux ARM64
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o xiaohongshu-mcp-linux-arm64 .
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o xiaohongshu-login-linux-arm64 ./cmd/login
+
     - name: Package binaries
       run: |
         # 创建压缩包
@@ -87,6 +91,9 @@ jobs:
 
         # Linux x64
         tar czf xiaohongshu-mcp-linux-amd64.tar.gz xiaohongshu-mcp-linux-amd64 xiaohongshu-login-linux-amd64
+
+        # Linux ARM64
+        tar czf xiaohongshu-mcp-linux-arm64.tar.gz xiaohongshu-mcp-linux-arm64 xiaohongshu-login-linux-arm64
 
     - name: Clean up old releases
       run: |
@@ -121,6 +128,7 @@ jobs:
           - **macOS Intel**: `xiaohongshu-mcp-darwin-amd64.tar.gz`
           - **Windows x64**: `xiaohongshu-mcp-windows-amd64.zip`
           - **Linux x64**: `xiaohongshu-mcp-linux-amd64.tar.gz`
+          - **Linux ARM64**: `xiaohongshu-mcp-linux-arm64.tar.gz`
 
           每个压缩包包含：
           - `xiaohongshu-mcp-*`: MCP 服务主程序
@@ -156,3 +164,4 @@ jobs:
           xiaohongshu-mcp-darwin-amd64.tar.gz
           xiaohongshu-mcp-windows-amd64.zip
           xiaohongshu-mcp-linux-amd64.tar.gz
+          xiaohongshu-mcp-linux-arm64.tar.gz

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -65,6 +65,10 @@ jobs:
         GOOS=linux GOARCH=amd64 go build -o xiaohongshu-mcp-linux-amd64 .
         GOOS=linux GOARCH=amd64 go build -o xiaohongshu-login-linux-amd64 ./cmd/login
 
+        # Linux ARM64
+        GOOS=linux GOARCH=arm64 go build -o xiaohongshu-mcp-linux-arm64 .
+        GOOS=linux GOARCH=arm64 go build -o xiaohongshu-login-linux-arm64 ./cmd/login
+
     - name: Generate changelog
       id: changelog
       run: |
@@ -111,12 +115,14 @@ jobs:
           - **macOS Intel**: `xiaohongshu-mcp-darwin-amd64`
           - **Windows x64**: `xiaohongshu-mcp-windows-amd64.exe`
           - **Linux x64**: `xiaohongshu-mcp-linux-amd64`
+          - **Linux ARM64**: `xiaohongshu-mcp-linux-arm64`
 
           **登录工具：**
           - **macOS Apple Silicon**: `xiaohongshu-login-darwin-arm64`
           - **macOS Intel**: `xiaohongshu-login-darwin-amd64`
           - **Windows x64**: `xiaohongshu-login-windows-amd64.exe`
           - **Linux x64**: `xiaohongshu-login-linux-amd64`
+          - **Linux ARM64**: `xiaohongshu-login-linux-arm64`
 
           ### 🔧 使用方法
 
@@ -147,7 +153,9 @@ jobs:
           xiaohongshu-mcp-darwin-amd64
           xiaohongshu-mcp-windows-amd64.exe
           xiaohongshu-mcp-linux-amd64
+          xiaohongshu-mcp-linux-arm64
           xiaohongshu-login-darwin-arm64
           xiaohongshu-login-darwin-amd64
           xiaohongshu-login-windows-amd64.exe
           xiaohongshu-login-linux-amd64
+          xiaohongshu-login-linux-arm64


### PR DESCRIPTION
## Summary
- 在 release.yml 和 tag-release.yml 中添加 Linux ARM64 构建支持
- 更新发布文件列表，新增 `xiaohongshu-mcp-linux-arm64.tar.gz`
- 更新下载说明文档

Closes #415

## Test plan
- [ ] PR 合入后检查 GitHub Actions 是否正常触发
- [ ] 确认 release 中包含 `xiaohongshu-mcp-linux-arm64.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)