### PR TITLE
fix: 复用共享浏览器实例，避免 Chrome 进程泄漏

### DIFF
--- a/app_server.go
+++ b/app_server.go
@@ -67,5 +67,8 @@ func (s *AppServer) Start(port string) error {
 		logrus.Infof("服务器已优雅关闭")
 	}
 
+	// 关闭共享浏览器
+	s.xiaohongshuService.Close()
+
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -19,11 +20,57 @@ import (
 )
 
 // XiaohongshuService 小红书业务服务
-type XiaohongshuService struct{}
+// 内部维护一个共享的浏览器实例，避免每次请求都创建新的 Chrome 进程。
+type XiaohongshuService struct {
+	mu      sync.Mutex
+	browser *headless_browser.Browser
+}
 
 // NewXiaohongshuService 创建小红书服务实例
 func NewXiaohongshuService() *XiaohongshuService {
 	return &XiaohongshuService{}
+}
+
+// Close 关闭共享浏览器，在服务退出时调用
+func (s *XiaohongshuService) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.browser != nil {
+		s.browser.Close()
+		s.browser = nil
+		logrus.Info("共享浏览器已关闭")
+	}
+}
+
+// getBrowser 返回共享浏览器实例，首次调用时惰性创建
+func (s *XiaohongshuService) getBrowser() *headless_browser.Browser {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.browser == nil {
+		s.browser = newBrowser()
+		logrus.Info("共享浏览器已创建")
+	}
+	return s.browser
+}
+
+// resetBrowser 关闭并重建浏览器（登录后需要重新加载 cookies）
+func (s *XiaohongshuService) resetBrowser() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.browser != nil {
+		s.browser.Close()
+		s.browser = nil
+	}
+	s.browser = newBrowser()
+	logrus.Info("共享浏览器已重建")
+}
+
+// newPage 从共享浏览器创建新页面（开销很小，仅创建一个 tab）
+func (s *XiaohongshuService) newPage() *rod.Page {
+	return s.getBrowser().NewPage()
 }
 
 // PublishRequest 发布请求
@@ -97,15 +144,17 @@ type UserProfileResponse struct {
 func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
 	cookiePath := cookies.GetCookiesFilePath()
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
-	return cookieLoader.DeleteCookies()
+	if err := cookieLoader.DeleteCookies(); err != nil {
+		return err
+	}
+	// cookies 变更后重建浏览器
+	s.resetBrowser()
+	return nil
 }
 
 // CheckLoginStatus 检查登录状态
 func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatusResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	loginAction := xiaohongshu.NewLogin(page)
@@ -125,12 +174,10 @@ func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatus
 
 // GetLoginQrcode 获取登录的扫码二维码
 func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeResponse, error) {
-	b := newBrowser()
-	page := b.NewPage()
+	page := s.newPage()
 
 	deferFunc := func() {
 		_ = page.Close()
-		b.Close()
 	}
 
 	loginAction := xiaohongshu.NewLogin(page)
@@ -155,6 +202,8 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 				if er := saveCookies(page); er != nil {
 					logrus.Errorf("failed to save cookies: %v", er)
 				}
+				// 登录成功后重建浏览器，加载新 cookies
+				s.resetBrowser()
 			}
 		}()
 	}
@@ -246,10 +295,7 @@ func (s *XiaohongshuService) processImages(images []string) ([]string, error) {
 
 // publishContent 执行内容发布
 func (s *XiaohongshuService) publishContent(ctx context.Context, content xiaohongshu.PublishImageContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action, err := xiaohongshu.NewPublishImageAction(page)
@@ -329,10 +375,7 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 
 // publishVideo 执行视频发布
 func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongshu.PublishVideoContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action, err := xiaohongshu.NewPublishVideoAction(page)
@@ -345,10 +388,7 @@ func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongs
 
 // ListFeeds 获取Feeds列表
 func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	// 创建 Feeds 列表 action
@@ -370,10 +410,7 @@ func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse,
 }
 
 func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, filters ...xiaohongshu.FilterOption) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewSearchAction(page)
@@ -398,10 +435,7 @@ func (s *XiaohongshuService) GetFeedDetail(ctx context.Context, feedID, xsecToke
 
 // GetFeedDetailWithConfig 使用配置获取Feed详情
 func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID, xsecToken string, loadAllComments bool, config xiaohongshu.CommentLoadConfig) (*FeedDetailResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	// 创建 Feed 详情 action
@@ -423,10 +457,7 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 
 // UserProfile 获取用户信息
 func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken string) (*UserProfileResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewUserProfileAction(page)
@@ -447,10 +478,7 @@ func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken 
 
 // PostCommentToFeed 发表评论到Feed
 func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsecToken, content string) (*PostCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewCommentFeedAction(page)
@@ -464,10 +492,7 @@ func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsec
 
 // LikeFeed 点赞笔记
 func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewLikeAction(page)
@@ -479,10 +504,7 @@ func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken str
 
 // UnlikeFeed 取消点赞笔记
 func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewLikeAction(page)
@@ -494,10 +516,7 @@ func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken s
 
 // FavoriteFeed 收藏笔记
 func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewFavoriteAction(page)
@@ -509,10 +528,7 @@ func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken
 
 // UnfavoriteFeed 取消收藏笔记
 func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewFavoriteAction(page)
@@ -524,10 +540,7 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 
 // ReplyCommentToFeed 回复指定评论
 func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xsecToken, commentID, userID, content string) (*ReplyCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
+	page := s.newPage()
 	defer page.Close()
 
 	action := xiaohongshu.NewCommentFeedAction(page)
@@ -564,27 +577,13 @@ func saveCookies(page *rod.Page) error {
 	return cookieLoader.SaveCookies(data)
 }
 
-// withBrowserPage 执行需要浏览器页面的操作的通用函数
-func withBrowserPage(fn func(*rod.Page) error) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
-
-	return fn(page)
-}
-
 // GetMyProfile 获取当前登录用户的个人信息
 func (s *XiaohongshuService) GetMyProfile(ctx context.Context) (*UserProfileResponse, error) {
-	var result *xiaohongshu.UserProfileResponse
-	var err error
+	page := s.newPage()
+	defer page.Close()
 
-	err = withBrowserPage(func(page *rod.Page) error {
-		action := xiaohongshu.NewUserProfileAction(page)
-		result, err = action.GetMyProfileViaSidebar(ctx)
-		return err
-	})
+	action := xiaohongshu.NewUserProfileAction(page)
+	result, err := action.GetMyProfileViaSidebar(ctx)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## 问题

每次 MCP 工具调用都通过 `newBrowser()` 创建一个新的 Chrome 进程。在以下场景中进程会泄漏：
- context 取消时 `defer b.Close()` 可能未执行
- panic 绕过 defer
- Rod 库的 `Close()` 对子进程清理存在局限性

长时间运行后，数十个 `headless_shell` 进程占满系统资源。

关联 Issue: #470

## 方案

在 `XiaohongshuService` 中维护一个**共享浏览器实例**，所有请求复用同一个 Chrome 进程：

- `getBrowser()`: 惰性创建浏览器，后续请求直接复用
- `newPage()`: 每次请求只创建新的 page（浏览器 tab），开销极小
- `resetBrowser()`: 登录成功 / 删除 cookies 后重建浏览器，加载新 cookies
- `Close()`: 服务关闭时清理浏览器进程（在 `AppServer.Start` 退出时调用）

## 改动范围

- `service.go`: 替换 12 处 `newBrowser()` 为 `s.newPage()`，新增 `getBrowser/resetBrowser/Close/newPage` 方法
- `app_server.go`: 服务关闭时调用 `s.xiaohongshuService.Close()`

## 效果

| 改前 | 改后 |
|------|------|
| 每次请求 1 个新 Chrome 进程 | 所有请求共享 1 个进程 |
| 进程数随请求数线性增长 | 始终 1 个进程 |
| 关机时可能残留僵尸进程 | 服务退出时统一清理 |