### PR TITLE
feat: add --stdio flag to run MCP in stdio mode

### DIFF
--- a/app_server.go
+++ b/app_server.go
@@ -33,6 +33,18 @@ func NewAppServer(xiaohongshuService *XiaohongshuService) *AppServer {
 	return appServer
 }
 
+// RunStdio 使用 stdio 模式运行 MCP 服务器
+func (s *AppServer) RunStdio() error {
+	logrus.Info("使用 stdio 模式启动 MCP 服务器")
+
+	if err := s.mcpServer.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+		logrus.Errorf("MCP stdio 服务器运行失败: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 // Start 启动服务器
 func (s *AppServer) Start(port string) error {
 	s.router = setupRoutes(s)

--- a/main.go
+++ b/main.go
@@ -13,10 +13,12 @@ func main() {
 		headless bool
 		binPath  string // 浏览器二进制文件路径
 		port     string
+		stdio    bool
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
+	flag.BoolVar(&stdio, "stdio", false, "使用 stdio 模式运行 MCP（不启动 HTTP 服务器）")
 	flag.Parse()
 
 	if len(binPath) == 0 {
@@ -29,9 +31,21 @@ func main() {
 	// 初始化服务
 	xiaohongshuService := NewXiaohongshuService()
 
-	// 创建并启动应用服务器
+	// 创建应用服务器
 	appServer := NewAppServer(xiaohongshuService)
-	if err := appServer.Start(port); err != nil {
-		logrus.Fatalf("failed to run server: %v", err)
+
+	if stdio {
+		if port != ":18060" {
+			logrus.Warn("stdio 模式下 --port 参数将被忽略")
+		}
+		// 使用 stdio 模式运行 MCP
+		if err := appServer.RunStdio(); err != nil {
+			logrus.Fatalf("failed to run stdio server: %v", err)
+		}
+	} else {
+		// 启动 HTTP 服务器
+		if err := appServer.Start(port); err != nil {
+			logrus.Fatalf("failed to run server: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
mcporter 默认是用stdio communicate的，配置HTTP有一些门槛，加一个stdio 模式来简化openclaw/mcporter的构建
go的mcp sdk已经支持stdio模式，只需调用相应api即可

测试：

`go run . --stdio`  ，输入

```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": "2024-11-05",
    "clientInfo": {
      "name": "test",
      "version": "1.0"
    },
    "capabilities": {}
  }
}
```

确认服务器恢复初始化成功：

```
{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{},"tools":{"listChanged":true}},"protocolVersion":"2024-11-05","serverInfo":{"name":"xiaohongshu-mcp","version":"2.0.0"}}}
```

输入

```
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "tools/list",
  "params": {}
}
```

确认服务器返回完整tools列表