### PR TITLE
feat: support favorites, categories, and category-based retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ test_*.sh
 
 # Cookies files (contain sensitive login information)
 cookies.json
+
+# Local runtime state
+.run/

--- a/README.md
+++ b/README.md
@@ -714,6 +714,8 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
   - `video`: 仅支持本地视频文件绝对路径
 - `list_feeds` - 获取小红书首页推荐列表（无参数）
 - `list_favorite_feeds` - 获取当前登录用户收藏笔记列表（无参数）
+- `list_favorite_categories` - 获取当前登录用户收藏专辑分类列表（无参数）
+- `list_favorite_feeds_by_category` - 按收藏分类获取笔记列表（可传：category_id/category_name/limit）
 - `search_feeds` - 搜索小红书内容（需要：keyword）
 - `get_feed_detail` - 获取帖子详情（需要：feed_id, xsec_token）
 - `post_comment_to_feed` - 发表评论到小红书帖子（需要：feed_id, xsec_token, content）

--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ Cline 是一个强大的 AI 编程助手，支持 MCP 协议集成。
 - `publish_with_video` - 发布视频内容到小红书（必需：title, content, video）
   - `video`: 仅支持本地视频文件绝对路径
 - `list_feeds` - 获取小红书首页推荐列表（无参数）
+- `list_favorite_feeds` - 获取当前登录用户收藏笔记列表（无参数）
 - `search_feeds` - 搜索小红书内容（需要：keyword）
 - `get_feed_detail` - 获取帖子详情（需要：feed_id, xsec_token）
 - `post_comment_to_feed` - 发表评论到小红书帖子（需要：feed_id, xsec_token, content）

--- a/README_EN.md
+++ b/README_EN.md
@@ -699,6 +699,7 @@ After successful connection, you can use the following MCP tools:
 - `publish_with_video` - Publish video content to RedNote (required: title, content, video)
   - `video`: Only supports local video file absolute paths
 - `list_feeds` - Get RedNote homepage recommendation list (no parameters)
+- `list_favorite_feeds` - Get current logged-in user's favorite notes list (no parameters)
 - `search_feeds` - Search RedNote content (required: keyword)
 - `get_feed_detail` - Get post details (required: feed_id, xsec_token)
 - `post_comment_to_feed` - Post comments to RedNote posts (required: feed_id, xsec_token, content)

--- a/README_EN.md
+++ b/README_EN.md
@@ -700,6 +700,8 @@ After successful connection, you can use the following MCP tools:
   - `video`: Only supports local video file absolute paths
 - `list_feeds` - Get RedNote homepage recommendation list (no parameters)
 - `list_favorite_feeds` - Get current logged-in user's favorite notes list (no parameters)
+- `list_favorite_categories` - Get favorite album categories for current logged-in user (no parameters)
+- `list_favorite_feeds_by_category` - Get favorite notes by category (optional: category_id/category_name/limit)
 - `search_feeds` - Search RedNote content (required: keyword)
 - `get_feed_detail` - Get post details (required: feed_id, xsec_token)
 - `post_comment_to_feed` - Post comments to RedNote posts (required: feed_id, xsec_token, content)

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,8 @@
 | POST | `/api/v1/publish_video` | 发布视频内容 |
 | GET | `/api/v1/feeds/list` | 获取 Feeds 列表 |
 | GET | `/api/v1/feeds/favorites` | 获取收藏列表 |
+| GET | `/api/v1/feeds/favorite_categories` | 获取收藏分类列表 |
+| POST | `/api/v1/feeds/favorites/by_category` | 按分类获取收藏列表 |
 | GET/POST | `/api/v1/feeds/search` | 搜索 Feeds |
 | POST | `/api/v1/feeds/detail` | 获取 Feed 详情 |
 | POST | `/api/v1/user/profile` | 获取用户主页信息 |
@@ -840,6 +842,76 @@ Content-Type: application/json
 
 ---
 
+#### 4.5 获取收藏分类列表
+
+获取当前登录用户收藏下的专辑分类（board）列表。
+
+**请求**
+```
+GET /api/v1/feeds/favorite_categories
+```
+
+**响应**
+```json
+{
+  "success": true,
+  "data": {
+    "categories": [
+      {
+        "id": "663b6e90000000001c019d29",
+        "name": "Trip",
+        "noteCount": 44,
+        "url": "https://www.xiaohongshu.com/board/663b6e90000000001c019d29?source=web_user_page"
+      }
+    ],
+    "count": 12
+  },
+  "message": "获取收藏分类成功"
+}
+```
+
+#### 4.6 按分类获取收藏列表
+
+按分类 ID 或名称获取该分类下的收藏笔记列表。
+
+**请求**
+```
+POST /api/v1/feeds/favorites/by_category
+Content-Type: application/json
+```
+
+**请求体**
+```json
+{
+  "category_id": "663b6e90000000001c019d29",
+  "category_name": "Trip",
+  "limit": 20
+}
+```
+
+**请求参数说明:**
+- `category_id` (string, optional): 分类 ID，优先匹配
+- `category_name` (string, optional): 分类名称（当 category_id 为空时按名称匹配）
+- `limit` (int, optional): 返回数量上限，不填表示不限制
+
+**响应**
+```json
+{
+  "success": true,
+  "data": {
+    "category": {
+      "id": "663b6e90000000001c019d29",
+      "name": "Trip",
+      "noteCount": 44,
+      "url": "https://www.xiaohongshu.com/board/663b6e90000000001c019d29?source=web_user_page"
+    },
+    "feeds": [],
+    "count": 0
+  },
+  "message": "按分类获取收藏列表成功"
+}
+```
+
 ## 错误代码
 
 所有 API 在发生错误时会返回统一格式的错误响应。以下是可能出现的错误代码：
@@ -854,6 +926,8 @@ Content-Type: application/json
 | `PUBLISH_VIDEO_FAILED` | 500 | 发布视频内容失败 |
 | `LIST_FEEDS_FAILED` | 500 | 获取 Feeds 列表失败 |
 | `LIST_FAVORITE_FEEDS_FAILED` | 500 | 获取收藏列表失败 |
+| `LIST_FAVORITE_CATEGORIES_FAILED` | 500 | 获取收藏分类失败 |
+| `LIST_FAVORITE_FEEDS_BY_CATEGORY_FAILED` | 500 | 按分类获取收藏列表失败 |
 | `SEARCH_FEEDS_FAILED` | 500 | 搜索 Feeds 失败 |
 | `GET_FEED_DETAIL_FAILED` | 500 | 获取 Feed 详情失败 |
 | `GET_USER_PROFILE_FAILED` | 500 | 获取用户主页信息失败 |

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,6 +41,7 @@
 | POST | `/api/v1/publish` | 发布图文内容 |
 | POST | `/api/v1/publish_video` | 发布视频内容 |
 | GET | `/api/v1/feeds/list` | 获取 Feeds 列表 |
+| GET | `/api/v1/feeds/favorites` | 获取收藏列表 |
 | GET/POST | `/api/v1/feeds/search` | 搜索 Feeds |
 | POST | `/api/v1/feeds/detail` | 获取 Feed 详情 |
 | POST | `/api/v1/user/profile` | 获取用户主页信息 |
@@ -331,7 +332,52 @@ GET /api/v1/feeds/list
   - `sharedCount`: 分享数
 ```
 
-#### 4.2 搜索 Feeds
+#### 4.2 获取收藏列表
+
+获取当前登录用户的收藏笔记列表。
+
+**请求**
+```
+GET /api/v1/feeds/favorites
+```
+
+**响应**
+```json
+{
+  "success": true,
+  "data": {
+    "feeds": [
+      {
+        "xsecToken": "security_token_value",
+        "id": "feed_id_1",
+        "modelType": "note",
+        "noteCard": {
+          "type": "normal",
+          "displayTitle": "收藏笔记标题",
+          "interactInfo": {
+            "liked": false,
+            "likedCount": "120",
+            "collected": true,
+            "collectedCount": "88",
+            "commentCount": "16",
+            "sharedCount": "4"
+          }
+        },
+        "index": 0
+      }
+    ],
+    "count": 12
+  },
+  "message": "获取收藏列表成功"
+}
+```
+
+**响应字段说明:**
+- 响应结构与"获取 Feeds 列表"接口相同
+- 若账号暂无收藏内容，`feeds` 可能为空数组，`count` 为 `0`
+```
+
+#### 4.3 搜索 Feeds
 
 根据关键词搜索 Feeds，支持 GET 和 POST 两种请求方式。
 
@@ -418,7 +464,7 @@ Content-Type: application/json
 - `video`: 视频笔记时有此字段，图文笔记为 null
 ```
 
-#### 4.3 获取 Feed 详情
+#### 4.4 获取 Feed 详情
 
 获取指定 Feed 的详细信息，支持加载全部评论和自定义评论加载配置。
 
@@ -807,6 +853,7 @@ Content-Type: application/json
 | `PUBLISH_FAILED` | 500 | 发布图文内容失败 |
 | `PUBLISH_VIDEO_FAILED` | 500 | 发布视频内容失败 |
 | `LIST_FEEDS_FAILED` | 500 | 获取 Feeds 列表失败 |
+| `LIST_FAVORITE_FEEDS_FAILED` | 500 | 获取收藏列表失败 |
 | `SEARCH_FEEDS_FAILED` | 500 | 搜索 Feeds 失败 |
 | `GET_FEED_DETAIL_FAILED` | 500 | 获取 Feed 详情失败 |
 | `GET_USER_PROFILE_FAILED` | 500 | 获取用户主页信息失败 |

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -147,6 +147,39 @@ func (s *AppServer) listFavoriteFeedsHandler(c *gin.Context) {
 	respondSuccess(c, result, "获取收藏列表成功")
 }
 
+// listFavoriteCategoriesHandler 获取收藏分类列表
+func (s *AppServer) listFavoriteCategoriesHandler(c *gin.Context) {
+	result, err := s.xiaohongshuService.ListFavoriteCategories(c.Request.Context())
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "LIST_FAVORITE_CATEGORIES_FAILED",
+			"获取收藏分类失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "获取收藏分类成功")
+}
+
+// listFavoriteFeedsByCategoryHandler 按收藏分类获取笔记
+func (s *AppServer) listFavoriteFeedsByCategoryHandler(c *gin.Context) {
+	var req FavoriteFeedsByCategoryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	result, err := s.xiaohongshuService.ListFavoriteFeedsByCategory(c.Request.Context(), req.CategoryID, req.CategoryName, req.Limit)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "LIST_FAVORITE_FEEDS_BY_CATEGORY_FAILED",
+			"按分类获取收藏列表失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "按分类获取收藏列表成功")
+}
+
 // searchFeedsHandler 搜索Feeds
 func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 	var keyword string

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -134,6 +134,19 @@ func (s *AppServer) listFeedsHandler(c *gin.Context) {
 	respondSuccess(c, result, "获取Feeds列表成功")
 }
 
+// listFavoriteFeedsHandler 获取收藏列表
+func (s *AppServer) listFavoriteFeedsHandler(c *gin.Context) {
+	result, err := s.xiaohongshuService.ListFavoriteFeeds(c.Request.Context())
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "LIST_FAVORITE_FEEDS_FAILED",
+			"获取收藏列表失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "获取收藏列表成功")
+}
+
 // searchFeedsHandler 搜索Feeds
 func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 	var keyword string

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -317,6 +317,74 @@ func (s *AppServer) handleListFavoriteFeeds(ctx context.Context) *MCPToolResult 
 	}
 }
 
+// handleListFavoriteCategories 处理获取收藏分类
+func (s *AppServer) handleListFavoriteCategories(ctx context.Context) *MCPToolResult {
+	logrus.Info("MCP: 获取收藏分类")
+
+	result, err := s.xiaohongshuService.ListFavoriteCategories(ctx)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "获取收藏分类失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("获取收藏分类成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
+// handleListFavoriteFeedsByCategory 处理按分类获取收藏笔记
+func (s *AppServer) handleListFavoriteFeedsByCategory(ctx context.Context, args FavoriteFeedsByCategoryArgs) *MCPToolResult {
+	logrus.Infof("MCP: 按分类获取收藏笔记 - category_id=%s category_name=%s limit=%d", args.CategoryID, args.CategoryName, args.Limit)
+
+	result, err := s.xiaohongshuService.ListFavoriteFeedsByCategory(ctx, args.CategoryID, args.CategoryName, args.Limit)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "按分类获取收藏笔记失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("按分类获取收藏笔记成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleSearchFeeds 处理搜索Feeds
 func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs) *MCPToolResult {
 	logrus.Info("MCP: 搜索Feeds")

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -283,6 +283,40 @@ func (s *AppServer) handleListFeeds(ctx context.Context) *MCPToolResult {
 	}
 }
 
+// handleListFavoriteFeeds 处理获取收藏列表
+func (s *AppServer) handleListFavoriteFeeds(ctx context.Context) *MCPToolResult {
+	logrus.Info("MCP: 获取收藏列表")
+
+	result, err := s.xiaohongshuService.ListFavoriteFeeds(ctx)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "获取收藏列表失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("获取收藏列表成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleSearchFeeds 处理搜索Feeds
 func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs) *MCPToolResult {
 	logrus.Info("MCP: 搜索Feeds")

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -98,6 +98,13 @@ type FavoriteFeedArgs struct {
 	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
+// FavoriteFeedsByCategoryArgs 按分类获取收藏
+type FavoriteFeedsByCategoryArgs struct {
+	CategoryID   string `json:"category_id,omitempty" jsonschema:"收藏分类ID（专辑ID），优先匹配此参数"`
+	CategoryName string `json:"category_name,omitempty" jsonschema:"收藏分类名称（当 category_id 为空时按名称匹配）"`
+	Limit        int    `json:"limit,omitempty" jsonschema:"返回笔记数量上限，默认不限制"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -257,7 +264,39 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 7: 搜索内容
+	// 工具 7: 获取收藏分类
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "list_favorite_categories",
+			Description: "获取当前登录用户收藏下的专辑分类列表",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Favorite Categories",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("list_favorite_categories", func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleListFavoriteCategories(ctx)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 8: 按分类获取收藏笔记
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "list_favorite_feeds_by_category",
+			Description: "按收藏专辑分类获取笔记列表（支持按分类ID或名称过滤）",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Favorite Feeds By Category",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("list_favorite_feeds_by_category", func(ctx context.Context, req *mcp.CallToolRequest, args FavoriteFeedsByCategoryArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleListFavoriteFeedsByCategory(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 9: 搜索内容
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "search_feeds",
@@ -273,7 +312,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 8: 获取Feed详情
+	// 工具 10: 获取Feed详情
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
@@ -318,7 +357,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 9: 获取用户主页
+	// 工具 11: 获取用户主页
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "user_profile",
@@ -338,7 +377,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 10: 发表评论
+	// 工具 12: 发表评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "post_comment_to_feed",
@@ -359,7 +398,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 11: 回复评论
+	// 工具 13: 回复评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "reply_comment_in_feed",
@@ -389,7 +428,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	// 工具 12: 发布视频（仅本地文件）
+	// 工具 14: 发布视频（仅本地文件）
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "publish_with_video",
@@ -413,7 +452,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 13: 点赞笔记
+	// 工具 15: 点赞笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "like_feed",
@@ -434,7 +473,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 14: 收藏笔记
+	// 工具 16: 收藏笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "favorite_feed",
@@ -455,7 +494,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 14)
+	logrus.Infof("Registered %d MCP tools", 16)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -241,7 +241,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 6: 搜索内容
+	// 工具 6: 获取收藏列表
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "list_favorite_feeds",
+			Description: "获取当前登录用户的收藏笔记列表",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Favorite Feeds",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("list_favorite_feeds", func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleListFavoriteFeeds(ctx)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 7: 搜索内容
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "search_feeds",
@@ -257,7 +273,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 7: 获取Feed详情
+	// 工具 8: 获取Feed详情
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
@@ -302,7 +318,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 8: 获取用户主页
+	// 工具 9: 获取用户主页
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "user_profile",
@@ -322,7 +338,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 9: 发表评论
+	// 工具 10: 发表评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "post_comment_to_feed",
@@ -343,7 +359,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 10: 回复评论
+	// 工具 11: 回复评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "reply_comment_in_feed",
@@ -373,7 +389,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	// 工具 11: 发布视频（仅本地文件）
+	// 工具 12: 发布视频（仅本地文件）
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "publish_with_video",
@@ -397,7 +413,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 12: 点赞笔记
+	// 工具 13: 点赞笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "like_feed",
@@ -418,7 +434,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 13: 收藏笔记
+	// 工具 14: 收藏笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "favorite_feed",
@@ -439,7 +455,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/routes.go
+++ b/routes.go
@@ -45,6 +45,8 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.POST("/publish_video", appServer.publishVideoHandler)
 		api.GET("/feeds/list", appServer.listFeedsHandler)
 		api.GET("/feeds/favorites", appServer.listFavoriteFeedsHandler)
+		api.GET("/feeds/favorite_categories", appServer.listFavoriteCategoriesHandler)
+		api.POST("/feeds/favorites/by_category", appServer.listFavoriteFeedsByCategoryHandler)
 		api.GET("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/detail", appServer.getFeedDetailHandler)

--- a/routes.go
+++ b/routes.go
@@ -44,6 +44,7 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.POST("/publish", appServer.publishHandler)
 		api.POST("/publish_video", appServer.publishVideoHandler)
 		api.GET("/feeds/list", appServer.listFeedsHandler)
+		api.GET("/feeds/favorites", appServer.listFavoriteFeedsHandler)
 		api.GET("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/detail", appServer.getFeedDetailHandler)

--- a/service.go
+++ b/service.go
@@ -91,6 +91,17 @@ type UserProfileResponse struct {
 	Feeds         []xiaohongshu.Feed             `json:"feeds"`
 }
 
+type FavoriteCategoryListResponse struct {
+	Categories []xiaohongshu.FavoriteCategory `json:"categories"`
+	Count      int                            `json:"count"`
+}
+
+type FavoriteCategoryFeedsResponse struct {
+	Category *xiaohongshu.FavoriteCategory `json:"category"`
+	Feeds    []xiaohongshu.Feed            `json:"feeds"`
+	Count    int                           `json:"count"`
+}
+
 // DeleteCookies 删除 cookies 文件，用于登录重置
 func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
 	cookiePath := cookies.GetCookiesFilePath()
@@ -409,6 +420,47 @@ func (s *XiaohongshuService) ListFavoriteFeeds(ctx context.Context) (*FeedsListR
 	}
 
 	return response, nil
+}
+
+func (s *XiaohongshuService) ListFavoriteCategories(ctx context.Context) (*FavoriteCategoryListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewFavoriteFeedsAction(page)
+	categories, err := action.GetFavoriteCategories(ctx)
+	if err != nil {
+		logrus.Errorf("获取收藏分类失败: %v", err)
+		return nil, err
+	}
+
+	return &FavoriteCategoryListResponse{
+		Categories: categories,
+		Count:      len(categories),
+	}, nil
+}
+
+func (s *XiaohongshuService) ListFavoriteFeedsByCategory(ctx context.Context, categoryID, categoryName string, limit int) (*FavoriteCategoryFeedsResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewFavoriteFeedsAction(page)
+	feeds, category, err := action.GetFavoriteFeedsByCategory(ctx, categoryID, categoryName, limit)
+	if err != nil {
+		logrus.Errorf("按分类获取收藏失败: %v", err)
+		return nil, err
+	}
+
+	return &FavoriteCategoryFeedsResponse{
+		Category: category,
+		Feeds:    feeds,
+		Count:    len(feeds),
+	}, nil
 }
 
 // GetFeedDetail 获取Feed详情

--- a/service.go
+++ b/service.go
@@ -387,6 +387,30 @@ func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, fi
 	return response, nil
 }
 
+// ListFavoriteFeeds 获取当前登录用户收藏列表
+func (s *XiaohongshuService) ListFavoriteFeeds(ctx context.Context) (*FeedsListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewFavoriteFeedsAction(page)
+
+	feeds, err := action.GetFavoriteFeeds(ctx)
+	if err != nil {
+		logrus.Errorf("获取收藏列表失败: %v", err)
+		return nil, err
+	}
+
+	response := &FeedsListResponse{
+		Feeds: feeds,
+		Count: len(feeds),
+	}
+
+	return response, nil
+}
+
 // GetFeedDetail 获取Feed详情
 func (s *XiaohongshuService) GetFeedDetail(ctx context.Context, feedID, xsecToken string, loadAllComments bool) (*FeedDetailResponse, error) {
 	return s.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAllComments, xiaohongshu.DefaultCommentLoadConfig())

--- a/types.go
+++ b/types.go
@@ -103,6 +103,12 @@ type UserProfileRequest struct {
 	XsecToken string `json:"xsec_token" binding:"required"`
 }
 
+type FavoriteFeedsByCategoryRequest struct {
+	CategoryID   string `json:"category_id,omitempty"`
+	CategoryName string `json:"category_name,omitempty"`
+	Limit        int    `json:"limit,omitempty"`
+}
+
 // ActionResult 通用动作响应（点赞/收藏等）
 type ActionResult struct {
 	FeedID  string `json:"feed_id"`

--- a/xiaohongshu/favorite_categories.go
+++ b/xiaohongshu/favorite_categories.go
@@ -1,0 +1,335 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+// GetFavoriteCategories 获取收藏下的专辑分类列表
+func (f *FavoriteFeedsAction) GetFavoriteCategories(ctx context.Context) ([]FavoriteCategory, error) {
+	page := f.page.Context(ctx)
+	if err := f.navigateToFavoriteBoardTab(ctx, page); err != nil {
+		return nil, err
+	}
+
+	result := page.MustEval(`() => {
+		const anchors = Array.from(document.querySelectorAll('a[href*="/board/"]'));
+		const map = new Map();
+
+		const parseBoardId = (href) => {
+			try {
+				const u = new URL(href, location.origin);
+				const m = u.pathname.match(/\/board\/([^/?#]+)/);
+				return m && m[1] ? m[1] : "";
+			} catch {
+				return "";
+			}
+		};
+
+		for (const a of anchors) {
+			const href = a.getAttribute("href") || "";
+			const id = parseBoardId(href);
+			if (!id) continue;
+
+			const card = a.closest("section, article, li, .board-item, .album-item, .note-item") || a;
+			const text = (card.textContent || a.textContent || "").replace(/\s+/g, " ").trim();
+			let name = text;
+			let count = 0;
+			const strict = text.match(/^(.+?)\\s*笔记・\\s*(\\d+)/);
+			if (strict) {
+				name = strict[1].trim();
+				count = Number(strict[2]) || 0;
+			} else {
+				const countMatch = text.match(/笔记・(\\d+)/);
+				if (countMatch) {
+					count = Number(countMatch[1]) || 0;
+					name = text.slice(0, countMatch.index).trim();
+				}
+			}
+			if (!name) name = "未命名专辑";
+			name = name.replace(/\s*笔记[・·]\s*\d+.*$/, "").trim() || name;
+
+			if (!map.has(id)) {
+				map.set(id, {
+					id,
+					name,
+					noteCount: count,
+					url: new URL(href, location.origin).toString(),
+				});
+			}
+		}
+
+		return JSON.stringify(Array.from(map.values()));
+	}`).String()
+
+	var categories []FavoriteCategory
+	if err := json.Unmarshal([]byte(result), &categories); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal favorite categories: %w", err)
+	}
+
+	return categories, nil
+}
+
+// GetFavoriteFeedsByCategory 获取指定收藏专辑下的笔记
+func (f *FavoriteFeedsAction) GetFavoriteFeedsByCategory(ctx context.Context, categoryID, categoryName string, limit int) ([]Feed, *FavoriteCategory, error) {
+	page := f.page.Context(ctx)
+	if err := f.navigateToFavoriteBoardTab(ctx, page); err != nil {
+		return nil, nil, err
+	}
+
+	targetResult := page.MustEval(`(args) => {
+		const { categoryID, categoryName } = args;
+		const anchors = Array.from(document.querySelectorAll('a[href*="/board/"]'));
+
+		const parseBoardId = (href) => {
+			try {
+				const u = new URL(href, location.origin);
+				const m = u.pathname.match(/\/board\/([^/?#]+)/);
+				return m && m[1] ? m[1] : "";
+			} catch {
+				return "";
+			}
+		};
+
+		const normalize = (s) => (s || "").replace(/\s+/g, " ").trim().toLowerCase();
+		const normalizedName = normalize(categoryName);
+
+		for (const a of anchors) {
+			const href = a.getAttribute("href") || "";
+			const id = parseBoardId(href);
+			if (!id) continue;
+
+			const card = a.closest("section, article, li, .board-item, .album-item, .note-item") || a;
+			const text = (card.textContent || a.textContent || "").replace(/\s+/g, " ").trim();
+			let name = text;
+			let count = 0;
+			const strict = text.match(/^(.+?)\\s*笔记・\\s*(\\d+)/);
+			if (strict) {
+				name = strict[1].trim();
+				count = Number(strict[2]) || 0;
+			} else {
+				const countMatch = text.match(/笔记・(\\d+)/);
+				if (countMatch) {
+					count = Number(countMatch[1]) || 0;
+					name = text.slice(0, countMatch.index).trim();
+				}
+			}
+			if (!name) name = "未命名专辑";
+			name = name.replace(/\s*笔记[・·]\s*\d+.*$/, "").trim() || name;
+
+			const idMatch = categoryID && id === categoryID;
+			const normalizedCandidate = normalize(name);
+			const nameMatch = normalizedName && (normalizedCandidate === normalizedName || normalizedCandidate.startsWith(normalizedName) || normalizedCandidate.includes(normalizedName));
+			const fallback = !categoryID && !normalizedName;
+			if (!(idMatch || nameMatch || fallback)) continue;
+
+			return JSON.stringify({
+				id,
+				name,
+				noteCount: count,
+				url: new URL(href, location.origin).toString(),
+				clickHref: href,
+			});
+		}
+
+		return "";
+	}`, map[string]any{
+		"categoryID":   categoryID,
+		"categoryName": categoryName,
+	}).String()
+
+	if targetResult == "" {
+		return nil, nil, fmt.Errorf("favorite category not found (id=%q, name=%q)", categoryID, categoryName)
+	}
+
+	var target struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		NoteCount int    `json:"noteCount"`
+		URL       string `json:"url"`
+		ClickHref string `json:"clickHref"`
+	}
+	if err := json.Unmarshal([]byte(targetResult), &target); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse target category: %w", err)
+	}
+
+	page.MustNavigate(target.URL).MustWaitLoad().MustWaitDOMStable()
+	time.Sleep(800 * time.Millisecond)
+
+	feedResult := page.MustEval(`(limit) => {
+		const feeds = [];
+		const seen = new Set();
+
+		const extractValue = (v) => {
+			if (v === null || v === undefined) return undefined;
+			if (typeof v === "object") {
+				if (v.value !== undefined) return v.value;
+				if (v._value !== undefined) return v._value;
+			}
+			return v;
+		};
+
+		const toFeed = (node) => {
+			if (!node || typeof node !== "object") return null;
+			const id = node.id || node.noteId || node.note_id;
+			const xsecToken = node.xsecToken ?? node.xsec_token ?? node.xsec;
+			if (!id || !xsecToken) return null;
+			return {
+				...node,
+				id,
+				xsecToken,
+				modelType: node.modelType || "note",
+				noteCard: node.noteCard || node,
+			};
+		};
+
+		const walkState = (node) => {
+			const value = extractValue(node);
+			if (value === undefined || value === null) return;
+			if (Array.isArray(value)) {
+				for (const item of value) walkState(item);
+				return;
+			}
+			if (typeof value !== "object") return;
+
+			const feed = toFeed(value);
+			if (feed) {
+				const key = feed.id + ":" + feed.xsecToken;
+				if (!seen.has(key)) {
+					seen.add(key);
+					feed.index = feeds.length;
+					feeds.push(feed);
+				}
+				return;
+			}
+
+			for (const v of Object.values(value)) walkState(v);
+		};
+
+		// 优先从 board 状态读取，通常包含完整 xsecToken
+		const state = window.__INITIAL_STATE__ || {};
+		const board = state.board || {};
+		const boardCandidates = [
+			board.boardFeedsMap,
+			board.boardDetails,
+			board.boardListData,
+		];
+		for (const c of boardCandidates) {
+			walkState(c);
+			if (limit > 0 && feeds.length >= limit) break;
+		}
+		if (feeds.length > 0) {
+			if (limit > 0) return JSON.stringify(feeds.slice(0, limit));
+			return JSON.stringify(feeds);
+		}
+
+		const parseID = (u) => {
+			const p = u.pathname || "";
+			const m1 = p.match(/\/user\/profile\/[^/?#]+\/([^/?#]+)/);
+			if (m1 && m1[1]) return m1[1];
+			const m2 = p.match(/\/explore\/([^/?#]+)/);
+			if (m2 && m2[1]) return m2[1];
+			const m3 = p.match(/\/discovery\/item\/([^/?#]+)/);
+			if (m3 && m3[1]) return m3[1];
+			return "";
+		};
+
+		const anchors = Array.from(document.querySelectorAll('a[href*="/user/profile/"], a[href*="/explore/"], a[href*="/discovery/item/"]'));
+		for (const a of anchors) {
+			const href = a.getAttribute("href") || "";
+			let u;
+			try { u = new URL(href, location.origin); } catch { continue; }
+			const id = parseID(u);
+			const xsecToken =
+				u.searchParams.get("xsec_token") ||
+				u.searchParams.get("xsecToken") ||
+				a.getAttribute("data-xsec-token") ||
+				"";
+			if (!id || !xsecToken) continue;
+
+			const key = id + ":" + xsecToken;
+			if (seen.has(key)) continue;
+			seen.add(key);
+
+			const card = a.closest("section, article, li, .note-item, .feeds-page, .note-card") || a.parentElement;
+			const titleEl =
+				card?.querySelector(".title span") ||
+				card?.querySelector(".title") ||
+				card?.querySelector(".desc") ||
+				card?.querySelector("h3") ||
+				card?.querySelector("h4");
+			const title = ((titleEl?.textContent || a.textContent || "").trim()).slice(0, 200);
+
+			feeds.push({
+				id,
+				xsecToken,
+				modelType: "note",
+				noteCard: { type: "normal", displayTitle: title },
+				index: feeds.length,
+			});
+
+			if (limit > 0 && feeds.length >= limit) break;
+		}
+
+		return JSON.stringify(feeds);
+	}`, limit).String()
+
+	var feeds []Feed
+	if err := json.Unmarshal([]byte(feedResult), &feeds); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal category feeds: %w", err)
+	}
+
+	category := &FavoriteCategory{
+		ID:        target.ID,
+		Name:      target.Name,
+		NoteCount: target.NoteCount,
+		URL:       target.URL,
+	}
+
+	return feeds, category, nil
+}
+
+func (f *FavoriteFeedsAction) navigateToFavoriteBoardTab(ctx context.Context, page *rod.Page) error {
+	navigate := NewNavigate(page)
+	if err := navigate.ToProfilePage(ctx); err != nil {
+		return fmt.Errorf("failed to navigate to profile page: %w", err)
+	}
+	page.MustWaitDOMStable()
+
+	clickedFav := page.MustEval(`() => {
+		const sels=['span.channel','.reds-tab-item','.tab-item','div[class*="tab"]'];
+		for(const s of sels){
+			const n=[...document.querySelectorAll(s)].find(x=>(x.textContent||'').trim()==='收藏');
+			if(n){n.click();return true;}
+		}
+		return false;
+	}`).Bool()
+	if !clickedFav {
+		return fmt.Errorf("failed to switch to favorite tab")
+	}
+
+	page.MustWaitDOMStable()
+	time.Sleep(500 * time.Millisecond)
+
+	clickedBoard := page.MustEval(`() => {
+		const sels=['span.channel','.reds-tab-item','.tab-item','div[class*="tab"]'];
+		for(const s of sels){
+			const nodes=[...document.querySelectorAll(s)];
+			const n=nodes.find(x=>(x.textContent||'').trim().startsWith('专辑'));
+			if(n){n.click();return true;}
+		}
+		// already in subTab=board also consider success
+		return location.search.includes('subTab=board');
+	}`).Bool()
+	if !clickedBoard {
+		return fmt.Errorf("failed to switch to board tab")
+	}
+
+	page.MustWaitDOMStable()
+	time.Sleep(700 * time.Millisecond)
+	return nil
+}

--- a/xiaohongshu/favorite_feeds.go
+++ b/xiaohongshu/favorite_feeds.go
@@ -1,0 +1,135 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/errors"
+)
+
+type FavoriteFeedsAction struct {
+	page *rod.Page
+}
+
+func NewFavoriteFeedsAction(page *rod.Page) *FavoriteFeedsAction {
+	pp := page.Timeout(60 * time.Second)
+	return &FavoriteFeedsAction{page: pp}
+}
+
+// GetFavoriteFeeds 获取当前登录用户的收藏笔记列表
+func (f *FavoriteFeedsAction) GetFavoriteFeeds(ctx context.Context) ([]Feed, error) {
+	page := f.page.Context(ctx)
+	navigate := NewNavigate(page)
+
+	if err := navigate.ToProfilePage(ctx); err != nil {
+		return nil, fmt.Errorf("failed to navigate to profile page: %w", err)
+	}
+
+	page.MustWaitDOMStable()
+
+	clicked := page.MustEval(`() => {
+		const candidates = [
+			'span.channel',
+			'.reds-tab-item',
+			'.tab-item',
+			'div[class*="tab"]'
+		];
+
+		for (const selector of candidates) {
+			const nodes = Array.from(document.querySelectorAll(selector));
+			const target = nodes.find((n) => (n.textContent || "").trim() === "收藏");
+			if (target) {
+				target.click();
+				return true;
+			}
+		}
+		return false;
+	}`).Bool()
+	if !clicked {
+		return nil, fmt.Errorf("failed to switch to favorite tab")
+	}
+
+	page.MustWaitDOMStable()
+	time.Sleep(800 * time.Millisecond)
+
+	result := page.MustEval(`() => {
+		const state = window.__INITIAL_STATE__;
+		const user = state?.user;
+		if (!user) return "";
+
+		const extractValue = (v) => {
+			if (v === null || v === undefined) return undefined;
+			if (typeof v === "object") {
+				if (v.value !== undefined) return v.value;
+				if (v._value !== undefined) return v._value;
+			}
+			return v;
+		};
+
+		const candidates = [
+			user.collectNotes,
+			user.collectNote,
+			user.collections,
+			user.collects,
+			user.favorites,
+			user.favoriteNotes
+		];
+
+		let seenCandidate = false;
+
+		const toFeed = (node) => {
+			if (!node || typeof node !== "object") return null;
+			const id = node.id;
+			const xsecToken = node.xsecToken ?? node.xsec_token ?? node.xsec;
+			if (!id || !xsecToken) return null;
+			return {
+				...node,
+				xsecToken
+			};
+		};
+
+		const walk = (node, out) => {
+			const value = extractValue(node);
+			if (value === undefined || value === null) return;
+			if (Array.isArray(value)) {
+				value.forEach((item) => walk(item, out));
+				return;
+			}
+			if (typeof value !== "object") return;
+
+			const feed = toFeed(value);
+			if (feed) {
+				out.push(feed);
+				return;
+			}
+
+			Object.values(value).forEach((item) => walk(item, out));
+		};
+
+		for (const candidate of candidates) {
+			if (candidate === undefined) continue;
+			seenCandidate = true;
+
+			const feeds = [];
+			walk(candidate, feeds);
+			if (feeds.length > 0) return JSON.stringify(feeds);
+		}
+
+		if (seenCandidate) return "[]";
+		return "";
+	}`).String()
+
+	if result == "" {
+		return nil, errors.ErrNoFeeds
+	}
+
+	var feeds []Feed
+	if err := json.Unmarshal([]byte(result), &feeds); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal favorite feeds: %w", err)
+	}
+
+	return feeds, nil
+}

--- a/xiaohongshu/favorite_feeds.go
+++ b/xiaohongshu/favorite_feeds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -22,165 +23,71 @@ func NewFavoriteFeedsAction(page *rod.Page) *FavoriteFeedsAction {
 // GetFavoriteFeeds 获取当前登录用户的收藏笔记列表
 func (f *FavoriteFeedsAction) GetFavoriteFeeds(ctx context.Context) ([]Feed, error) {
 	page := f.page.Context(ctx)
-	navigate := NewNavigate(page)
 
-	if err := navigate.ToProfilePage(ctx); err != nil {
-		return nil, fmt.Errorf("failed to navigate to profile page: %w", err)
+	if err := navigateToFavoriteNoteTab(page); err != nil {
+		return nil, err
 	}
 
-	page.MustWaitDOMStable()
-
-	clicked := page.MustEval(`() => {
-		const candidates = [
-			'span.channel',
-			'.reds-tab-item',
-			'.tab-item',
-			'div[class*="tab"]'
-		];
-
-		for (const selector of candidates) {
-			const nodes = Array.from(document.querySelectorAll(selector));
-			const target = nodes.find((n) => (n.textContent || "").trim() === "收藏");
-			if (target) {
-				target.click();
-				return true;
-			}
-		}
-		return false;
-	}`).Bool()
-	if !clicked {
-		return nil, fmt.Errorf("failed to switch to favorite tab")
+	profileURL := page.MustEval(`() => location.href`).String()
+	favoriteURL, err := favoriteNoteTabURL(profileURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build favorite note tab URL: %w", err)
 	}
 
-	page.MustWaitDOMStable()
-	time.Sleep(800 * time.Millisecond)
+	page.MustNavigate(favoriteURL).MustWaitLoad().MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
 
 	result := page.MustEval(`() => {
-		const state = window.__INITIAL_STATE__;
-		const user = state?.user;
-		if (!user) return "";
-
-		const extractValue = (v) => {
-			if (v === null || v === undefined) return undefined;
-			if (typeof v === "object") {
-				if (v.value !== undefined) return v.value;
-				if (v._value !== undefined) return v._value;
-			}
-			return v;
-		};
-
-		const candidates = [
-			user.collectNotes,
-			user.collectNote,
-			user.collections,
-			user.collects,
-			user.favorites,
-			user.favoriteNotes
-		];
-
-		let seenCandidate = false;
-
-		const toFeed = (node) => {
-			if (!node || typeof node !== "object") return null;
-			const id = node.id;
-			const xsecToken = node.xsecToken ?? node.xsec_token ?? node.xsec;
-			if (!id || !xsecToken) return null;
-			return {
-				...node,
-				xsecToken
-			};
-		};
-
-		const walk = (node, out) => {
-			const value = extractValue(node);
-			if (value === undefined || value === null) return;
-			if (Array.isArray(value)) {
-				value.forEach((item) => walk(item, out));
-				return;
-			}
-			if (typeof value !== "object") return;
-
-			const feed = toFeed(value);
-			if (feed) {
-				out.push(feed);
-				return;
-			}
-
-			Object.values(value).forEach((item) => walk(item, out));
-		};
-
-		for (const candidate of candidates) {
-			if (candidate === undefined) continue;
-			seenCandidate = true;
-
-			const feeds = [];
-			walk(candidate, feeds);
-			if (feeds.length > 0) return JSON.stringify(feeds);
-		}
-
-		// Fallback: 从收藏页面可见卡片链接提取笔记信息，避免 __INITIAL_STATE__ 字段变化导致抓取失败
-			const anchors = Array.from(document.querySelectorAll('a[href*="/explore/"], a[href*="/discovery/item/"], a[href*="/user/profile/"]'));
-		const fallbackFeeds = [];
+		const feeds = [];
 		const seen = new Set();
+		const normalize = (s) => (s || "").replace(/\s+/g, " ").trim();
 
-			const tryExtractID = (pathname) => {
-				const m1 = pathname.match(/\/explore\/([^/?#]+)/);
-				if (m1 && m1[1]) return m1[1];
-				const m2 = pathname.match(/\/discovery\/item\/([^/?#]+)/);
-				if (m2 && m2[1]) return m2[1];
-				const m3 = pathname.match(/\/user\/profile\/[^/?#]+\/([^/?#]+)/);
-				if (m3 && m3[1]) return m3[1];
-				return "";
-			};
-
-		for (const a of anchors) {
-			const href = a.getAttribute("href");
-			if (!href) continue;
-
-			let u;
+		const noteFromHref = (href) => {
 			try {
-				u = new URL(href, location.origin);
+				const u = new URL(href, location.origin);
+				const m = u.pathname.match(/^\/explore\/([^/?#]+)/);
+				if (!m || !m[1]) return null;
+				return { id: m[1], xsecToken: u.searchParams.get("xsec_token") || u.searchParams.get("xsecToken") || "" };
 			} catch {
-				continue;
+				return null;
 			}
+		};
 
-			const id = tryExtractID(u.pathname);
-			const xsecToken =
-				u.searchParams.get("xsec_token") ||
-				u.searchParams.get("xsecToken") ||
-				a.getAttribute("data-xsec-token") ||
-				"";
-			if (!id || !xsecToken) continue;
+		const anchors = Array.from(document.querySelectorAll('a[href*="/explore/"]'));
+		for (const a of anchors) {
+			const parsed = noteFromHref(a.getAttribute("href") || "");
+			if (!parsed || seen.has(parsed.id)) continue;
+			seen.add(parsed.id);
 
-			const key = id + ":" + xsecToken;
-			if (seen.has(key)) continue;
-			seen.add(key);
-
-			const card = a.closest("section, article, .note-item, .feeds-page, .note-card") || a.parentElement;
+			const card = a.closest("section, article, li, .note-item, .feeds-page, .note-card") || a.parentElement || a;
 			const titleEl =
 				card?.querySelector(".title span") ||
 				card?.querySelector(".title") ||
 				card?.querySelector(".desc") ||
 				card?.querySelector("h3") ||
 				card?.querySelector("h4");
-			const title = ((titleEl?.textContent || a.textContent || "").trim()).slice(0, 200);
+			const authorEl =
+				card?.querySelector(".author .name") ||
+				card?.querySelector(".name") ||
+				card?.querySelector('a[href*="/user/profile/"] span') ||
+				card?.querySelector('a[href*="/user/profile/"]');
 
-			fallbackFeeds.push({
-				id,
-				xsecToken,
+			feeds.push({
+				id: parsed.id,
+				xsecToken: parsed.xsecToken,
 				modelType: "note",
 				noteCard: {
 					type: "normal",
-					displayTitle: title
+					displayTitle: normalize(titleEl?.textContent || a.textContent || ""),
+					user: {
+						nickName: normalize(authorEl?.textContent || "")
+					}
 				},
-				index: fallbackFeeds.length
+				index: feeds.length
 			});
 		}
 
-		if (fallbackFeeds.length > 0) return JSON.stringify(fallbackFeeds);
-
-		if (seenCandidate) return "[]";
-		return "";
+		return JSON.stringify(feeds);
 	}`).String()
 
 	if result == "" {
@@ -222,4 +129,50 @@ func (f *FavoriteFeedsAction) GetFavoriteFeeds(ctx context.Context) ([]Feed, err
 	}
 
 	return feeds, nil
+}
+
+func navigateToFavoriteNoteTab(page *rod.Page) error {
+	page.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad().MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+
+	profileTarget := page.MustEval(`() => {
+		const selectors = [
+			'div.main-container li.user.side-bar-component a.link-wrapper',
+			'li.user.side-bar-component a',
+			'a.link-wrapper[href*="/user/profile/"]'
+		];
+		for (const selector of selectors) {
+			const node = document.querySelector(selector);
+			if (!node) continue;
+			const href = node.getAttribute("href");
+			if (href && href.includes("/user/profile/")) {
+				return new URL(href, location.origin).toString();
+			}
+			node.click();
+			return "__clicked__";
+		}
+		return "";
+	}`).String()
+
+	if profileTarget == "" {
+		return fmt.Errorf("failed to find profile link")
+	}
+	if profileTarget == "__clicked__" {
+		page.MustWaitLoad().MustWaitDOMStable()
+		time.Sleep(1200 * time.Millisecond)
+		return nil
+	}
+
+	page.MustNavigate(profileTarget).MustWaitLoad().MustWaitDOMStable()
+	time.Sleep(1200 * time.Millisecond)
+	return nil
+}
+
+func favoriteNoteTabURL(profileURL string) (string, error) {
+	u, err := url.Parse(profileURL)
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = "tab=fav&subTab=note"
+	return u.String(), nil
 }

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -168,3 +168,11 @@ type UserInteractions struct {
 	Name  string `json:"name"`  // 关注 粉丝 获赞与收藏
 	Count string `json:"count"` // 数量
 }
+
+// FavoriteCategory 收藏专辑分类
+type FavoriteCategory struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	NoteCount int    `json:"noteCount,omitempty"`
+	URL       string `json:"url,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add `list_favorite_feeds` MCP tool + HTTP endpoint `GET /api/v1/feeds/favorites`
- add `list_favorite_categories` MCP tool + HTTP endpoint `GET /api/v1/feeds/favorite_categories`
- add `list_favorite_feeds_by_category` MCP tool + HTTP endpoint `POST /api/v1/feeds/favorites/by_category`
- implement robust extraction for favorite feeds and category pages:
  - read from `__INITIAL_STATE__` where available
  - fallback to DOM link extraction (`/user/profile/.../<note_id>?xsec_token=...`)
  - board/category flow supports `/board/<id>` and extraction of note cards with `xsecToken`
- update README/README_EN tool lists and API docs

## Verified manually
- `GET /api/v1/feeds/favorites` returns favorite notes with `id + xsecToken`
- `GET /api/v1/feeds/favorite_categories` returns category list (boards)
- `POST /api/v1/feeds/favorites/by_category` returns notes in target category with `id + xsecToken`

## Build/Test
- `go build ./...` passes
- `go test ./... -timeout 60s` still has existing integration timeout in `xiaohongshu/search_test.go: TestSearchWithFilters` (pre-existing, unrelated)
