### PR TITLE
fix: stabilize comment reply matching and cookie path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - 2026-02-16
+
+### Fixed
+
+#### 1) `reply_comment_in_feed` frequently failed with "未找到评论"
+
+- **Root cause**:
+  - Comment lookup relied on a narrow set of selectors (legacy DOM assumptions).
+  - Loop could terminate too early when `THE END` marker appeared, even before robust lookup had a chance.
+- **Fixes** (`xiaohongshu/comment_feed.go`):
+  - Lookup order changed: try `comment_id` / `user_id` matching first, then evaluate end-of-list signals.
+  - Added more selector variants for comment matching:
+    - `#comment-...`, `id*`, `data-comment-id`, `data-commentid`, `data-rid`
+  - Added XPath fallback for `user_id` profile-link ancestry matching.
+  - Added robust comment counting across multiple selector families.
+  - Refined stop logic to avoid premature break on transient bottom markers.
+  - Added reply button fallback strategy (class selector + text fallback for "回复").
+  - Reduced unproductive long waits and improved diagnostic logs.
+
+#### 2) Login success but daemon still reported "未登录" (cookie path drift)
+
+- **Root cause**:
+  - Cookie path default depended on current working directory (`cookies.json`),
+    so login binary and daemon could read/write different files.
+- **Fixes** (`cookies/cookies.go`):
+  - `COOKIES_PATH` now has highest priority.
+  - Backward-compatible fallback chain:
+    1. `COOKIES_PATH`
+    2. legacy `/tmp/cookies.json`
+    3. local `./cookies.json` (if exists)
+    4. stable default `~/.xiaohongshu-mcp/cookies.json`
+  - `SaveCookies()` now auto-creates parent directory when needed.
+
+### Validation
+
+- `go build ./...` passed.
+- End-to-end validation on target note:
+  - `get_feed_detail` returns target `comment_id` and `user_id`.
+  - `reply_comment_in_feed` returns success for existing top-level comment.
+
+### Notes
+
+- This patch focuses on reliability of comment reply discovery and cookie-path stability.
+- No intentional breaking API changes.

--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -3,6 +3,7 @@ package xiaohongshu
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -83,14 +84,14 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToken, commentID, userID, content string) error {
 	// 增加超时时间，因为需要滚动查找评论
 	// 注意：不使用 Context(ctx)，避免继承外部 context 的超时
-	page := f.page.Timeout(5 * time.Minute)
+	page := f.page.Timeout(3 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 	logrus.Infof("打开 feed 详情页进行回复: %s", url)
 
 	// 导航到详情页
 	page.MustNavigate(url)
 	page.MustWaitDOMStable()
-	time.Sleep(1 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 
 	// 检测页面是否可访问
 	if err := checkPageAccessible(page); err != nil {
@@ -98,7 +99,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	}
 
 	// 等待评论容器加载
-	time.Sleep(2 * time.Second)
+	time.Sleep(1800 * time.Millisecond)
 
 	// 使用 Go 实现的查找逻辑
 	commentEl, err := findCommentElement(page, commentID, userID)
@@ -109,12 +110,12 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	// 滚动到评论位置
 	logrus.Info("滚动到评论位置...")
 	commentEl.MustScrollIntoView()
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	logrus.Info("准备点击回复按钮")
 
-	// 查找并点击回复按钮
-	replyBtn, err := commentEl.Element(".right .interactions .reply")
+	// 查找并点击回复按钮（增强兼容）
+	replyBtn, err := findReplyButton(commentEl)
 	if err != nil {
 		return fmt.Errorf("无法找到回复按钮: %w", err)
 	}
@@ -123,7 +124,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 		return fmt.Errorf("点击回复按钮失败: %w", err)
 	}
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(600 * time.Millisecond)
 
 	// 查找回复输入框
 	inputEl, err := page.Element("div.input-box div.content-edit p.content-input")
@@ -136,7 +137,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 		return fmt.Errorf("输入回复内容失败: %w", err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(350 * time.Millisecond)
 
 	// 查找并点击提交按钮
 	submitBtn, err := page.Element("div.bottom button.submit")
@@ -148,17 +149,17 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 		return fmt.Errorf("点击提交按钮失败: %w", err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(1200 * time.Millisecond)
 	logrus.Infof("回复评论成功")
 	return nil
 }
 
-// findCommentElement 查找指定评论元素（参考 feed_detail.go 的滚动逻辑）
+// findCommentElement 查找指定评论元素（兼容更多 DOM）
 func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element, error) {
 	logrus.Infof("开始查找评论 - commentID: %s, userID: %s", commentID, userID)
 
-	const maxAttempts = 100
-	const scrollInterval = 800 * time.Millisecond
+	const maxAttempts = 35
+	const scrollInterval = 650 * time.Millisecond
 
 	// 先滚动到评论区
 	scrollToCommentsArea(page)
@@ -166,24 +167,48 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 
 	var lastCommentCount = 0
 	stagnantChecks := 0
+	zeroCountChecks := 0
 
 	logrus.Infof("开始循环查找，最大尝试次数: %d", maxAttempts)
 
+	endSeenCount := 0
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		logrus.Infof("=== 查找尝试 %d/%d ===", attempt+1, maxAttempts)
 
-		// === 1. 检查是否到达底部 ===
-		if checkEndContainer(page) {
-			logrus.Info("已到达评论底部，未找到目标评论")
-			break
+		// 优先精准查找，避免被“THE END”过早短路
+		if commentID != "" {
+			if el := findByCommentID(page, commentID); el != nil {
+				logrus.Infof("✓ 通过 commentID 找到评论: %s", commentID)
+				return el, nil
+			}
+		}
+		if userID != "" {
+			if el := findByUserID(page, userID); el != nil {
+				logrus.Infof("✓ 通过 userID 找到评论: %s", userID)
+				return el, nil
+			}
 		}
 
-		// === 2. 获取当前评论数量 ===
-		currentCount := getCommentCount(page)
-		logrus.Infof("当前评论数: %d", currentCount)
-		
+		// === 1. 检查是否到达底部（仅作为信号，不立即退出）===
+		if checkEndContainer(page) {
+			endSeenCount++
+			logrus.Infof("检测到评论底部标记（THE END）次数: %d", endSeenCount)
+		}
+
+		if checkNoCommentsArea(page) {
+			return nil, fmt.Errorf("评论区显示为空（这是一片荒地），无法回复指定评论")
+		}
+
+		// === 2. 获取当前评论数量（更鲁棒）===
+		currentCount := getCommentCountRobust(page)
+		logrus.Infof("当前评论数(robust): %d", currentCount)
+
+		if currentCount == 0 {
+			zeroCountChecks++
+		}
+
 		if currentCount != lastCommentCount {
-			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
+			logrus.Infof("✓ 评论数变化: %d -> %d", lastCommentCount, currentCount)
 			lastCommentCount = currentCount
 			stagnantChecks = 0
 		} else {
@@ -193,81 +218,137 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 			}
 		}
 
-		// === 3. 停滞检测 ===
-		if stagnantChecks >= 10 {
-			logrus.Info("评论数量停滞超过10次，可能已加载完所有评论")
-			break
+		// === 3. 快速失败：一直是0，说明会话/DOM异常 ===
+		if zeroCountChecks >= 8 {
+			return nil, fmt.Errorf("评论元素持续为0，疑似web登录态失效或DOM结构变更")
 		}
 
-		// === 4. 先滚动到最后一个评论（触发懒加载）===
-		if currentCount > 0 {
-			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-			
-			// 使用 Go 获取所有评论元素
-			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
-			if err == nil && len(elements) > 0 {
-				// 滚动到最后一个评论
-				lastComment := elements[len(elements)-1]
-				err := lastComment.ScrollIntoView()
-				if err != nil {
-					logrus.Warnf("滚动到最后一个评论失败: %v", err)
-				}
-			} else {
-				logrus.Warnf("未找到评论元素: %v", err)
+		if stagnantChecks >= 12 {
+			if endSeenCount >= 3 {
+				logrus.Info("评论数量停滞且多次到底，停止继续滚动")
+				break
 			}
-			time.Sleep(300 * time.Millisecond)
+			logrus.Info("评论数量停滞但未稳定到底，继续尝试")
+			stagnantChecks = 8
 		}
 
-		// === 5. 继续向下滚动 ===
-		logrus.Infof("继续向下滚动...")
-		_, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`)
+		// === 4. 向下滚动并重试 ===
+		_, err := page.Eval(`() => { window.scrollBy(0, Math.max(420, window.innerHeight * 0.8)); return true; }`)
 		if err != nil {
 			logrus.Warnf("滚动失败: %v", err)
 		}
-		time.Sleep(500 * time.Millisecond)
 
-		// === 6. 滚动后立即查找（边滚动边查找）===
-		// 优先通过 commentID 查找（使用 Timeout 避免长时间等待）
-		if commentID != "" {
-			selector := fmt.Sprintf("#comment-%s", commentID)
-			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-			
-			// 使用 Timeout 避免长时间等待
-			el, err := page.Timeout(2 * time.Second).Element(selector)
-			if err == nil && el != nil {
-				logrus.Infof("✓ 通过 commentID 找到评论: %s (尝试 %d 次)", commentID, attempt+1)
-				return el, nil
-			}
-			logrus.Infof("未找到 commentID (2秒超时)")
-		}
-
-		// 通过 userID 查找
-		if userID != "" {
-			logrus.Infof("尝试通过 userID 查找: %s", userID)
-			
-			// 使用 Timeout 避免长时间等待
-			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
-			if err == nil && len(elements) > 0 {
-				logrus.Infof("找到 %d 个评论元素", len(elements))
-				for i, el := range elements {
-					// 快速检查，不等待
-					userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID))
-					if err == nil && userEl != nil {
-						logrus.Infof("✓ 通过 userID 在第 %d 个元素中找到评论: %s (尝试 %d 次)", i+1, userID, attempt+1)
-						return el, nil
-					}
-				}
-				logrus.Infof("在 %d 个元素中未找到匹配的 userID", len(elements))
-			} else {
-				logrus.Infof("获取评论元素失败或超时: %v", err)
-			}
-		}
-		
-		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
-
-		// === 7. 等待内容加载 ===
 		time.Sleep(scrollInterval)
 	}
 
 	return nil, fmt.Errorf("未找到评论 (commentID: %s, userID: %s), 尝试次数: %d", commentID, userID, maxAttempts)
+}
+
+func findByCommentID(page *rod.Page, commentID string) *rod.Element {
+	selectors := []string{
+		fmt.Sprintf("#comment-%s", commentID),
+		fmt.Sprintf(`[id="comment-%s"]`, commentID),
+		fmt.Sprintf(`[id*="%s"]`, commentID),
+		fmt.Sprintf(`[data-comment-id="%s"]`, commentID),
+		fmt.Sprintf(`[data-commentid="%s"]`, commentID),
+		fmt.Sprintf(`[data-rid="%s"]`, commentID),
+	}
+
+	for _, sel := range selectors {
+		el, err := page.Timeout(1200 * time.Millisecond).Element(sel)
+		if err == nil && el != nil {
+			return el
+		}
+	}
+
+	// 兜底：遍历常见评论节点，检查 id/data-* 是否包含 commentID
+	elements, err := page.Timeout(1500 * time.Millisecond).Elements(".parent-comment, .comment-item, .comment, [class*='comment']")
+	if err != nil || len(elements) == 0 {
+		return nil
+	}
+	for _, el := range elements {
+		idAttr, _ := el.Attribute("id")
+		if idAttr != nil && strings.Contains(*idAttr, commentID) {
+			return el
+		}
+		for _, k := range []string{"data-comment-id", "data-commentid", "data-id"} {
+			v, _ := el.Attribute(k)
+			if v != nil && strings.Contains(*v, commentID) {
+				return el
+			}
+		}
+	}
+	return nil
+}
+
+func findByUserID(page *rod.Page, userID string) *rod.Element {
+	// 优先 XPath：匹配个人主页链接再回溯到评论容器
+	xpath := fmt.Sprintf("//a[contains(@href,'/user/profile/%s')]/ancestor::*[contains(@class,'comment')][1]", userID)
+	if el, err := page.Timeout(1200 * time.Millisecond).ElementX(xpath); err == nil && el != nil {
+		return el
+	}
+
+	elements, err := page.Timeout(1800 * time.Millisecond).Elements(".parent-comment, .comment-item, .comment, [class*='comment']")
+	if err != nil || len(elements) == 0 {
+		return nil
+	}
+
+	for _, el := range elements {
+		for _, sel := range []string{
+			fmt.Sprintf(`[data-user-id="%s"]`, userID),
+			fmt.Sprintf(`[data-userid="%s"]`, userID),
+			fmt.Sprintf(`a[href*="/user/profile/%s"]`, userID),
+		} {
+			u, err := el.Timeout(350 * time.Millisecond).Element(sel)
+			if err == nil && u != nil {
+				return el
+			}
+		}
+	}
+	return nil
+}
+
+func getCommentCountRobust(page *rod.Page) int {
+	selectors := []string{
+		".parent-comment",
+		".comment-item",
+		".comments-container .comment",
+	}
+	best := 0
+	for _, sel := range selectors {
+		elems, err := page.Timeout(1200 * time.Millisecond).Elements(sel)
+		if err == nil {
+			if n := len(elems); n > best {
+				best = n
+			}
+		}
+	}
+	return best
+}
+
+func findReplyButton(commentEl *rod.Element) (*rod.Element, error) {
+	// 常见结构优先
+	for _, sel := range []string{
+		".right .interactions .reply",
+		".interactions .reply",
+		"[class*='reply']",
+	} {
+		el, err := commentEl.Timeout(1200 * time.Millisecond).Element(sel)
+		if err == nil && el != nil {
+			return el, nil
+		}
+	}
+
+	// 文案兜底（找包含“回复”的可点击元素）
+	elements, err := commentEl.Timeout(1500 * time.Millisecond).Elements("button, span, div")
+	if err != nil {
+		return nil, err
+	}
+	for _, el := range elements {
+		t, err := el.Timeout(200 * time.Millisecond).Text()
+		if err == nil && strings.Contains(strings.TrimSpace(t), "回复") {
+			return el, nil
+		}
+	}
+	return nil, fmt.Errorf("未找到包含“回复”文案的按钮")
 }


### PR DESCRIPTION
## Summary / 摘要
This PR improves reliability of comment reply automation and fixes cookie-path drift that can cause false login mismatch.
本 PR 主要提升评论回复自动化的稳定性，并修复 cookies 路径漂移导致“看似已登录但实际未登录”的问题。

## What changed / 变更内容

### 1) `reply_comment_in_feed` robustness (`xiaohongshu/comment_feed.go`)
- Prevent early abort caused by transient end-marker (`THE END`) checks.
避免因临时出现的底部标记（`THE END`）而过早退出。
- Prioritize exact lookup by `comment_id` / `user_id` before end-of-list heuristics.
优先按 `comment_id` / `user_id` 精确查找，再做列表结束判断。
- Add broader selector compatibility for comment lookup:
扩展评论查找选择器兼容范围：
- `#comment-*`, `id*`, `data-comment-id`, `data-commentid`, `data-rid`
- Add XPath fallback for `user_id` profile-link ancestry matching.
新增基于 `user_id` 的 XPath 回溯兜底匹配。
- Improve reply-button compatibility (`class` + text fallback for `回复`).
增强“回复按钮”定位兼容（class + 文本“回复”兜底）。
- Improve stop conditions and diagnostics to avoid long blind retries.
优化停止条件与日志诊断，避免长时间盲重试。

### 2) Cookie-path stability (`cookies/cookies.go`)
- Fix cwd-dependent cookie path behavior by introducing stable fallback order:
修复 cookies 路径依赖 cwd 的问题，改为稳定优先级：
1. `COOKIES_PATH` env
2. legacy `/tmp/cookies.json`
3. local `./cookies.json` (if exists)
4. stable default `~/.xiaohongshu-mcp/cookies.json`
- `SaveCookies()` now ensures parent directory exists before writing.
`SaveCookies()` 写入前自动创建父目录。

### 3) Changelog
- Added `CHANGELOG.md` entry for this patch set.
新增 `CHANGELOG.md` 记录本次修复内容。

## Why / 背景与动机
Two recurring operational failures were observed:
实际使用中反复出现两个问题：
1. Reply action failed with `未找到评论` despite target comment existing.
目标评论存在，但回复接口频繁报 `未找到评论`。
2. Login binary reported success but daemon still showed `未登录` due to reading different cookie files.
登录程序提示成功，但守护进程仍显示未登录（读取了不同 cookies 文件）。

## Validation / 验证
- `go build ./...` ✅
- Runtime validation against real note/comment:
在真实笔记评论上验证：
- `get_feed_detail` returned target `comment_id`/`user_id` ✅
- `reply_comment_in_feed` returned success in patched build ✅

## Notes / 说明
- No intentional breaking API changes.
无破坏性 API 变更。
- This patch is backward-compatible with existing cookie files.
与现有 cookies 文件兼容。