### PR TITLE
fix: 改善 Docker 部署时本地图片路径不可访问的提示和文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ Docker 版本会自动：
 - 挂载 `./images` 用于存储发布的图片
 - 暴露 18060 端口供 MCP 连接
 
+> **注意：** 如果需要通过 MCP 发布本地图片，请在启动容器时挂载宿主机目录，例如：
+> ```bash
+> docker run -d --name xiaohongshu-mcp -p 18060:18060 -v /tmp:/tmp xpzouying/xiaohongshu-mcp
+> ```
+> 否则容器内无法访问宿主机上的图片文件。也可以使用 HTTP URL 格式的图片链接来避免此问题。
+
 详细使用说明请参考：[Docker 部署指南](./docker/README.md)
 
 </details>

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -205,7 +205,7 @@ func uploadImages(page *rod.Page, imagesPaths []string) error {
 	validPaths := make([]string, 0, len(imagesPaths))
 	for _, path := range imagesPaths {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
-			logrus.Warnf("图片文件不存在: %s", path)
+			logrus.Warnf("图片文件不存在: %s (如果使用 Docker 部署，请确保已挂载宿主机目录，例如: docker run -v /tmp:/tmp ...，或使用 HTTP URL 格式的图片链接)", path)
 			continue
 		}
 		validPaths = append(validPaths, path)

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -203,13 +203,19 @@ func isElementBlocked(elem *rod.Element) (bool, error) {
 func uploadImages(page *rod.Page, imagesPaths []string) error {
 	// 验证文件路径有效性
 	validPaths := make([]string, 0, len(imagesPaths))
+	hasNotFound := false
 	for _, path := range imagesPaths {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
-			logrus.Warnf("图片文件不存在: %s (如果使用 Docker 部署，请确保已挂载宿主机目录，例如: docker run -v /tmp:/tmp ...，或使用 HTTP URL 格式的图片链接)", path)
+			logrus.Warnf("图片文件不存在: %s", path)
+			hasNotFound = true
 			continue
 		}
 		validPaths = append(validPaths, path)
 		logrus.Infof("获取有效图片：%s", path)
+	}
+
+	if hasNotFound {
+		logrus.Info("提示: Docker 部署时需挂载宿主机目录（如 -v /tmp:/tmp），或使用 HTTP URL 格式的图片链接，详见 README")
 	}
 
 	// 逐张上传：每张上传后等待预览出现，再上传下一张


### PR DESCRIPTION
## 修复内容

修复 #480

### 问题
使用 Docker 部署时，通过 MCP 调用 `publish_content` 传入宿主机本地图片路径，容器内无法访问该文件，仅输出一条简单的 `图片文件不存在` 警告，用户难以定位原因。

### 改动
1. **`xiaohongshu/publish.go`**: 在 `uploadImages()` 的文件不存在警告中，增加 Docker 部署场景的提示信息（挂载卷或使用 URL）
2. **`README.md`**: 在 Docker 部署章节中补充说明，提示用户需要挂载宿主机目录才能发布本地图片

### 测试
- 在 Docker 部署环境下验证：未挂载卷时日志提示更清晰
- 挂载 `-v /tmp:/tmp` 后，本地图片可正常上传发布