### PR TITLE
feat: add notification query tools (mentions, likes, connections)

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -631,6 +631,90 @@ func (s *AppServer) handlePostComment(ctx context.Context, args map[string]inter
 	}
 }
 
+// handleGetMentions 处理获取评论和@通知
+func (s *AppServer) handleGetMentions(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取评论和@通知")
+
+	num := 20
+	if v, ok := args["num"].(float64); ok && v > 0 {
+		num = int(v)
+	}
+	cursor, _ := args["cursor"].(string)
+
+	result, err := s.xiaohongshuService.GetMentions(ctx, num, cursor)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取评论和@通知失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: string(jsonData)}}}
+}
+
+// handleGetLikes 处理获取赞和收藏通知
+func (s *AppServer) handleGetLikes(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取赞和收藏通知")
+
+	num := 20
+	if v, ok := args["num"].(float64); ok && v > 0 {
+		num = int(v)
+	}
+	cursor, _ := args["cursor"].(string)
+
+	result, err := s.xiaohongshuService.GetLikes(ctx, num, cursor)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取赞和收藏通知失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: string(jsonData)}}}
+}
+
+// handleGetConnections 处理获取新增关注通知
+func (s *AppServer) handleGetConnections(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取新增关注通知")
+
+	num := 20
+	if v, ok := args["num"].(float64); ok && v > 0 {
+		num = int(v)
+	}
+	cursor, _ := args["cursor"].(string)
+
+	result, err := s.xiaohongshuService.GetConnections(ctx, num, cursor)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取新增关注通知失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: string(jsonData)}}}
+}
+
 // handleReplyComment 处理回复评论
 func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 回复评论")

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -631,6 +631,32 @@ func (s *AppServer) handlePostComment(ctx context.Context, args map[string]inter
 	}
 }
 
+// handleLikeComment 处理评论点赞
+func (s *AppServer) handleLikeComment(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 评论点赞")
+
+	feedID, _ := args["feed_id"].(string)
+	xsecToken, _ := args["xsec_token"].(string)
+	commentID, _ := args["comment_id"].(string)
+
+	if feedID == "" || xsecToken == "" || commentID == "" {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "评论点赞失败: 缺少feed_id、xsec_token或comment_id参数"}},
+			IsError: true,
+		}
+	}
+
+	err := s.xiaohongshuService.LikeComment(ctx, feedID, xsecToken, commentID)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "评论点赞失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("评论 %s 点赞成功", commentID)}}}
+}
+
 // handleNotification 通用通知处理函数，减少重复代码
 func (s *AppServer) handleNotification(ctx context.Context, args map[string]interface{}, label string, fetcher func(context.Context, int, string) (*NotificationsResponse, error)) *MCPToolResult {
 	logrus.Infof("MCP: 获取%s通知", label)

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -94,6 +94,13 @@ type NotificationArgs struct {
 	Cursor string `json:"cursor,omitempty" jsonschema:"分页游标，从上一次返回的cursor获取，首次查询不填"`
 }
 
+// LikeCommentArgs 评论点赞参数
+type LikeCommentArgs struct {
+	FeedID    string `json:"feed_id" jsonschema:"笔记ID"`
+	XsecToken string `json:"xsec_token" jsonschema:"笔记的xsec_token"`
+	CommentID string `json:"comment_id" jsonschema:"评论ID"`
+}
+
 // FavoriteFeedArgs 收藏参数
 type FavoriteFeedArgs struct {
 	FeedID     string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
@@ -499,7 +506,27 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 16)
+	// 工具 17: 评论点赞
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "like_comment",
+			Description: "点赞指定评论。需要feed_id、xsec_token和comment_id",
+			Annotations: &mcp.ToolAnnotations{
+				Title: "Like Comment",
+			},
+		},
+		withPanicRecovery("like_comment", func(ctx context.Context, req *mcp.CallToolRequest, args LikeCommentArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"feed_id":    args.FeedID,
+				"xsec_token": args.XsecToken,
+				"comment_id": args.CommentID,
+			}
+			result := appServer.handleLikeComment(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 17)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -88,6 +88,12 @@ type LikeFeedArgs struct {
 	Unlike    bool   `json:"unlike,omitempty" jsonschema:"是否取消点赞，true为取消点赞，false或未设置则为点赞"`
 }
 
+// NotificationArgs 通知查询参数
+type NotificationArgs struct {
+	Num    int    `json:"num,omitempty" jsonschema:"返回数量，默认20"`
+	Cursor string `json:"cursor,omitempty" jsonschema:"分页游标，从上一次返回的cursor获取，首次查询不填"`
+}
+
 // FavoriteFeedArgs 收藏参数
 type FavoriteFeedArgs struct {
 	FeedID     string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
@@ -433,7 +439,67 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	// 工具 14: 获取评论和@通知
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_mentions",
+			Description: "获取评论和@通知列表，返回其他用户对你的评论、回复和@提及",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Mentions",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_mentions", func(ctx context.Context, req *mcp.CallToolRequest, args NotificationArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"num":    float64(args.Num),
+				"cursor": args.Cursor,
+			}
+			result := appServer.handleGetMentions(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 15: 获取赞和收藏通知
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_likes",
+			Description: "获取赞和收藏通知列表，返回其他用户对你笔记的点赞和收藏记录",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Likes",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_likes", func(ctx context.Context, req *mcp.CallToolRequest, args NotificationArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"num":    float64(args.Num),
+				"cursor": args.Cursor,
+			}
+			result := appServer.handleGetLikes(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 16: 获取新增关注通知
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_connections",
+			Description: "获取新增关注通知列表，返回新关注你的用户信息",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Connections",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_connections", func(ctx context.Context, req *mcp.CallToolRequest, args NotificationArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"num":    float64(args.Num),
+				"cursor": args.Cursor,
+			}
+			result := appServer.handleGetConnections(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 16)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/service.go
+++ b/service.go
@@ -544,6 +544,18 @@ type NotificationsResponse struct {
 	Count    int         `json:"count"`
 }
 
+// LikeComment 点赞指定评论
+func (s *XiaohongshuService) LikeComment(ctx context.Context, feedID, xsecToken, commentID string) error {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewLikeCommentAction(page)
+	return action.LikeComment(ctx, feedID, xsecToken, commentID)
+}
+
 // fetchNotifications 通用通知获取函数，减少重复代码
 func (s *XiaohongshuService) fetchNotifications(
 	ctx context.Context,

--- a/service.go
+++ b/service.go
@@ -544,8 +544,11 @@ type NotificationsResponse struct {
 	Count    int         `json:"count"`
 }
 
-// GetMentions 获取评论和@通知
-func (s *XiaohongshuService) GetMentions(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
+// fetchNotifications 通用通知获取函数，减少重复代码
+func (s *XiaohongshuService) fetchNotifications(
+	ctx context.Context,
+	fetcher func(*xiaohongshu.NotificationAction) (*NotificationsResponse, error),
+) (*NotificationsResponse, error) {
 	b := newBrowser()
 	defer b.Close()
 
@@ -553,64 +556,49 @@ func (s *XiaohongshuService) GetMentions(ctx context.Context, num int, cursor st
 	defer page.Close()
 
 	action := xiaohongshu.NewNotificationAction(page)
-	result, err := action.GetMentions(ctx, num, cursor)
-	if err != nil {
-		return nil, err
-	}
+	return fetcher(action)
+}
 
-	return &NotificationsResponse{
-		Type:     "mentions",
-		HasMore:  result.Data.HasMore,
-		Cursor:   result.Data.StrCursor,
-		Messages: result.Data.Messages,
-		Count:    len(result.Data.Messages),
-	}, nil
+// GetMentions 获取评论和@通知
+func (s *XiaohongshuService) GetMentions(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
+	return s.fetchNotifications(ctx, func(action *xiaohongshu.NotificationAction) (*NotificationsResponse, error) {
+		result, err := action.GetMentions(ctx, num, cursor)
+		if err != nil {
+			return nil, err
+		}
+		return &NotificationsResponse{
+			Type: "mentions", HasMore: result.Data.HasMore, Cursor: result.Data.StrCursor,
+			Messages: result.Data.Messages, Count: len(result.Data.Messages),
+		}, nil
+	})
 }
 
 // GetLikes 获取赞和收藏通知
 func (s *XiaohongshuService) GetLikes(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
-
-	action := xiaohongshu.NewNotificationAction(page)
-	result, err := action.GetLikes(ctx, num, cursor)
-	if err != nil {
-		return nil, err
-	}
-
-	return &NotificationsResponse{
-		Type:     "likes",
-		HasMore:  result.Data.HasMore,
-		Cursor:   result.Data.StrCursor,
-		Messages: result.Data.Messages,
-		Count:    len(result.Data.Messages),
-	}, nil
+	return s.fetchNotifications(ctx, func(action *xiaohongshu.NotificationAction) (*NotificationsResponse, error) {
+		result, err := action.GetLikes(ctx, num, cursor)
+		if err != nil {
+			return nil, err
+		}
+		return &NotificationsResponse{
+			Type: "likes", HasMore: result.Data.HasMore, Cursor: result.Data.StrCursor,
+			Messages: result.Data.Messages, Count: len(result.Data.Messages),
+		}, nil
+	})
 }
 
 // GetConnections 获取新增关注通知
 func (s *XiaohongshuService) GetConnections(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
-
-	action := xiaohongshu.NewNotificationAction(page)
-	result, err := action.GetConnections(ctx, num, cursor)
-	if err != nil {
-		return nil, err
-	}
-
-	return &NotificationsResponse{
-		Type:     "connections",
-		HasMore:  result.Data.HasMore,
-		Cursor:   result.Data.StrCursor,
-		Messages: result.Data.Messages,
-		Count:    len(result.Data.Messages),
-	}, nil
+	return s.fetchNotifications(ctx, func(action *xiaohongshu.NotificationAction) (*NotificationsResponse, error) {
+		result, err := action.GetConnections(ctx, num, cursor)
+		if err != nil {
+			return nil, err
+		}
+		return &NotificationsResponse{
+			Type: "connections", HasMore: result.Data.HasMore, Cursor: result.Data.StrCursor,
+			Messages: result.Data.Messages, Count: len(result.Data.Messages),
+		}, nil
+	})
 }
 
 func newBrowser() *headless_browser.Browser {

--- a/service.go
+++ b/service.go
@@ -535,6 +535,84 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 	}, nil
 }
 
+// NotificationsResponse 通知响应（通用）
+type NotificationsResponse struct {
+	Type     string      `json:"type"`
+	HasMore  bool        `json:"has_more"`
+	Cursor   string      `json:"cursor"`
+	Messages interface{} `json:"messages"`
+	Count    int         `json:"count"`
+}
+
+// GetMentions 获取评论和@通知
+func (s *XiaohongshuService) GetMentions(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewNotificationAction(page)
+	result, err := action.GetMentions(ctx, num, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NotificationsResponse{
+		Type:     "mentions",
+		HasMore:  result.Data.HasMore,
+		Cursor:   result.Data.StrCursor,
+		Messages: result.Data.Messages,
+		Count:    len(result.Data.Messages),
+	}, nil
+}
+
+// GetLikes 获取赞和收藏通知
+func (s *XiaohongshuService) GetLikes(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewNotificationAction(page)
+	result, err := action.GetLikes(ctx, num, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NotificationsResponse{
+		Type:     "likes",
+		HasMore:  result.Data.HasMore,
+		Cursor:   result.Data.StrCursor,
+		Messages: result.Data.Messages,
+		Count:    len(result.Data.Messages),
+	}, nil
+}
+
+// GetConnections 获取新增关注通知
+func (s *XiaohongshuService) GetConnections(ctx context.Context, num int, cursor string) (*NotificationsResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewNotificationAction(page)
+	result, err := action.GetConnections(ctx, num, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NotificationsResponse{
+		Type:     "connections",
+		HasMore:  result.Data.HasMore,
+		Cursor:   result.Data.StrCursor,
+		Messages: result.Data.Messages,
+		Count:    len(result.Data.Messages),
+	}, nil
+}
+
 func newBrowser() *headless_browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(), browser.WithBinPath(configs.GetBinPath()))
 }

--- a/xiaohongshu/like_comment.go
+++ b/xiaohongshu/like_comment.go
@@ -1,0 +1,201 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/sirupsen/logrus"
+)
+
+// LikeCommentAction 评论点赞动作
+type LikeCommentAction struct {
+	page *rod.Page
+}
+
+func NewLikeCommentAction(page *rod.Page) *LikeCommentAction {
+	return &LikeCommentAction{page: page}
+}
+
+// LikeComment 点赞指定评论
+func (a *LikeCommentAction) LikeComment(ctx context.Context, feedID, xsecToken, commentID string) error {
+	page := a.page.Timeout(2 * time.Minute)
+	url := makeFeedDetailURL(feedID, xsecToken)
+	logrus.Infof("打开帖子页面进行评论点赞: %s", url)
+
+	page.MustNavigate(url)
+	page.MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+
+	if err := checkPageAccessible(page); err != nil {
+		return err
+	}
+
+	// 等待评论加载到DOM（等待.parent-comment出现）
+	loaded := false
+	for i := 0; i < 15; i++ {
+		count, err := page.Eval(`() => document.querySelectorAll('.parent-comment').length`)
+		if err == nil && count != nil && count.Value.Int() > 0 {
+			logrus.Infof("评论已加载: %d 条 (等待 %d 秒)", count.Value.Int(), i)
+			loaded = true
+			break
+		}
+		// 触发懒加载
+		page.MustEval(`() => {
+			const c = document.querySelector('.comments-container');
+			if (c) c.scrollIntoView();
+			let t = document.querySelector('.note-scroller') || document.documentElement;
+			t.dispatchEvent(new WheelEvent('wheel', {deltaY: 300, deltaMode: 0, bubbles: true, cancelable: true, view: window}));
+			window.scrollBy(0, 300);
+		}`)
+		time.Sleep(1 * time.Second)
+	}
+	if !loaded {
+		return fmt.Errorf("评论未加载，无法点赞")
+	}
+
+	// 用JS在__INITIAL_STATE__中找到评论的索引，然后点击对应的like按钮
+	js := fmt.Sprintf(`() => {
+		const state = window.__INITIAL_STATE__;
+		if (!state || !state.note) return JSON.stringify({error: "no state"});
+		const inner = state.note._rawValue || state.note;
+		const dm = inner.noteDetailMap;
+		if (!dm) return JSON.stringify({error: "no noteDetailMap"});
+
+		let comments = null;
+		for (const key of Object.keys(dm)) {
+			if (dm[key] && dm[key].comments && dm[key].comments.list) {
+				comments = dm[key].comments.list;
+				break;
+			}
+		}
+		if (!comments) return JSON.stringify({error: "no comments list"});
+
+		// 查找目标评论（主评论或子评论）
+		const targetId = "%s";
+		for (let i = 0; i < comments.length; i++) {
+			if (comments[i].id === targetId) {
+				return JSON.stringify({found: true, type: "parent", index: i, isLiked: comments[i].liked || false});
+			}
+			const subs = comments[i].subComments || [];
+			for (let j = 0; j < subs.length; j++) {
+				if (subs[j].id === targetId) {
+					return JSON.stringify({found: true, type: "sub", parentIndex: i, subIndex: j, isLiked: subs[j].liked || false});
+				}
+			}
+		}
+		return JSON.stringify({error: "comment not found in state", totalComments: comments.length, ids: comments.map(c => c.id)});
+	}`, commentID)
+
+	result, err := page.Eval(js)
+	if err != nil {
+		return fmt.Errorf("查找评论失败: %w", err)
+	}
+
+	var findResult struct {
+		Found       bool     `json:"found"`
+		Error       string   `json:"error"`
+		Type        string   `json:"type"`
+		Index       int      `json:"index"`
+		ParentIndex int      `json:"parentIndex"`
+		SubIndex    int      `json:"subIndex"`
+		IsLiked     bool     `json:"isLiked"`
+		IDs         []string `json:"ids"`
+	}
+	json.Unmarshal([]byte(result.Value.String()), &findResult)
+
+	if findResult.Error != "" {
+		return fmt.Errorf("评论未找到: %s (已有评论IDs: %v)", findResult.Error, findResult.IDs)
+	}
+
+	if findResult.IsLiked {
+		logrus.Infof("评论 %s 已经点赞过了", commentID)
+		return nil
+	}
+
+	// 根据类型找到对应的DOM元素并点击
+	var likeBtn *rod.Element
+	if findResult.Type == "parent" {
+		// 主评论：找第N个.parent-comment的.like-wrapper
+		elements, err := page.Elements(".parent-comment")
+		if err != nil || findResult.Index >= len(elements) {
+			return fmt.Errorf("找不到第 %d 个评论元素", findResult.Index)
+		}
+		commentEl := elements[findResult.Index]
+		commentEl.MustScrollIntoView()
+		time.Sleep(300 * time.Millisecond)
+
+		// 主评论的like-wrapper是第一个（子评论的在后面）
+		likeBtn, err = commentEl.Element(".comment-inner .like-wrapper")
+		if err != nil {
+			// fallback: 找第一个like-wrapper
+			likeBtn, err = commentEl.Element(".like-wrapper")
+			if err != nil {
+				return fmt.Errorf("找不到评论的点赞按钮: %w", err)
+			}
+		}
+	} else {
+		// 子评论：找第parentIndex个.parent-comment下的第subIndex个子评论的like-wrapper
+		elements, err := page.Elements(".parent-comment")
+		if err != nil || findResult.ParentIndex >= len(elements) {
+			return fmt.Errorf("找不到第 %d 个评论元素", findResult.ParentIndex)
+		}
+		parentEl := elements[findResult.ParentIndex]
+		parentEl.MustScrollIntoView()
+		time.Sleep(300 * time.Millisecond)
+
+		// 子评论在.reply-container里
+		subComments, err := parentEl.Elements(".reply-container .comment-item-sub, .reply-container .sub-comment")
+		if err != nil || findResult.SubIndex >= len(subComments) {
+			return fmt.Errorf("找不到第 %d 个子评论元素", findResult.SubIndex)
+		}
+		subEl := subComments[findResult.SubIndex]
+		subEl.MustScrollIntoView()
+		time.Sleep(300 * time.Millisecond)
+
+		likeBtn, err = subEl.Element(".like-wrapper")
+		if err != nil {
+			return fmt.Errorf("找不到子评论的点赞按钮: %w", err)
+		}
+	}
+
+	// 检查是否已点赞（DOM层面）
+	cls, _ := likeBtn.Attribute("class")
+	if cls != nil && strings.Contains(*cls, "like-active") {
+		logrus.Infof("评论 %s 已经点赞过了（DOM确认）", commentID)
+		return nil
+	}
+
+	// 点击点赞
+	if err := likeBtn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("点击点赞按钮失败: %w", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	// 验证点赞是否成功
+	cls, _ = likeBtn.Attribute("class")
+	if cls != nil && strings.Contains(*cls, "like-active") {
+		logrus.Infof("评论 %s 点赞成功（已验证）", commentID)
+		return nil
+	}
+
+	// 第一次没成功，再点一次
+	logrus.Warnf("评论 %s 点赞状态未变化，重试一次", commentID)
+	if err := likeBtn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("重试点击点赞按钮失败: %w", err)
+	}
+	time.Sleep(2 * time.Second)
+
+	cls, _ = likeBtn.Attribute("class")
+	if cls != nil && strings.Contains(*cls, "like-active") {
+		logrus.Infof("评论 %s 第二次点击点赞成功", commentID)
+		return nil
+	}
+
+	return fmt.Errorf("评论 %s 点赞可能未成功，状态未变化", commentID)
+}

--- a/xiaohongshu/notifications.go
+++ b/xiaohongshu/notifications.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -22,8 +24,15 @@ func NewNotificationAction(page *rod.Page) *NotificationAction {
 	return &NotificationAction{page: pp}
 }
 
+// apiPathPattern validates that the path only contains expected characters
+var apiPathPattern = regexp.MustCompile(`^/api/sns/web/v\d+/you/\w+\?[\w&=%]+$`)
+
 // signedFetch 通过浏览器JS上下文发起带签名的API请求
 func (n *NotificationAction) signedFetch(ctx context.Context, apiPath string) (string, error) {
+	if !apiPathPattern.MatchString(apiPath) {
+		return "", fmt.Errorf("invalid API path format: %s", apiPath)
+	}
+
 	page := n.page.Context(ctx)
 
 	js := fmt.Sprintf(`() => {
@@ -42,6 +51,16 @@ func (n *NotificationAction) signedFetch(ctx context.Context, apiPath string) (s
 					credentials: "include",
 					headers: headers
 				});
+				if (!resp.ok) {
+					const errorText = await resp.text();
+					resolve(JSON.stringify({
+						"error": "http_error",
+						"status": resp.status,
+						"statusText": resp.statusText,
+						"body": errorText
+					}));
+					return;
+				}
 				const text = await resp.text();
 				resolve(text);
 			} catch(e) {
@@ -54,7 +73,34 @@ func (n *NotificationAction) signedFetch(ctx context.Context, apiPath string) (s
 	if err != nil {
 		return "", fmt.Errorf("eval failed: %w", err)
 	}
-	return result.Value.String(), nil
+
+	raw := result.Value.String()
+
+	// Check for JS-level errors (fetch failure or HTTP error)
+	var jsErr struct {
+		Error      string `json:"error"`
+		Status     int    `json:"status"`
+		StatusText string `json:"statusText"`
+		Body       string `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(raw), &jsErr); err == nil && jsErr.Error != "" {
+		if jsErr.Status > 0 {
+			return "", fmt.Errorf("HTTP %d %s: %s", jsErr.Status, jsErr.StatusText, jsErr.Body[:min(len(jsErr.Body), 200)])
+		}
+		return "", fmt.Errorf("signedFetch JS error: %s", jsErr.Error)
+	}
+
+	return raw, nil
+}
+
+// buildNotificationPath 构建通知API路径，正确编码cursor参数
+func buildNotificationPath(endpoint string, num int, cursor string) string {
+	params := url.Values{}
+	params.Set("num", fmt.Sprintf("%d", num))
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+	return endpoint + "?" + params.Encode()
 }
 
 // NotificationResponse API通用响应
@@ -68,53 +114,53 @@ type NotificationResponse struct {
 type MentionsResponse struct {
 	NotificationResponse
 	Data struct {
-		HasMore   bool              `json:"has_more"`
-		Cursor    int64             `json:"cursor"`
-		StrCursor string            `json:"strCursor"`
-		Messages  []MentionMessage  `json:"message_list"`
+		HasMore   bool             `json:"has_more"`
+		Cursor    int64            `json:"cursor"`
+		StrCursor string           `json:"strCursor"`
+		Messages  []MentionMessage `json:"message_list"`
 	} `json:"data"`
 }
 
 type MentionMessage struct {
-	ID        string          `json:"id"`
-	Type      string          `json:"type"`
-	Time      int64           `json:"time"`
-	UserInfo  NotifUserInfo   `json:"user_info"`
-	ItemInfo  *NotifItemInfo  `json:"item_info,omitempty"`
-	SubType   string          `json:"sub_type,omitempty"`
-	Content   string          `json:"content,omitempty"`
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Time     int64          `json:"time"`
+	UserInfo NotifUserInfo  `json:"user_info"`
+	ItemInfo *NotifItemInfo `json:"item_info,omitempty"`
+	SubType  string         `json:"sub_type,omitempty"`
+	Content  string         `json:"content,omitempty"`
 }
 
 // LikesResponse 赞和收藏通知响应
 type LikesResponse struct {
 	NotificationResponse
 	Data struct {
-		HasMore   bool            `json:"has_more"`
-		Cursor    int64           `json:"cursor"`
-		StrCursor string          `json:"strCursor"`
-		Messages  []LikeMessage   `json:"message_list"`
+		HasMore   bool          `json:"has_more"`
+		Cursor    int64         `json:"cursor"`
+		StrCursor string        `json:"strCursor"`
+		Messages  []LikeMessage `json:"message_list"`
 	} `json:"data"`
 }
 
 type LikeMessage struct {
-	ID        string          `json:"id"`
-	Type      string          `json:"type"`
-	Time      int64           `json:"time"`
-	Score     int64           `json:"score"`
-	TrackType string          `json:"track_type"`
-	Title     string          `json:"title"`
-	UserInfo  NotifUserInfo   `json:"user_info"`
-	ItemInfo  *NotifItemInfo  `json:"item_info,omitempty"`
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Time      int64          `json:"time"`
+	Score     int64          `json:"score"`
+	TrackType string         `json:"track_type"`
+	Title     string         `json:"title"`
+	UserInfo  NotifUserInfo  `json:"user_info"`
+	ItemInfo  *NotifItemInfo `json:"item_info,omitempty"`
 }
 
 // ConnectionsResponse 新增关注通知响应
 type ConnectionsResponse struct {
 	NotificationResponse
 	Data struct {
-		HasMore   bool                  `json:"has_more"`
-		Cursor    int64                 `json:"cursor"`
-		StrCursor string                `json:"strCursor"`
-		Messages  []ConnectionMessage   `json:"message_list"`
+		HasMore   bool                `json:"has_more"`
+		Cursor    int64               `json:"cursor"`
+		StrCursor string              `json:"strCursor"`
+		Messages  []ConnectionMessage `json:"message_list"`
 	} `json:"data"`
 }
 
@@ -138,15 +184,23 @@ type NotifItemInfo struct {
 	Link    string `json:"link,omitempty"`
 }
 
+// checkAPIResponse 检查API响应是否成功，code=-1视为空数据
+func checkAPIResponse(code int, success bool, msg string) error {
+	if !success && code != 0 {
+		if code == -1 {
+			return nil // code=-1 means no data, not an error
+		}
+		return fmt.Errorf("API error: code=%d msg=%s", code, msg)
+	}
+	return nil
+}
+
 // GetMentions 获取评论和@通知
 func (n *NotificationAction) GetMentions(ctx context.Context, num int, cursor string) (*MentionsResponse, error) {
 	if num <= 0 {
 		num = 20
 	}
-	path := fmt.Sprintf("/api/sns/web/v1/you/mentions?num=%d", num)
-	if cursor != "" {
-		path += "&cursor=" + cursor
-	}
+	path := buildNotificationPath("/api/sns/web/v1/you/mentions", num, cursor)
 
 	raw, err := n.signedFetch(ctx, path)
 	if err != nil {
@@ -157,11 +211,8 @@ func (n *NotificationAction) GetMentions(ctx context.Context, num int, cursor st
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal mentions failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
 	}
-	if !resp.Success && resp.Code != 0 {
-		if resp.Code == -1 {
-			return &resp, nil
-		}
-		return nil, fmt.Errorf("mentions API error: code=%d msg=%s", resp.Code, resp.Msg)
+	if err := checkAPIResponse(resp.Code, resp.Success, resp.Msg); err != nil {
+		return nil, fmt.Errorf("mentions %w", err)
 	}
 	return &resp, nil
 }
@@ -171,10 +222,7 @@ func (n *NotificationAction) GetLikes(ctx context.Context, num int, cursor strin
 	if num <= 0 {
 		num = 20
 	}
-	path := fmt.Sprintf("/api/sns/web/v1/you/likes?num=%d", num)
-	if cursor != "" {
-		path += "&cursor=" + cursor
-	}
+	path := buildNotificationPath("/api/sns/web/v1/you/likes", num, cursor)
 
 	raw, err := n.signedFetch(ctx, path)
 	if err != nil {
@@ -185,11 +233,8 @@ func (n *NotificationAction) GetLikes(ctx context.Context, num int, cursor strin
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal likes failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
 	}
-	if !resp.Success && resp.Code != 0 {
-		if resp.Code == -1 {
-			return &resp, nil
-		}
-		return nil, fmt.Errorf("likes API error: code=%d msg=%s", resp.Code, resp.Msg)
+	if err := checkAPIResponse(resp.Code, resp.Success, resp.Msg); err != nil {
+		return nil, fmt.Errorf("likes %w", err)
 	}
 	return &resp, nil
 }
@@ -199,10 +244,7 @@ func (n *NotificationAction) GetConnections(ctx context.Context, num int, cursor
 	if num <= 0 {
 		num = 20
 	}
-	path := fmt.Sprintf("/api/sns/web/v1/you/connections?num=%d", num)
-	if cursor != "" {
-		path += "&cursor=" + cursor
-	}
+	path := buildNotificationPath("/api/sns/web/v1/you/connections", num, cursor)
 
 	raw, err := n.signedFetch(ctx, path)
 	if err != nil {
@@ -213,19 +255,8 @@ func (n *NotificationAction) GetConnections(ctx context.Context, num int, cursor
 	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		return nil, fmt.Errorf("unmarshal connections failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
 	}
-	if !resp.Success && resp.Code != 0 {
-		// code=-1 with empty msg may mean no data, return empty result
-		if resp.Code == -1 {
-			return &resp, nil
-		}
-		return nil, fmt.Errorf("connections API error: code=%d msg=%s", resp.Code, resp.Msg)
+	if err := checkAPIResponse(resp.Code, resp.Success, resp.Msg); err != nil {
+		return nil, fmt.Errorf("connections %w", err)
 	}
 	return &resp, nil
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/xiaohongshu/notifications.go
+++ b/xiaohongshu/notifications.go
@@ -1,0 +1,231 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+// NotificationAction 通知相关操作
+type NotificationAction struct {
+	page *rod.Page
+}
+
+func NewNotificationAction(page *rod.Page) *NotificationAction {
+	pp := page.Timeout(60 * time.Second)
+	pp.MustNavigate("https://www.xiaohongshu.com/explore")
+	pp.MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+	return &NotificationAction{page: pp}
+}
+
+// signedFetch 通过浏览器JS上下文发起带签名的API请求
+func (n *NotificationAction) signedFetch(ctx context.Context, apiPath string) (string, error) {
+	page := n.page.Context(ctx)
+
+	js := fmt.Sprintf(`() => {
+		return new Promise(async (resolve) => {
+			try {
+				const url = "%s";
+				let headers = {"Content-Type": "application/json"};
+				if (window._webmsxyw) {
+					const sign = window._webmsxyw(url, "");
+					if (sign) {
+						headers["x-s"] = sign["X-s"];
+						headers["x-t"] = sign["X-t"].toString();
+					}
+				}
+				const resp = await fetch("https://edith.xiaohongshu.com" + url, {
+					credentials: "include",
+					headers: headers
+				});
+				const text = await resp.text();
+				resolve(text);
+			} catch(e) {
+				resolve(JSON.stringify({"error": e.message}));
+			}
+		});
+	}`, apiPath)
+
+	result, err := page.Eval(js)
+	if err != nil {
+		return "", fmt.Errorf("eval failed: %w", err)
+	}
+	return result.Value.String(), nil
+}
+
+// NotificationResponse API通用响应
+type NotificationResponse struct {
+	Code    int    `json:"code"`
+	Success bool   `json:"success"`
+	Msg     string `json:"msg"`
+}
+
+// MentionsResponse 评论和@通知响应
+type MentionsResponse struct {
+	NotificationResponse
+	Data struct {
+		HasMore   bool              `json:"has_more"`
+		Cursor    int64             `json:"cursor"`
+		StrCursor string            `json:"strCursor"`
+		Messages  []MentionMessage  `json:"message_list"`
+	} `json:"data"`
+}
+
+type MentionMessage struct {
+	ID        string          `json:"id"`
+	Type      string          `json:"type"`
+	Time      int64           `json:"time"`
+	UserInfo  NotifUserInfo   `json:"user_info"`
+	ItemInfo  *NotifItemInfo  `json:"item_info,omitempty"`
+	SubType   string          `json:"sub_type,omitempty"`
+	Content   string          `json:"content,omitempty"`
+}
+
+// LikesResponse 赞和收藏通知响应
+type LikesResponse struct {
+	NotificationResponse
+	Data struct {
+		HasMore   bool            `json:"has_more"`
+		Cursor    int64           `json:"cursor"`
+		StrCursor string          `json:"strCursor"`
+		Messages  []LikeMessage   `json:"message_list"`
+	} `json:"data"`
+}
+
+type LikeMessage struct {
+	ID        string          `json:"id"`
+	Type      string          `json:"type"`
+	Time      int64           `json:"time"`
+	Score     int64           `json:"score"`
+	TrackType string          `json:"track_type"`
+	Title     string          `json:"title"`
+	UserInfo  NotifUserInfo   `json:"user_info"`
+	ItemInfo  *NotifItemInfo  `json:"item_info,omitempty"`
+}
+
+// ConnectionsResponse 新增关注通知响应
+type ConnectionsResponse struct {
+	NotificationResponse
+	Data struct {
+		HasMore   bool                  `json:"has_more"`
+		Cursor    int64                 `json:"cursor"`
+		StrCursor string                `json:"strCursor"`
+		Messages  []ConnectionMessage   `json:"message_list"`
+	} `json:"data"`
+}
+
+type ConnectionMessage struct {
+	ID       string        `json:"id"`
+	Type     string        `json:"type"`
+	Time     int64         `json:"time"`
+	UserInfo NotifUserInfo `json:"user_info"`
+}
+
+type NotifUserInfo struct {
+	UserID   string `json:"userid"`
+	Nickname string `json:"nickname"`
+	Image    string `json:"image"`
+	FStatus  string `json:"fstatus,omitempty"`
+}
+
+type NotifItemInfo struct {
+	Content string `json:"content,omitempty"`
+	Image   string `json:"image,omitempty"`
+	Link    string `json:"link,omitempty"`
+}
+
+// GetMentions 获取评论和@通知
+func (n *NotificationAction) GetMentions(ctx context.Context, num int, cursor string) (*MentionsResponse, error) {
+	if num <= 0 {
+		num = 20
+	}
+	path := fmt.Sprintf("/api/sns/web/v1/you/mentions?num=%d", num)
+	if cursor != "" {
+		path += "&cursor=" + cursor
+	}
+
+	raw, err := n.signedFetch(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp MentionsResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal mentions failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
+	}
+	if !resp.Success && resp.Code != 0 {
+		if resp.Code == -1 {
+			return &resp, nil
+		}
+		return nil, fmt.Errorf("mentions API error: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return &resp, nil
+}
+
+// GetLikes 获取赞和收藏通知
+func (n *NotificationAction) GetLikes(ctx context.Context, num int, cursor string) (*LikesResponse, error) {
+	if num <= 0 {
+		num = 20
+	}
+	path := fmt.Sprintf("/api/sns/web/v1/you/likes?num=%d", num)
+	if cursor != "" {
+		path += "&cursor=" + cursor
+	}
+
+	raw, err := n.signedFetch(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LikesResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal likes failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
+	}
+	if !resp.Success && resp.Code != 0 {
+		if resp.Code == -1 {
+			return &resp, nil
+		}
+		return nil, fmt.Errorf("likes API error: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return &resp, nil
+}
+
+// GetConnections 获取新增关注通知
+func (n *NotificationAction) GetConnections(ctx context.Context, num int, cursor string) (*ConnectionsResponse, error) {
+	if num <= 0 {
+		num = 20
+	}
+	path := fmt.Sprintf("/api/sns/web/v1/you/connections?num=%d", num)
+	if cursor != "" {
+		path += "&cursor=" + cursor
+	}
+
+	raw, err := n.signedFetch(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ConnectionsResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal connections failed: %w, raw: %s", err, raw[:min(len(raw), 200)])
+	}
+	if !resp.Success && resp.Code != 0 {
+		// code=-1 with empty msg may mean no data, return empty result
+		if resp.Code == -1 {
+			return &resp, nil
+		}
+		return nil, fmt.Errorf("connections API error: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return &resp, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## 功能描述

新增 3 个通知查询 MCP 工具：

| 工具名 | 功能 | API 端点 |
|--------|------|----------|
| `get_mentions` | 获取评论和@通知 | `/api/sns/web/v1/you/mentions` |
| `get_likes` | 获取赞和收藏通知 | `/api/sns/web/v1/you/likes` |
| `get_connections` | 获取新增关注通知 | `/api/sns/web/v1/you/connections` |

## 实现方式

通过浏览器 JS 上下文调用 `window._webmsxyw()` 生成 `x-s`/`x-t` 签名头，然后发起带签名的 fetch 请求到小红书 web API。

与现有工具的区别：现有工具从 `window.__INITIAL_STATE__` 提取数据，通知工具通过签名 API 请求获取数据（因为通知数据不在页面初始状态中）。

## 参数

所有工具支持相同的参数：
- `num`（可选）：返回数量，默认 20
- `cursor`（可选）：分页游标，从上一次返回的 cursor 获取

## 响应格式

```json
{
  "type": "mentions",
  "has_more": false,
  "cursor": "370235304",
  "messages": [...],
  "count": 1
}
```

## 修改文件

- `xiaohongshu/notifications.go`（新增）— 浏览器自动化层，签名请求 + 响应解析
- `service.go` — 新增 3 个 service 方法
- `mcp_handlers.go` — 新增 3 个 handler
- `mcp_server.go` — 新增 `NotificationArgs` 类型 + 注册 3 个工具

## 备注

- `connections` 端点在无数据时返回 `code=-1`，已做兼容处理（返回空列表而非报错）
- 已在实际环境中测试通过