### PR TITLE
fix: SPA warmup 修复 - 解决直接导航时页面渲染不完整的问题

### DIFF
--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -44,7 +44,7 @@ func newInteractAction(page *rod.Page) *interactAction {
 }
 
 func (a *interactAction) preparePage(ctx context.Context, actionType interactActionType, feedID, xsecToken string) *rod.Page {
-	page := a.page.Context(ctx).Timeout(60 * time.Second)
+	page := a.page.Context(ctx).Timeout(5 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 	logrus.Infof("Opening feed detail page for %s: %s", actionType, url)
 


### PR DESCRIPTION
## 问题

小红书是 SPA（单页应用），以下工具在直接导航到目标页面时存在渲染问题：

**1. `get_feed_detail`**：直接导航到 `/explore/{feedID}` 时，JS 运行时未初始化，`window.__INITIAL_STATE__.note.noteDetailMap` 为空，返回 `feed {id} not found in noteDetailMap` 错误。

**2. `post_comment_to_feed` / `reply_comment_in_feed`**：直接导航到帖子 URL 时，评论区 DOM 不渲染，导致找不到评论输入框或目标评论元素。

**3. `like_feed` / `favorite_feed`**：操作超时（60s）在页面加载较慢时容易触发失败。

**根本原因**：小红书 SPA 需要先完成运行时初始化（访问首页），再导航到子页面，否则 JS 状态和 DOM 渲染均不完整。

## 修复

### `xiaohongshu/feed_detail.go`
- 在 `GetFeedDetailWithConfig` 导航前先访问首页完成 SPA 运行时初始化（warmup）
- warmup 使用**独立 15s 超时**（`context.WithTimeout`），失败时记录 warning 并继续，不中断主流程
- `extractFeedDetail` 重试参数调整：`Attempts(3→5)`，`Delay(200ms→500ms)`，给 SPA 数据注入更充足的等待时间

### `xiaohongshu/comment_feed.go`
- `PostComment` 和 `ReplyToComment` 导航前先访问首页预热 SPA
- 导航后等待评论区容器元素渲染（最多 15s，检测 `#noteContainer` 等选择器）
- `findCommentElement` 循环开头先尝试直接查找目标评论，避免评论数量少时因 `.end-container` 提前退出

### `xiaohongshu/like_favorite.go`
- 操作超时从 60s 增加到 5 分钟，与其他操作保持一致

## 测试

在 OpenClaw 框架中实际运行验证：
- `get_feed_detail` 不再出现 `noteDetailMap` 为空的错误
- `reply_comment_in_feed` 能正确找到并回复评论
- `like_feed` / `favorite_feed` 不再因超时失败

Made with [Cursor](https://cursor.com)