### PR TITLE
feat：新增笔记管理模块以及笔记管理页面下删除笔记功能

### DIFF
--- a/handlers_api.go
+++ b/handlers_api.go
@@ -270,6 +270,26 @@ func (s *AppServer) replyCommentHandler(c *gin.Context) {
 	respondSuccess(c, result, result.Message)
 }
 
+// deleteNoteHandler 删除笔记
+func (s *AppServer) deleteNoteHandler(c *gin.Context) {
+	var req DeleteNoteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	result, err := s.xiaohongshuService.DeleteNote(c.Request.Context(), &req)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "DELETE_NOTE_FAILED",
+			"删除笔记失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "删除笔记成功")
+}
+
 // healthHandler 健康检查
 func healthHandler(c *gin.Context) {
 	respondSuccess(c, map[string]any{

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -319,6 +319,57 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 	}
 }
 
+// handleDeleteNote 删除笔记
+func (s *AppServer) handleDeleteNote(ctx context.Context, args DeleteNoteArgs) *MCPToolResult {
+	logrus.Info("MCP: 删除笔记")
+
+	if args.NoteID == "" && args.Title == "" && args.Index <= 0 {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "删除笔记失败: 缺少 note_id、title 或 index 参数",
+			}},
+			IsError: true,
+		}
+	}
+
+	logrus.Infof("MCP: 删除笔记 - note_id=%s, title=%s, index=%d, keyword=%s", args.NoteID, args.Title, args.Index, args.Keyword)
+
+	result, err := s.xiaohongshuService.DeleteNote(ctx, &DeleteNoteRequest{
+		Keyword: args.Keyword,
+		NoteID:  args.NoteID,
+		Title:   args.Title,
+		Index:   args.Index,
+	})
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "删除笔记失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("删除笔记成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleGetFeedDetail 处理获取Feed详情
 func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取Feed详情")

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -33,6 +33,14 @@ type PublishVideoArgs struct {
 	ScheduleAt string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
 }
 
+// DeleteNoteArgs 删除笔记参数
+type DeleteNoteArgs struct {
+	Keyword string `json:"keyword,omitempty" jsonschema:"搜索关键词（可选，用于过滤笔记列表）"`
+	NoteID  string `json:"note_id,omitempty" jsonschema:"笔记ID（优先级最高）"`
+	Title   string `json:"title,omitempty" jsonschema:"笔记标题关键词（模糊匹配）"`
+	Index   int    `json:"index,omitempty" jsonschema:"笔记序号（按页面列表从1开始）"`
+}
+
 // SearchFeedsArgs 搜索内容的参数
 type SearchFeedsArgs struct {
 	Keyword string       `json:"keyword" jsonschema:"搜索关键词"`
@@ -252,7 +260,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 7: 获取Feed详情
+	// 工具 7: 删除笔记
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "delete_note",
+			Description: "删除笔记管理页面的指定笔记（支持关键词筛选与序号定位）",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Delete Note",
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		withPanicRecovery("delete_note", func(ctx context.Context, req *mcp.CallToolRequest, args DeleteNoteArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleDeleteNote(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 8: 获取Feed详情
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
@@ -297,7 +321,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 8: 获取用户主页
+	// 工具 9: 获取用户主页
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "user_profile",
@@ -317,7 +341,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 9: 发表评论
+	// 工具 10: 发表评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "post_comment_to_feed",
@@ -338,7 +362,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 10: 回复评论
+	// 工具 11: 回复评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "reply_comment_in_feed",
@@ -368,7 +392,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	// 工具 11: 发布视频（仅本地文件）
+	// 工具 12: 发布视频（仅本地文件）
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "publish_with_video",
@@ -391,7 +415,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 12: 点赞笔记
+	// 工具 13: 点赞笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "like_feed",
@@ -412,7 +436,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 13: 收藏笔记
+	// 工具 14: 收藏笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "favorite_feed",
@@ -433,7 +457,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/routes.go
+++ b/routes.go
@@ -51,6 +51,7 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.POST("/feeds/comment", appServer.postCommentHandler)
 		api.POST("/feeds/comment/reply", appServer.replyCommentHandler)
 		api.GET("/user/me", appServer.myProfileHandler)
+		api.POST("/notes/delete", appServer.deleteNoteHandler)
 	}
 
 	return router

--- a/service.go
+++ b/service.go
@@ -75,6 +75,20 @@ type PublishVideoResponse struct {
 	PostID  string `json:"post_id,omitempty"`
 }
 
+// DeleteNoteRequest 删除笔记请求
+type DeleteNoteRequest struct {
+	Keyword string `json:"keyword,omitempty"`
+	NoteID  string `json:"note_id,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Index   int    `json:"index,omitempty"`
+}
+
+// DeleteNoteResponse 删除笔记响应
+type DeleteNoteResponse struct {
+	Deleted xiaohongshu.NoteSummary   `json:"deleted"`
+	Notes   []xiaohongshu.NoteSummary `json:"notes"`
+}
+
 // FeedsListResponse Feeds列表响应
 type FeedsListResponse struct {
 	Feeds []xiaohongshu.Feed `json:"feeds"`
@@ -379,6 +393,35 @@ func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, fi
 	}
 
 	return response, nil
+}
+
+// DeleteNote 删除笔记
+func (s *XiaohongshuService) DeleteNote(ctx context.Context, req *DeleteNoteRequest) (*DeleteNoteResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action, err := xiaohongshu.NewNoteManagerAction(page)
+	if err != nil {
+		return nil, err
+	}
+
+	deleted, notes, err := action.DeleteNote(ctx, xiaohongshu.DeleteNoteOptions{
+		Keyword: req.Keyword,
+		NoteID:  req.NoteID,
+		Title:   req.Title,
+		Index:   req.Index,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeleteNoteResponse{
+		Deleted: deleted,
+		Notes:   notes,
+	}, nil
 }
 
 // GetFeedDetail 获取Feed详情

--- a/xiaohongshu/note_manager.go
+++ b/xiaohongshu/note_manager.go
@@ -1,0 +1,335 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/sirupsen/logrus"
+)
+
+type NoteManagerAction struct {
+	page *rod.Page
+}
+
+type NoteSummary struct {
+	Index     int    `json:"index"`
+	NoteID    string `json:"note_id,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Status    string `json:"status,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+type DeleteNoteOptions struct {
+	Keyword string
+	NoteID  string
+	Title   string
+	Index   int
+}
+
+const (
+	urlOfNoteManager = "https://creator.xiaohongshu.com/new/note-manager?source=official"
+)
+
+func NewNoteManagerAction(page *rod.Page) (*NoteManagerAction, error) {
+	pp := page.Timeout(300 * time.Second)
+
+	// 使用更稳健的导航和等待策略
+	if err := pp.Navigate(urlOfNoteManager); err != nil {
+		return nil, fmt.Errorf("导航到笔记管理页面失败: %w", err)
+	}
+
+	if err := pp.WaitLoad(); err != nil {
+		logrus.Warnf("等待笔记管理页面加载出现问题: %v，继续尝试", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	if err := pp.WaitDOMStable(time.Second, 0.1); err != nil {
+		logrus.Warnf("等待笔记管理页面 DOM 稳定出现问题: %v，继续尝试", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	if err := waitNoteManagerReady(pp); err != nil {
+		logrus.Warnf("等待笔记管理页面可交互失败: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
+	return &NoteManagerAction{page: pp}, nil
+}
+
+func DeleteNoteAction(page *rod.Page) *NoteManagerAction {
+	action, err := NewNoteManagerAction(page)
+	if err != nil {
+		logrus.Warnf("初始化笔记管理页面失败: %v", err)
+		return &NoteManagerAction{page: page.Timeout(300 * time.Second)}
+	}
+	return action
+}
+
+func (n *NoteManagerAction) ListNotes(ctx context.Context, keyword string) ([]NoteSummary, error) {
+	page := n.page.Context(ctx)
+
+	if keyword != "" {
+		if err := applyNoteSearch(page, keyword); err != nil {
+			return nil, err
+		}
+	}
+
+	time.Sleep(1 * time.Second)
+
+	notes, err := readNoteSummaries(page)
+	if err != nil {
+		return nil, err
+	}
+
+	return notes, nil
+}
+
+func (n *NoteManagerAction) DeleteNote(ctx context.Context, opts DeleteNoteOptions) (NoteSummary, []NoteSummary, error) {
+	page := n.page.Context(ctx)
+
+	notes, err := n.ListNotes(ctx, opts.Keyword)
+	if err != nil {
+		return NoteSummary{}, nil, err
+	}
+
+	targetIndex, target, err := pickTargetNote(notes, opts)
+	if err != nil {
+		return NoteSummary{}, notes, err
+	}
+
+	if err := clickDeleteButton(page, targetIndex); err != nil {
+		return NoteSummary{}, notes, err
+	}
+
+	if err := confirmNoteDelete(page); err != nil {
+		return NoteSummary{}, notes, err
+	}
+
+	page.MustWaitStable()
+	time.Sleep(1 * time.Second)
+
+	return target, notes, nil
+}
+
+func applyNoteSearch(page *rod.Page, keyword string) error {
+	searchInput, err := findNoteSearchInput(page)
+	if err != nil {
+		return err
+	}
+
+	if err := searchInput.SelectAllText(); err != nil {
+		logrus.Warnf("选择搜索框文本失败: %v", err)
+	}
+
+	if err := searchInput.Input(keyword); err != nil {
+		return fmt.Errorf("输入搜索关键词失败: %w", err)
+	}
+
+	ka, err := searchInput.KeyActions()
+	if err != nil {
+		return fmt.Errorf("创建搜索输入键盘操作失败: %w", err)
+	}
+	if err := ka.Press(input.Enter).Do(); err != nil {
+		return fmt.Errorf("触发搜索失败: %w", err)
+	}
+
+	time.Sleep(1 * time.Second)
+	page.MustWaitStable()
+
+	return nil
+}
+
+func findNoteSearchInput(page *rod.Page) (*rod.Element, error) {
+	selectors := []string{
+		`input.d-text[placeholder*="搜索已发布笔记"]`,
+		`input.d-text[placeholder*="搜索"]`,
+		`input.d-text[placeholder*="笔记"]`,
+		`input.d-text[placeholder*="标题"]`,
+		`input.d-text[placeholder*="关键词"]`,
+		`input[placeholder*="搜索"]`,
+		`input[type="search"]`,
+	}
+
+	for _, selector := range selectors {
+		elem, err := page.Element(selector)
+		if err == nil && elem != nil {
+			return elem, nil
+		}
+	}
+
+	return nil, fmt.Errorf("未找到笔记管理页面搜索框")
+}
+
+func waitNoteManagerReady(page *rod.Page) error {
+	selector := `input.d-text[placeholder*="搜索"]`
+	elem := page.MustElement(selector)
+	if err := elem.WaitVisible(); err != nil {
+		return fmt.Errorf("等待笔记管理搜索框出现失败: %w", err)
+	}
+	return nil
+}
+
+func readNoteSummaries(page *rod.Page) ([]NoteSummary, error) {
+	result := page.MustEval(`() => {
+		const buttons = Array.from(document.querySelectorAll('span.control.data-del'));
+		const notes = buttons.map((btn, idx) => {
+			const card = btn.closest('.note') || btn.closest('[data-note-id],[data-id],[data-noteid]');
+			const getText = (el) => el ? el.textContent.trim() : '';
+			let noteId = '';
+			let title = '';
+			let status = '';
+			let updatedAt = '';
+			let url = '';
+
+			if (card) {
+				noteId = card.getAttribute('data-note-id') || card.getAttribute('data-id') || card.getAttribute('data-noteid') || '';
+				if (!noteId) {
+					const impression = card.getAttribute('data-impression') || '';
+					const match = impression.match(/noteId\"\s*:\"([^\"]+)/);
+					if (match && match[1]) {
+						noteId = match[1];
+					}
+				}
+				const titleEl = card.querySelector('.title');
+				title = getText(titleEl);
+				const statusEl = card.querySelector('.permission_msg');
+				status = getText(statusEl);
+				const timeEl = card.querySelector('.time');
+				updatedAt = getText(timeEl);
+				const linkEl = card.querySelector('a[href]');
+				if (linkEl && linkEl.href) {
+					url = linkEl.href;
+				}
+			}
+
+			return {
+				index: idx + 1,
+				note_id: noteId,
+				title,
+				status,
+				updated_at: updatedAt,
+				url,
+			};
+		});
+		return JSON.stringify(notes);
+	}`).String()
+
+	if result == "" {
+		return nil, fmt.Errorf("未获取到笔记列表")
+	}
+
+	var notes []NoteSummary
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("解析笔记列表失败: %w", err)
+	}
+
+	if len(notes) == 0 {
+		logrus.Warn("笔记列表为空")
+	}
+
+	return notes, nil
+}
+
+func pickTargetNote(notes []NoteSummary, opts DeleteNoteOptions) (int, NoteSummary, error) {
+	if len(notes) == 0 {
+		return 0, NoteSummary{}, fmt.Errorf("笔记列表为空，无法删除")
+	}
+
+	if opts.NoteID != "" {
+		for _, note := range notes {
+			if note.NoteID == opts.NoteID {
+				return note.Index, note, nil
+			}
+		}
+		return 0, NoteSummary{}, fmt.Errorf("未找到匹配 note_id=%s 的笔记", opts.NoteID)
+	}
+
+	if opts.Title != "" {
+		for _, note := range notes {
+			if strings.Contains(note.Title, opts.Title) {
+				return note.Index, note, nil
+			}
+		}
+		return 0, NoteSummary{}, fmt.Errorf("未找到标题包含 %s 的笔记", opts.Title)
+	}
+
+	if opts.Index > 0 {
+		for _, note := range notes {
+			if note.Index == opts.Index {
+				return note.Index, note, nil
+			}
+		}
+		return 0, NoteSummary{}, fmt.Errorf("未找到 index=%d 的笔记", opts.Index)
+	}
+
+	return 0, NoteSummary{}, fmt.Errorf("缺少删除目标，请提供 note_id、title 或 index")
+}
+
+func clickDeleteButton(page *rod.Page, targetIndex int) error {
+	buttons, err := page.Elements(`span.control.data-del`)
+	if err != nil {
+		return fmt.Errorf("查找删除按钮失败: %w", err)
+	}
+
+	if targetIndex <= 0 || targetIndex > len(buttons) {
+		return fmt.Errorf("删除目标 index=%d 超出范围，总数=%d", targetIndex, len(buttons))
+	}
+
+	if err := buttons[targetIndex-1].Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("点击删除按钮失败: %w", err)
+	}
+
+	return nil
+}
+
+func confirmNoteDelete(page *rod.Page) error {
+	time.Sleep(800 * time.Millisecond)
+
+	_, modal, err := page.Has("div[role='dialog'], div.d-modal, div.modal")
+	if err != nil {
+		logrus.Warnf("检查删除确认弹窗失败: %v", err)
+		return nil
+	}
+	if modal == nil {
+		return nil
+	}
+
+	confirmBtn, err := modal.Element("button.confirm-btn")
+	if err == nil && confirmBtn != nil {
+		if err := confirmBtn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+			return fmt.Errorf("点击删除确认按钮失败: %w", err)
+		}
+		return nil
+	}
+
+	buttons, err := modal.Elements("button")
+	if err != nil {
+		buttons, err = page.Elements("button")
+		if err != nil {
+			return fmt.Errorf("查找确认删除按钮失败: %w", err)
+		}
+	}
+
+	for _, btn := range buttons {
+		text, err := btn.Text()
+		if err != nil {
+			continue
+		}
+		text = strings.TrimSpace(text)
+		if text == "确定" || text == "确认" || strings.Contains(text, "确定") {
+			if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				return fmt.Errorf("点击删除确认按钮失败: %w", err)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("未找到删除确认按钮")
+}

--- a/xiaohongshu/note_manager.go
+++ b/xiaohongshu/note_manager.go
@@ -2,7 +2,6 @@ package xiaohongshu
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -177,64 +176,122 @@ func waitNoteManagerReady(page *rod.Page) error {
 }
 
 func readNoteSummaries(page *rod.Page) ([]NoteSummary, error) {
-	result := page.MustEval(`() => {
-		const buttons = Array.from(document.querySelectorAll('span.control.data-del'));
-		const notes = buttons.map((btn, idx) => {
-			const card = btn.closest('.note') || btn.closest('[data-note-id],[data-id],[data-noteid]');
-			const getText = (el) => el ? el.textContent.trim() : '';
-			let noteId = '';
-			let title = '';
-			let status = '';
-			let updatedAt = '';
-			let url = '';
-
-			if (card) {
-				noteId = card.getAttribute('data-note-id') || card.getAttribute('data-id') || card.getAttribute('data-noteid') || '';
-				if (!noteId) {
-					const impression = card.getAttribute('data-impression') || '';
-					const match = impression.match(/noteId\"\s*:\"([^\"]+)/);
-					if (match && match[1]) {
-						noteId = match[1];
-					}
-				}
-				const titleEl = card.querySelector('.title');
-				title = getText(titleEl);
-				const statusEl = card.querySelector('.permission_msg');
-				status = getText(statusEl);
-				const timeEl = card.querySelector('.time');
-				updatedAt = getText(timeEl);
-				const linkEl = card.querySelector('a[href]');
-				if (linkEl && linkEl.href) {
-					url = linkEl.href;
-				}
-			}
-
-			return {
-				index: idx + 1,
-				note_id: noteId,
-				title,
-				status,
-				updated_at: updatedAt,
-				url,
-			};
-		});
-		return JSON.stringify(notes);
-	}`).String()
-
-	if result == "" {
-		return nil, fmt.Errorf("未获取到笔记列表")
+	// 找到所有删除按钮，每个按钮对应一条笔记
+	buttons, err := page.Elements(`span.control.data-del`)
+	if err != nil {
+		return nil, fmt.Errorf("查找笔记列表失败: %w", err)
 	}
 
-	var notes []NoteSummary
-	if err := json.Unmarshal([]byte(result), &notes); err != nil {
-		return nil, fmt.Errorf("解析笔记列表失败: %w", err)
-	}
-
-	if len(notes) == 0 {
+	if len(buttons) == 0 {
 		logrus.Warn("笔记列表为空")
+		return nil, nil
+	}
+
+	notes := make([]NoteSummary, 0, len(buttons))
+	for idx, btn := range buttons {
+		note := NoteSummary{Index: idx + 1}
+
+		// 向上找到最近的笔记卡片容器
+		card, err := findNoteCard(btn)
+		if err != nil {
+			logrus.Warnf("第 %d 条笔记未找到卡片容器: %v", idx+1, err)
+			notes = append(notes, note)
+			continue
+		}
+
+		// 提取 note_id（优先从 data 属性读取）
+		for _, attr := range []string{"data-note-id", "data-id", "data-noteid"} {
+			if val, err := card.Attribute(attr); err == nil && val != nil && *val != "" {
+				note.NoteID = *val
+				break
+			}
+		}
+		// 若 data 属性中没有，尝试从 data-impression 中解析
+		if note.NoteID == "" {
+			if impression, err := card.Attribute("data-impression"); err == nil && impression != nil {
+				note.NoteID = extractNoteIDFromImpression(*impression)
+			}
+		}
+
+		// 提取标题
+		note.Title = elemText(card, ".title")
+
+		// 提取状态
+		note.Status = elemText(card, ".permission_msg")
+
+		// 提取更新时间
+		note.UpdatedAt = elemText(card, ".time")
+
+		// 提取链接
+		if link, err := card.Element("a[href]"); err == nil && link != nil {
+			if href, err := link.Attribute("href"); err == nil && href != nil {
+				note.URL = *href
+			}
+		}
+
+		notes = append(notes, note)
 	}
 
 	return notes, nil
+}
+
+// findNoteCard 从删除按钮向上查找最近的笔记卡片容器
+// go-rod 没有原生的 closest API，通过「打标记 → 定位 → 清除标记」的方式实现
+func findNoteCard(btn *rod.Element) (*rod.Element, error) {
+	return findNoteCardByJS(btn)
+}
+
+// findNoteCardByJS 通过 JS 找到笔记卡片，返回对应的 rod.Element
+// go-rod 的 Eval 不传参数，JS 中用 this 引用当前元素
+func findNoteCardByJS(btn *rod.Element) (*rod.Element, error) {
+	// 给卡片元素打上临时标记，再用 go-rod 定位
+	const marker = "__rod_note_card__"
+	_, err := btn.Eval(fmt.Sprintf(`() => {
+		const card = this.closest('.note') || this.closest('[data-note-id]') || this.closest('[data-id]') || this.closest('[data-noteid]');
+		if (card) { card.setAttribute('%s', '1'); }
+		return card !== null;
+	}`, marker))
+	if err != nil {
+		return nil, fmt.Errorf("标记笔记卡片失败: %w", err)
+	}
+
+	card, err := btn.Page().Element(fmt.Sprintf("[%s]", marker))
+	if err != nil {
+		return nil, fmt.Errorf("定位笔记卡片失败: %w", err)
+	}
+
+	// 清除临时标记
+	_, _ = card.Eval(fmt.Sprintf(`() => this.removeAttribute('%s')`, marker))
+
+	return card, nil
+}
+
+// elemText 在指定容器内查找子元素并返回其文本，找不到时返回空字符串
+func elemText(parent *rod.Element, selector string) string {
+	el, err := parent.Element(selector)
+	if err != nil || el == nil {
+		return ""
+	}
+	text, err := el.Text()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+// extractNoteIDFromImpression 从 data-impression 属性值中解析 noteId
+func extractNoteIDFromImpression(impression string) string {
+	const prefix = `noteId":"`
+	idx := strings.Index(impression, prefix)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(prefix)
+	end := strings.Index(impression[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return impression[start : start+end]
 }
 
 func pickTargetNote(notes []NoteSummary, opts DeleteNoteOptions) (int, NoteSummary, error) {

--- a/xiaohongshu/note_manager_test.go
+++ b/xiaohongshu/note_manager_test.go
@@ -1,0 +1,51 @@
+package xiaohongshu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xpzouying/xiaohongshu-mcp/browser"
+)
+
+func TestDeleteNoteByIndex(t *testing.T) {
+	// 删除属于破坏性操作，默认跳过
+	t.Skip("SKIP: 删除笔记为破坏性操作，请确认后开启")
+	b := browser.NewBrowser(false)
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action, err := NewNoteManagerAction(page)
+	require.NoError(t, err)
+
+	notes, err := action.ListNotes(context.Background(), "")
+	require.NoError(t, err)
+	require.NotEmpty(t, notes, "notes should not be empty")
+
+	deleted, _, err := action.DeleteNote(context.Background(), DeleteNoteOptions{Index: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, deleted.Title)
+}
+
+func TestDeleteNoteByTitle(t *testing.T) {
+	// 删除属于破坏性操作，默认跳过
+	t.Skip("SKIP: 删除笔记为破坏性操作，请确认后开启")
+
+	b := browser.NewBrowser(false)
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action, err := NewNoteManagerAction(page)
+	require.NoError(t, err)
+
+	deleted, _, err := action.DeleteNote(context.Background(), DeleteNoteOptions{
+		Keyword: "",
+		Title:   "测试",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, deleted.Title)
+}


### PR DESCRIPTION
Summary
--- 
功能新增：新增 note_manager 删除笔记能力，覆盖按 note_id / 标题 / 序号 / 关键词删除，并支持搜索框过滤。note_manager.go
交互稳定性：对齐 publish 的页面等待策略，增强未登录场景的页面等待与可交互性检查。note_manager.go
工具接口：新增删除笔记 API 与 MCP 工具入口，保证服务层能力可调用。mcp_handlers.go

Checklist
--- 
- [x] Tests for the changes have been added (for bug fixes / features);

Does this PR introduce a breaking change?
--- 
- [ ] Yes
- [x] No