### PR TITLE
chore: 更新 headless_browser 至 v0.3.0 并补充代理文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,20 @@ go run .
 go run . -headless=false
 ```
 
+**配置代理（可选）**：
+
+如果需要通过代理访问，可以设置 `XHS_PROXY` 环境变量：
+
+```bash
+# 设置代理后启动
+XHS_PROXY=http://user:pass@proxy:port ./xiaohongshu-mcp-darwin-arm64
+
+# 或使用源码
+XHS_PROXY=http://proxy:port go run .
+```
+
+支持 HTTP/HTTPS/SOCKS5 代理，日志中会自动隐藏代理的认证信息。
+
 ## 1.4. 验证 MCP
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -92,7 +92,34 @@ docker compose pull && docker compose up -d
 
 <img width="1662" height="458" alt="image" src="https://github.com/user-attachments/assets/309c2dab-51c4-4502-a41b-cdd4a3dd57ac" />
 
-## 4. 扫码登录
+## 4. 配置代理（可选）
+
+如果需要通过代理访问小红书，可以通过 `XHS_PROXY` 环境变量配置。
+
+### 使用 docker run
+
+```bash
+docker run -e XHS_PROXY=http://user:pass@proxy:port xpzouying/xiaohongshu-mcp
+```
+
+### 使用 docker-compose
+
+在 `docker-compose.yml` 的 `environment` 中添加 `XHS_PROXY`：
+
+```yaml
+environment:
+  - ROD_BROWSER_BIN=/usr/bin/google-chrome
+  - COOKIES_PATH=/app/data/cookies.json
+  - XHS_PROXY=http://user:pass@proxy:port
+```
+
+支持 HTTP/HTTPS/SOCKS5 代理。日志中会自动隐藏代理的认证信息，输出示例：
+
+```
+Using proxy: http://***:***@proxy:port
+```
+
+## 5. 扫码登录
 
 1. **重要**，一定要先把 App 提前打开，准备扫码登录。
 2. 尽快扫码，有可能二维码会过期。

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
-	github.com/xpzouying/headless_browser v0.2.0
+	github.com/xpzouying/headless_browser v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/xpzouying/headless_browser v0.2.0 h1:EmuHXDVzx0tAevHJUdETs8iT/eK+QqrLiybvGd1xZDA=
 github.com/xpzouying/headless_browser v0.2.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
+github.com/xpzouying/headless_browser v0.3.0 h1:ila/Kmei1dvBbP71SXEQuWfLuvjCw5HMqsgOzK39xn0=
+github.com/xpzouying/headless_browser v0.3.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/ysmood/fetchup v0.2.3 h1:ulX+SonA0Vma5zUFXtv52Kzip/xe7aj4vqT5AJwQ+ZQ=


### PR DESCRIPTION
## Summary

- 升级 `headless_browser` 依赖 `v0.2.0` → `v0.3.0`，使 PR #461 引入的 `WithProxy` 功能可正常编译
- 在 README 启动说明中补充 `XHS_PROXY` 环境变量用法
- 在 `docker/README.md` 中补充 `docker run` 和 `docker-compose` 两种代理配置方式

## Test plan

- [x] `go build ./...` 编译通过
- [ ] 设置 `XHS_PROXY` 环境变量后启动，确认日志输出脱敏的代理地址

🤖 Generated with [Claude Code](https://claude.com/claude-code)