### PR TITLE
docs: 优化社区群二维码排版

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,29 +797,21 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 
 **重要：在群里问问题之前，请一定要先仔细看完 README 文档以及查看 Issues。**
 
-<!-- 两列排布：飞书二群 | 微信群 -->
+### 微信群
 
-| 【飞书 3 群】：扫码进入                                                                                                   | 【微信群 14 群】：扫码进入                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| <img src="https://github.com/user-attachments/assets/9a0ec41a-cb65-4f4e-a0f7-31658a49512d" alt="qrcode_2qun" width="300"> | <img src="https://github.com/user-attachments/assets/03db7a63-b9b7-4ab4-aecf-14d05b74cc13" alt="WechatIMG119" width="300"> |
+| 【微信群 14 群】：扫码进入 |
+| :---: |
+| <img src="https://github.com/user-attachments/assets/03db7a63-b9b7-4ab4-aecf-14d05b74cc13" alt="WechatIMG119" width="300"> |
 
+### 飞书群
 
-飞书1群
+| 飞书 1 群 | 飞书 2 群 | 飞书 3 群 | 飞书 4 群 |
+| :---: | :---: | :---: | :---: |
+| <img src="https://github.com/user-attachments/assets/65579771-3543-4661-9b48-def48eed609b" alt="qr-feishu01" width="260"> | <img src="https://github.com/user-attachments/assets/4983ea42-ce5b-4e26-a8c0-33889093b579" alt="qr-feishu02" width="260"> | <img src="https://github.com/user-attachments/assets/c77b45da-6028-4d3a-b421-ccc6c7210695" alt="qr-feishu03" width="260"> | <img src="https://github.com/user-attachments/assets/c42f5595-71cd-4d9b-b7f8-0c333bd25e2b" alt="qr-feishu04" width="260"> |
 
-<img width="1372" height="1488" alt="qr-feishu01" src="https://github.com/user-attachments/assets/65579771-3543-4661-9b48-def48eed609b" />
-
-飞书2群
-
-<img width="1372" height="1488" alt="qr-feishu02" src="https://github.com/user-attachments/assets/4983ea42-ce5b-4e26-a8c0-33889093b579" />
-
-飞书3群
-
-<img width="1372" height="1488" alt="qr-feishu03" src="https://github.com/user-attachments/assets/c77b45da-6028-4d3a-b421-ccc6c7210695" />
-
-
-飞书4群
-
-<img width="1372" height="1488" alt="qr-feishu04" src="https://github.com/user-attachments/assets/c42f5595-71cd-4d9b-b7f8-0c333bd25e2b" />
+> **注意：**
+> 1. 微信群的二维码有时间限制，有时候忘记更新，麻烦等待更新或者提交 Issue 催我更新。
+> 2. 飞书群，如果有的群满了，可以尝试扫一下另外一个群，总有坑位。
 
 
 ## 🙏 致谢贡献者 ✨

--- a/README_EN.md
+++ b/README_EN.md
@@ -798,11 +798,21 @@ Use xiaohongshu-mcp's video publishing feature.
 
 **Important: Before asking questions in the group, please make sure to read the README documentation thoroughly and check Issues first.**
 
-<!-- Two-column layout: Feishu Group 3 | WeChat Group 14 -->
+### WeChat Group
 
-| 【Feishu Group 3】: Scan to join                                                                                           | 【WeChat Group 14】: Scan to join                                                                                           |
-| ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| <img src="https://github.com/user-attachments/assets/9a0ec41a-cb65-4f4e-a0f7-31658a49512d" alt="qrcode_2qun" width="300"> | <img src="https://github.com/user-attachments/assets/f597fbef-0d67-4a5d-a07c-3066bee49fc5" alt="WechatIMG119" width="300"> |
+| 【WeChat Group 14】: Scan to join |
+| :---: |
+| <img src="https://github.com/user-attachments/assets/03db7a63-b9b7-4ab4-aecf-14d05b74cc13" alt="WechatIMG119" width="300"> |
+
+### Feishu (Lark) Groups
+
+| Feishu Group 1 | Feishu Group 2 | Feishu Group 3 | Feishu Group 4 |
+| :---: | :---: | :---: | :---: |
+| <img src="https://github.com/user-attachments/assets/65579771-3543-4661-9b48-def48eed609b" alt="qr-feishu01" width="260"> | <img src="https://github.com/user-attachments/assets/4983ea42-ce5b-4e26-a8c0-33889093b579" alt="qr-feishu02" width="260"> | <img src="https://github.com/user-attachments/assets/c77b45da-6028-4d3a-b421-ccc6c7210695" alt="qr-feishu03" width="260"> | <img src="https://github.com/user-attachments/assets/c42f5595-71cd-4d9b-b7f8-0c333bd25e2b" alt="qr-feishu04" width="260"> |
+
+> **Note:**
+> 1. WeChat group QR codes have a time limit. Sometimes I forget to update them — please wait for an update or submit an Issue to remind me.
+> 2. If a Feishu group is full, try scanning another group's QR code — there's always a spot somewhere.
 
 ## 🙏 Thanks to Contributors ✨
 


### PR DESCRIPTION
## Summary
- 将微信群和飞书群分为独立表格展示
- 飞书群改为一行四列布局，展示全部 4 个群二维码
- 添加二维码更新和群满的注意事项
- 同步更新 README_EN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)