### PR TITLE
fix: get_feed_detail 和点赞/收藏操作的 SPA 预热修复

### DIFF
--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -44,7 +44,7 @@ func newInteractAction(page *rod.Page) *interactAction {
 }
 
 func (a *interactAction) preparePage(ctx context.Context, actionType interactActionType, feedID, xsecToken string) *rod.Page {
-	page := a.page.Context(ctx).Timeout(60 * time.Second)
+	page := a.page.Context(ctx).Timeout(5 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 	logrus.Infof("Opening feed detail page for %s: %s", actionType, url)
 


### PR DESCRIPTION
## 问题

小红书是 SPA（单页应用）。直接导航到笔记详情 URL 时，JavaScript 运行时尚未完全初始化，导致 `window.__INITIAL_STATE__.note.noteDetailMap` 为空，`get_feed_detail` 无法提取笔记数据。

点赞/收藏操作在网络较慢时也会因为 60 秒超时不足而失败。

## 改动

### `xiaohongshu/feed_detail.go`
- 在导航到笔记 URL 前，先访问小红书主页完成 SPA 运行时初始化
- 预热使用独立的 15 秒超时上下文，避免主页加载缓慢时耗尽调用方的超时预算
- 重试次数从 3 次增加到 5 次，基础延迟 500ms，给 SPA 更多时间将笔记数据注入 `__INITIAL_STATE__`

### `xiaohongshu/like_favorite.go`
- 页面操作超时从 60 秒增加到 5 分钟，适应网络较慢时加载笔记页面的场景

## 验证

手动验证：`get_feed_detail` 现在在首次直接导航到笔记 URL 时能稳定返回笔记内容和评论数据。