### PR TITLE
docs: add WSL troubleshooting for login/cookies and hanging requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,7 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 
 1. 在 Windows 中先运行 `xiaohongshu-login-windows-amd64.exe` 完成登录。
 2. 把 Windows 生成的 `cookies.json` 复制到 WSL 的 `bin` 目录，并重启 Linux 版 MCP：
+   - 下面命令里的 `~/.openclaw/workspace/skills/xiaohongshu-mcp/bin` 是 OpenClaw 默认路径；如果你是手动部署，请替换成你自己的 `xiaohongshu-mcp/bin` 目录。
 
 ```bash
 cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status

--- a/README.md
+++ b/README.md
@@ -768,6 +768,28 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 
 ---
 
+**Q:** 在 WSL（无 GUI）里运行 `xiaohongshu-login-linux-amd64` 报 `Missing X server or $DISPLAY` 怎么办？
+**A:** `xiaohongshu-login-linux-amd64` 需要图形界面，纯 WSL 终端环境会失败。推荐使用“Windows 登录 + WSL 复用 cookies”的方式：
+
+1. 在 Windows 中先运行 `xiaohongshu-login-windows-amd64.exe` 完成登录。
+2. 把 Windows 生成的 `cookies.json` 复制到 WSL 的 `bin` 目录，并重启 Linux 版 MCP：
+
+```bash
+cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
+```
+
+---
+
+**Q:** 在 WSL 里 `search_feeds` / `publish_content` 长时间无返回怎么办？
+**A:** 常见是登录态缺失或 Chromium 运行依赖不完整，排查步骤如下：
+
+1. 先检查登录状态：`GET /api/v1/login/status`，确认 `is_logged_in=true`。
+2. 若日志出现 `libnss3.so` 缺失，安装依赖后重启服务：
+   - `sudo apt-get update && sudo apt-get install -y libnss3 libnspr4 libgbm1 libgtk-3-0 libx11-xcb1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libasound2t64 libatk1.0-0 libcups2 libxkbcommon0 libxshmfence1 fonts-liberation xdg-utils`
+3. 重试 `search_feeds` / `publish_content`，并查看 `bin/mcp.log` 中对应请求的耗时与报错。
+
+---
+
 **Q:** 在设备上运行 MCP 程序出现闪退如何解决？
 **A:**
 

--- a/README.md
+++ b/README.md
@@ -769,25 +769,17 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 ---
 
 **Q:** 在 WSL（无 GUI）里运行 `xiaohongshu-login-linux-amd64` 报 `Missing X server or $DISPLAY` 怎么办？
-**A:** `xiaohongshu-login-linux-amd64` 需要图形界面，纯 WSL 终端环境会失败。推荐使用“Windows 登录 + WSL 复用 cookies”的方式：
-
-1. 在 Windows 中先运行 `xiaohongshu-login-windows-amd64.exe` 完成登录。
-2. 把 Windows 生成的 `cookies.json` 复制到 WSL 的 `bin` 目录，并重启 Linux 版 MCP：
-   - 下面命令里的 `~/.openclaw/workspace/skills/xiaohongshu-mcp/bin` 是 OpenClaw 默认路径；如果你是手动部署，请替换成你自己的 `xiaohongshu-mcp/bin` 目录。
-
-```bash
-cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
-```
+**A:** `xiaohongshu-login-linux-amd64` 需要图形界面。请先为 WSL 配置 GUI 支持（如 WSLg）后再运行登录工具；纯终端环境无法完成扫码登录。
 
 ---
 
 **Q:** 在 WSL 里 `search_feeds` / `publish_content` 长时间无返回怎么办？
-**A:** 常见是登录态缺失或 Chromium 运行依赖不完整，排查步骤如下：
+**A:** 常见原因是登录态缺失或 Chromium 运行依赖未满足，建议按以下顺序排查：
 
 1. 先检查登录状态：`GET /api/v1/login/status`，确认 `is_logged_in=true`。
-2. 若日志出现 `libnss3.so` 缺失，安装依赖后重启服务：
-   - `sudo apt-get update && sudo apt-get install -y libnss3 libnspr4 libgbm1 libgtk-3-0 libx11-xcb1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libasound2t64 libatk1.0-0 libcups2 libxkbcommon0 libxshmfence1 fonts-liberation xdg-utils`
-3. 重试 `search_feeds` / `publish_content`，并查看 `bin/mcp.log` 中对应请求的耗时与报错。
+2. 若日志出现 Chromium 依赖相关错误（如缺少系统库），请按 go-rod 官方文档补齐 Linux 依赖：
+   - https://go-rod.github.io/#/compatibility?id=linux
+3. 重启 MCP 后重试，并查看 `bin/mcp.log` 中对应请求的耗时与报错。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -771,6 +771,14 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 **Q:** 在 WSL（无 GUI）里运行 `xiaohongshu-login-linux-amd64` 报 `Missing X server or $DISPLAY` 怎么办？
 **A:** `xiaohongshu-login-linux-amd64` 需要图形界面。请先为 WSL 配置 GUI 支持（如 WSLg）后再运行登录工具；纯终端环境无法完成扫码登录。
 
+如果你暂时不启用 WSL GUI，也可以用精简的 cookies 复用方式（可选）：
+1. 先在 Windows 运行 `xiaohongshu-login-windows-amd64.exe` 完成登录。
+2. 在 WSL 将该 `cookies.json` 拷到 Linux 版 MCP 的 `bin` 目录后重启服务：
+
+```bash
+cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true && nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
+```
+
 ---
 
 **Q:** 在 WSL 里 `search_feeds` / `publish_content` 长时间无返回怎么办？

--- a/README_EN.md
+++ b/README_EN.md
@@ -771,6 +771,7 @@ Use xiaohongshu-mcp's video publishing feature.
 
 1. Run `xiaohongshu-login-windows-amd64.exe` on Windows and complete login.
 2. Copy `cookies.json` from Windows to WSL `bin` and restart Linux MCP:
+   - In the command below, `~/.openclaw/workspace/skills/xiaohongshu-mcp/bin` is the OpenClaw default path. If you deployed manually, replace it with your own `xiaohongshu-mcp/bin` path.
 
 ```bash
 cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status

--- a/README_EN.md
+++ b/README_EN.md
@@ -766,6 +766,28 @@ Use xiaohongshu-mcp's video publishing feature.
 
 ---
 
+**Q:** Running `xiaohongshu-login-linux-amd64` in WSL (without GUI) returns `Missing X server or $DISPLAY`. What should I do?
+**A:** `xiaohongshu-login-linux-amd64` requires a graphical environment, so it fails in headless WSL terminals. Recommended flow: login on Windows, then reuse cookies in WSL:
+
+1. Run `xiaohongshu-login-windows-amd64.exe` on Windows and complete login.
+2. Copy `cookies.json` from Windows to WSL `bin` and restart Linux MCP:
+
+```bash
+cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
+```
+
+---
+
+**Q:** `search_feeds` / `publish_content` hangs for a long time on WSL. How to troubleshoot?
+**A:** Most cases are caused by missing login state or incomplete Chromium runtime dependencies:
+
+1. Check login status first: `GET /api/v1/login/status` and ensure `is_logged_in=true`.
+2. If logs show missing `libnss3.so`, install dependencies and restart MCP:
+   - `sudo apt-get update && sudo apt-get install -y libnss3 libnspr4 libgbm1 libgtk-3-0 libx11-xcb1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libasound2t64 libatk1.0-0 libcups2 libxkbcommon0 libxshmfence1 fonts-liberation xdg-utils`
+3. Retry `search_feeds` / `publish_content` and inspect request timing/errors in `bin/mcp.log`.
+
+---
+
 **Q:** The MCP program crashes on my device, how to resolve?
 **A:**
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -769,6 +769,14 @@ Use xiaohongshu-mcp's video publishing feature.
 **Q:** Running `xiaohongshu-login-linux-amd64` in WSL (without GUI) returns `Missing X server or $DISPLAY`. What should I do?
 **A:** `xiaohongshu-login-linux-amd64` requires a graphical environment. Configure GUI support for WSL first (for example, WSLg), then run the login tool. A headless terminal-only WSL session cannot complete QR login.
 
+If you do not want to enable WSL GUI yet, you can also use a minimal cookie-reuse flow (optional):
+1. Run `xiaohongshu-login-windows-amd64.exe` on Windows and finish login.
+2. In WSL, copy that `cookies.json` into the Linux MCP `bin` directory, then restart:
+
+```bash
+cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true && nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
+```
+
 ---
 
 **Q:** `search_feeds` / `publish_content` hangs for a long time on WSL. How to troubleshoot?

--- a/README_EN.md
+++ b/README_EN.md
@@ -767,25 +767,17 @@ Use xiaohongshu-mcp's video publishing feature.
 ---
 
 **Q:** Running `xiaohongshu-login-linux-amd64` in WSL (without GUI) returns `Missing X server or $DISPLAY`. What should I do?
-**A:** `xiaohongshu-login-linux-amd64` requires a graphical environment, so it fails in headless WSL terminals. Recommended flow: login on Windows, then reuse cookies in WSL:
-
-1. Run `xiaohongshu-login-windows-amd64.exe` on Windows and complete login.
-2. Copy `cookies.json` from Windows to WSL `bin` and restart Linux MCP:
-   - In the command below, `~/.openclaw/workspace/skills/xiaohongshu-mcp/bin` is the OpenClaw default path. If you deployed manually, replace it with your own `xiaohongshu-mcp/bin` path.
-
-```bash
-cd ~/.openclaw/workspace/skills/xiaohongshu-mcp/bin && cp -f /mnt/c/Users/<your-user>/.openclaw/workspace/skills/xiaohongshu-mcp/bin/cookies.json ./cookies.json && (pkill -f xiaohongshu-mcp-linux-amd64 2>/dev/null || true) && { nohup ./xiaohongshu-mcp-linux-amd64 > mcp.log 2>&1 & } && sleep 3 && curl -sS http://127.0.0.1:18060/api/v1/login/status
-```
+**A:** `xiaohongshu-login-linux-amd64` requires a graphical environment. Configure GUI support for WSL first (for example, WSLg), then run the login tool. A headless terminal-only WSL session cannot complete QR login.
 
 ---
 
 **Q:** `search_feeds` / `publish_content` hangs for a long time on WSL. How to troubleshoot?
-**A:** Most cases are caused by missing login state or incomplete Chromium runtime dependencies:
+**A:** The usual causes are missing login state or unmet Chromium runtime dependencies:
 
 1. Check login status first: `GET /api/v1/login/status` and ensure `is_logged_in=true`.
-2. If logs show missing `libnss3.so`, install dependencies and restart MCP:
-   - `sudo apt-get update && sudo apt-get install -y libnss3 libnspr4 libgbm1 libgtk-3-0 libx11-xcb1 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libasound2t64 libatk1.0-0 libcups2 libxkbcommon0 libxshmfence1 fonts-liberation xdg-utils`
-3. Retry `search_feeds` / `publish_content` and inspect request timing/errors in `bin/mcp.log`.
+2. If logs show Chromium dependency errors (missing system libs), follow the go-rod Linux compatibility guide:
+   - https://go-rod.github.io/#/compatibility?id=linux
+3. Restart MCP, retry, and inspect request timing/errors in `bin/mcp.log`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add WSL FAQ entry for `xiaohongshu-login-linux-amd64` failing with `Missing X server or $DISPLAY` in headless environments
- document Windows-login + WSL-cookie-reuse workflow with a one-line recovery command
- add WSL troubleshooting steps for long-running/hanging `search_feeds` and `publish_content` requests
- include required Chromium runtime dependencies when `libnss3.so` is missing

## Files
- README.md
- README_EN.md

## Why
These issues were reproduced in real WSL deployments and caused common "no response" symptoms even when MCP itself was running. This PR adds direct, actionable troubleshooting to reduce repeated setup failures.
