### PR TITLE
feat: 添加小红书发布原创声明功能

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -135,7 +135,10 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 	// 解析定时发布参数
 	scheduleAt, _ := args["schedule_at"].(string)
 
-	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s", title, len(imagePaths), len(tags), scheduleAt)
+	// 解析原创参数
+	isOriginal, _ := args["is_original"].(bool)
+
+	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s, 原创: %v", title, len(imagePaths), len(tags), scheduleAt, isOriginal)
 
 	// 构建发布请求
 	req := &PublishRequest{
@@ -144,6 +147,7 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 		Images:     imagePaths,
 		Tags:       tags,
 		ScheduleAt: scheduleAt,
+		IsOriginal: isOriginal,
 	}
 
 	// 执行发布

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -22,6 +22,7 @@ type PublishContentArgs struct {
 	Images     []string `json:"images" jsonschema:"图片路径列表（至少需要1张图片）。支持两种方式：1. HTTP/HTTPS图片链接（自动下载）；2. 本地图片绝对路径（推荐，如:/Users/user/image.jpg）"`
 	Tags       []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
 	ScheduleAt string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
+	IsOriginal bool     `json:"is_original,omitempty" jsonschema:"是否声明原创（可选），true为声明原创，false或不填则不声明"`
 }
 
 // PublishVideoArgs 发布视频的参数（仅支持本地单个视频文件）
@@ -214,6 +215,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 				"images":      convertStringsToInterfaces(args.Images),
 				"tags":        convertStringsToInterfaces(args.Tags),
 				"schedule_at": args.ScheduleAt,
+				"is_original": args.IsOriginal,
 			}
 			result := appServer.handlePublishContent(ctx, argsMap)
 			return convertToMCPResult(result), nil, nil

--- a/service.go
+++ b/service.go
@@ -33,6 +33,7 @@ type PublishRequest struct {
 	Images     []string `json:"images" binding:"required,min=1"`
 	Tags       []string `json:"tags,omitempty"`
 	ScheduleAt string   `json:"schedule_at,omitempty"` // 定时发布时间，ISO8601格式，为空则立即发布
+	IsOriginal bool     `json:"is_original,omitempty"` // 是否声明原创
 }
 
 // LoginStatusResponse 登录状态响应
@@ -212,6 +213,7 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 		Tags:         req.Tags,
 		ImagePaths:   imagePaths,
 		ScheduleTime: scheduleTime,
+		IsOriginal:   req.IsOriginal,
 	}
 
 	// 执行发布


### PR DESCRIPTION
功能说明： 添加小红书图文发布时的"原创声明"可选参数

修改文件：

mcp_server.go - 新增 is_original 参数定义
mcp_handlers.go - 解析并传递 is_original 参数
service.go - PublishRequest 结构体添加 IsOriginal 字段
xiaohongshu/publish.go - 实现原创声明勾选逻辑
功能说明：

发布小红书图文时，支持通过 is_original=true 参数声明原创。流程如下：

查找页面上的"原创声明"开关并点击
弹出确认弹窗后，勾选"我已阅读并同意《原创声明须知》"
点击"声明原创"按钮完成声明
使用示例：

json
应用
{
  "title": "标题",
  "content": "正文内容",
  "images": ["/path/to/image.jpg"],
  "is_original": true
}
注意事项：

该参数为可选参数，默认为 false，不影响现有功能
原创声明失败时仅记录警告日志，不中断发布流程