### PR TITLE
fix: browser robustness improvements — singleton pool, headless-new, reply & search fixes

### DIFF
--- a/browser_pool.go
+++ b/browser_pool.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/go-rod/stealth"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
+	"github.com/xpzouying/xiaohongshu-mcp/cookies"
+)
+
+// browserPool 全局浏览器单例，避免每次工具调用都创建新 Chromium 实例
+var browserPool = &BrowserPool{}
+
+// BrowserPool 管理共享的 rod.Browser 实例
+type BrowserPool struct {
+	mu       sync.Mutex
+	browser  *rod.Browser
+	launcher *launcher.Launcher
+}
+
+// GetPage 获取一个新的 stealth page（复用全局 Browser）
+func (bp *BrowserPool) GetPage() (*rod.Page, error) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+
+	if err := bp.ensureBrowser(); err != nil {
+		return nil, fmt.Errorf("获取浏览器失败: %w", err)
+	}
+
+	page, err := stealth.Page(bp.browser)
+	if err != nil {
+		// 浏览器可能已崩溃，重建
+		logrus.Warnf("创建页面失败，尝试重建浏览器: %v", err)
+		bp.closeLocked()
+		if err2 := bp.ensureBrowser(); err2 != nil {
+			return nil, fmt.Errorf("重建浏览器失败: %w", err2)
+		}
+		page, err = stealth.Page(bp.browser)
+		if err != nil {
+			return nil, fmt.Errorf("重建后仍无法创建页面: %w", err)
+		}
+	}
+
+	return page, nil
+}
+
+// ensureBrowser 确保全局 Browser 存在（必须在持有锁时调用）
+func (bp *BrowserPool) ensureBrowser() error {
+	if bp.browser != nil {
+		// 检查连接是否还活着
+		_, err := bp.browser.Version()
+		if err == nil {
+			return nil
+		}
+		logrus.Warnf("浏览器连接已断开: %v, 准备重建", err)
+		bp.closeLocked()
+	}
+
+	// 清理 SingletonLock
+	rodDir := os.Getenv("ROD_DIR")
+	if rodDir == "" {
+		// 从启动参数中获取 rod dir
+		rodDir = getRodDir()
+	}
+	if rodDir != "" {
+		for _, lock := range []string{
+			filepath.Join(rodDir, "SingletonLock"),
+			filepath.Join(rodDir, "Default", "SingletonLock"),
+		} {
+			os.Remove(lock)
+		}
+	}
+
+	// 创建 launcher，根据 headless 模式选择启动方式
+	l := launcher.New()
+	switch configs.GetHeadlessMode() {
+	case configs.HeadlessNew:
+		l = l.HeadlessNew(true)
+	case configs.HeadlessOld:
+		l = l.Headless(true)
+	default: // HeadlessOff — 有窗口模式
+		l = l.Headless(false)
+	}
+	l = l.Set("--no-sandbox").
+		Set("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
+
+	binPath := configs.GetBinPath()
+	if binPath != "" {
+		l = l.Bin(binPath)
+	}
+
+	u, err := l.Launch()
+	if err != nil {
+		return fmt.Errorf("启动浏览器失败: %w", err)
+	}
+
+	b := rod.New().ControlURL(u)
+	if err := b.Connect(); err != nil {
+		l.Cleanup()
+		return fmt.Errorf("连接浏览器失败: %w", err)
+	}
+
+	// 加载 cookies
+	cookiePath := cookies.GetCookiesFilePath()
+	cookieLoader := cookies.NewLoadCookie(cookiePath)
+	if data, err := cookieLoader.LoadCookies(); err == nil {
+		var cks []*proto.NetworkCookie
+		if err := json.Unmarshal(data, &cks); err != nil {
+			logrus.Warnf("解析 cookies 失败: %v", err)
+		} else {
+			if err := b.SetCookies(toNetworkCookieParams(cks)); err != nil {
+				logrus.Warnf("设置 cookies 失败: %v", err)
+			}
+		}
+	} else {
+		logrus.Warnf("加载 cookies 失败: %v", err)
+	}
+
+	bp.browser = b
+	bp.launcher = l
+	logrus.Info("全局浏览器实例已创建")
+	return nil
+}
+
+// closeLocked 关闭浏览器（必须在持有锁时调用）
+func (bp *BrowserPool) closeLocked() {
+	if bp.browser != nil {
+		_ = bp.browser.Close()
+		bp.browser = nil
+	}
+	if bp.launcher != nil {
+		bp.launcher.Cleanup()
+		bp.launcher = nil
+	}
+}
+
+// Close 关闭全局浏览器
+func (bp *BrowserPool) Close() {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	bp.closeLocked()
+}
+
+// GetBrowser 获取底层 rod.Browser（用于 saveCookies 等操作）
+func (bp *BrowserPool) GetBrowser() *rod.Browser {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	return bp.browser
+}
+
+// toNetworkCookieParams 转换 cookie 格式
+func toNetworkCookieParams(cks []*proto.NetworkCookie) []*proto.NetworkCookieParam {
+	params := make([]*proto.NetworkCookieParam, 0, len(cks))
+	for _, c := range cks {
+		p := &proto.NetworkCookieParam{
+			Name:     c.Name,
+			Value:    c.Value,
+			Domain:   c.Domain,
+			Path:     c.Path,
+			Secure:   c.Secure,
+			HTTPOnly: c.HTTPOnly,
+			SameSite: c.SameSite,
+		}
+		if c.Expires > 0 {
+			expires := proto.TimeSinceEpoch(c.Expires)
+			p.Expires = expires
+		}
+		params = append(params, p)
+	}
+	return params
+}
+
+// getRodDir 从环境中获取 rod profile 目录
+func getRodDir() string {
+	// 优先使用命令行传入的 rod dir（通过 -rod 参数解析）
+	// fallback 到常见位置
+	home, _ := os.UserHomeDir()
+	profileDir := filepath.Join(home, ".mcp", "xiaohongshu", "chromium_profile")
+	if _, err := os.Stat(profileDir); err == nil {
+		return profileDir
+	}
+	return ""
+}

--- a/configs/browser.go
+++ b/configs/browser.go
@@ -1,18 +1,27 @@
 package configs
 
-var (
-	useHeadless = true
+// HeadlessMode 浏览器 headless 模式
+type HeadlessMode string
 
-	binPath = ""
+const (
+	HeadlessOff HeadlessMode = "false" // 有窗口（调试/登录用）
+	HeadlessOld HeadlessMode = "true"  // 旧 headless（易被反爬检测）
+	HeadlessNew HeadlessMode = "new"   // 新 headless（Chrome 112+，推荐）
 )
 
-func InitHeadless(h bool) {
-	useHeadless = h
+var (
+	headlessMode HeadlessMode = HeadlessNew
+	binPath                   = ""
+)
+
+// InitHeadlessMode 设置 headless 模式（"new"/"true"/"false"）
+func InitHeadlessMode(m string) {
+	headlessMode = HeadlessMode(m)
 }
 
-// IsHeadless 是否无头模式。
-func IsHeadless() bool {
-	return useHeadless
+// GetHeadlessMode 获取当前 headless 模式
+func GetHeadlessMode() HeadlessMode {
+	return headlessMode
 }
 
 func SetBinPath(b string) {

--- a/main.go
+++ b/main.go
@@ -10,11 +10,11 @@ import (
 
 func main() {
 	var (
-		headless bool
-		binPath  string // 浏览器二进制文件路径
-		port     string
+		headlessMode string
+		binPath      string // 浏览器二进制文件路径
+		port         string
 	)
-	flag.BoolVar(&headless, "headless", true, "是否无头模式")
+	flag.StringVar(&headlessMode, "headless-mode", "new", "headless模式: new(推荐)/true/false")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
 	flag.Parse()
@@ -23,7 +23,7 @@ func main() {
 		binPath = os.Getenv("ROD_BROWSER_BIN")
 	}
 
-	configs.InitHeadless(headless)
+	configs.InitHeadlessMode(headlessMode)
 	configs.SetBinPath(binPath)
 
 	// 初始化服务

--- a/service.go
+++ b/service.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
-	"github.com/xpzouying/headless_browser"
-	"github.com/xpzouying/xiaohongshu-mcp/browser"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/pkg/downloader"
@@ -97,10 +95,10 @@ func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
 
 // CheckLoginStatus 检查登录状态
 func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatusResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	loginAction := xiaohongshu.NewLogin(page)
@@ -120,12 +118,13 @@ func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatus
 
 // GetLoginQrcode 获取登录的扫码二维码
 func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeResponse, error) {
-	b := newBrowser()
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 
 	deferFunc := func() {
 		_ = page.Close()
-		b.Close()
 	}
 
 	loginAction := xiaohongshu.NewLogin(page)
@@ -238,10 +237,10 @@ func (s *XiaohongshuService) processImages(images []string) ([]string, error) {
 
 // publishContent 执行内容发布
 func (s *XiaohongshuService) publishContent(ctx context.Context, content xiaohongshu.PublishImageContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return err
+	}
 	defer page.Close()
 
 	action, err := xiaohongshu.NewPublishImageAction(page)
@@ -319,10 +318,10 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 
 // publishVideo 执行视频发布
 func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongshu.PublishVideoContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return err
+	}
 	defer page.Close()
 
 	action, err := xiaohongshu.NewPublishVideoAction(page)
@@ -335,10 +334,10 @@ func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongs
 
 // ListFeeds 获取Feeds列表
 func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	// 创建 Feeds 列表 action
@@ -360,10 +359,10 @@ func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse,
 }
 
 func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, filters ...xiaohongshu.FilterOption) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewSearchAction(page)
@@ -388,10 +387,10 @@ func (s *XiaohongshuService) GetFeedDetail(ctx context.Context, feedID, xsecToke
 
 // GetFeedDetailWithConfig 使用配置获取Feed详情
 func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID, xsecToken string, loadAllComments bool, config xiaohongshu.CommentLoadConfig) (*FeedDetailResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	// 创建 Feed 详情 action
@@ -413,10 +412,10 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 
 // UserProfile 获取用户信息
 func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken string) (*UserProfileResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewUserProfileAction(page)
@@ -437,10 +436,10 @@ func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken 
 
 // PostCommentToFeed 发表评论到Feed
 func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsecToken, content string) (*PostCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewCommentFeedAction(page)
@@ -454,10 +453,10 @@ func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsec
 
 // LikeFeed 点赞笔记
 func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewLikeAction(page)
@@ -469,10 +468,10 @@ func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken str
 
 // UnlikeFeed 取消点赞笔记
 func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewLikeAction(page)
@@ -484,10 +483,10 @@ func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken s
 
 // FavoriteFeed 收藏笔记
 func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewFavoriteAction(page)
@@ -499,10 +498,10 @@ func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken
 
 // UnfavoriteFeed 取消收藏笔记
 func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewFavoriteAction(page)
@@ -514,10 +513,10 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 
 // ReplyCommentToFeed 回复指定评论
 func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xsecToken, commentID, userID, content string) (*ReplyCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return nil, err
+	}
 	defer page.Close()
 
 	action := xiaohongshu.NewCommentFeedAction(page)
@@ -533,10 +532,6 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 		Success:         true,
 		Message:         "评论回复成功",
 	}, nil
-}
-
-func newBrowser() *headless_browser.Browser {
-	return browser.NewBrowser(configs.IsHeadless(), browser.WithBinPath(configs.GetBinPath()))
 }
 
 func saveCookies(page *rod.Page) error {
@@ -556,10 +551,10 @@ func saveCookies(page *rod.Page) error {
 
 // withBrowserPage 执行需要浏览器页面的操作的通用函数
 func withBrowserPage(fn func(*rod.Page) error) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page, err := browserPool.GetPage()
+	if err != nil {
+		return err
+	}
 	defer page.Close()
 
 	return fn(page)


### PR DESCRIPTION
## Summary

This PR addresses several stability and robustness issues in the headless browser automation layer:

1. **Browser singleton pool** (`browser_pool.go`): Replace per-call `newBrowser()` with a shared `BrowserPool` that reuses a single `rod.Browser` instance across all tool invocations. Includes automatic reconnection on crash and `SingletonLock` cleanup.

2. **Chrome new headless mode** (`configs/browser.go`, `main.go`): Add support for Chrome 112+ `--headless=new` mode via `-headless-mode` flag (`new`/`true`/`false`). The new headless mode has significantly better anti-detection capabilities compared to the legacy headless.

3. **Reply comment context lifecycle fix** (`xiaohongshu/comment_feed.go`): Fix `context deadline exceeded` errors when replying to comments. Root cause: `findCommentElement()` returns elements bound to a short-timeout context (1s); by the time `clickReplyButton()` operates on them, the context has expired. Fix: confirm existence first, then re-acquire the element using the main page context.

4. **Multi-strategy reply button click** (`xiaohongshu/comment_feed.go`): New `clickReplyButton()` function with 3 fallback strategies — CSS selectors, JS text search ("回复"), and comment text click — to handle DOM structure variations.

5. **Homepage warm-up navigation** (`xiaohongshu/comment_feed.go`, `xiaohongshu/search.go`): Navigate to `xiaohongshu.com` homepage first before accessing detail/search pages. This establishes a proper browsing session and avoids `error_code 300031` (direct URL access blocked without referrer).

6. **Interaction robustness** (`xiaohongshu/like_favorite.go`): Replace `MustElement`/`MustClick` with error-handling `Element`/`Click` in `performClick()`. Update like/favorite selectors to `.like-wrapper`/`.collect-wrapper`.

7. **Search timeout fix** (`xiaohongshu/search.go`): Replace `MustWaitStable()` + `MustWait(__INITIAL_STATE__)` with `MustWaitDOMStable()` + `time.Sleep()` to avoid hanging on pages where `__INITIAL_STATE__` is set asynchronously.

## Files Changed

| File | Change |
|------|--------|
| `browser_pool.go` | New — browser singleton pool with auto-reconnect |
| `configs/browser.go` | `HeadlessMode` enum replacing `bool` |
| `main.go` | `-headless-mode` string flag replacing `-headless` bool |
| `service.go` | All methods use `browserPool.GetPage()` instead of `newBrowser()` |
| `xiaohongshu/comment_feed.go` | Context lifecycle fix, multi-strategy reply, homepage warm-up |
| `xiaohongshu/like_favorite.go` | Error-handling click, updated selectors |
| `xiaohongshu/search.go` | Homepage warm-up, stable wait fix |

## Breaking Changes

- CLI flag changed: `-headless` (bool) → `-headless-mode` (string, default: `"new"`)
  - Migration: `-headless=true` → `-headless-mode=true`, `-headless=false` → `-headless-mode=false`

## Test Plan

- [x] `search_feeds` — returns results without timeout
- [x] `reply_comment_in_feed` — successfully replies to comments (verified via `get_feed_detail`)
- [x] `list_feeds` — continues to work as before
- [x] `post_comment_to_feed` — comment posting with retry and verification
- [x] `like_feed` / `favorite_feed` — graceful error handling on click failure