### PR TITLE
docs: update README_EN MCP Tools to match README (13 tools)

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -214,6 +214,61 @@ Get RedNote user's personal profile information, including basic user informatio
 
 </details>
 
+<details>
+<summary><b>9. Reply to Comments</b></summary>
+
+Reply to a specific comment under a note, supporting precise replies to specific users' comments.
+
+**Feature Description:**
+
+- Reply to a specific comment under a note
+- Support locating target comment by comment ID or user ID
+- Requires feed_id, xsec_token, comment_id/user_id, and reply content
+
+**⚠️ Important Note:**
+
+- Must login first to use this feature
+- At least one of comment_id or user_id must be provided
+- These parameters can be obtained from the comment list in post details
+
+</details>
+
+<details>
+<summary><b>10. Like / Unlike</b></summary>
+
+Like or unlike a note, with smart detection of current status to avoid duplicate operations.
+
+**Feature Description:**
+
+- Like or unlike a specified note
+- Smart detection: skips liking if already liked, skips unliking if not liked
+- Requires feed_id and xsec_token
+
+**⚠️ Important Note:**
+
+- Must login first to use this feature
+- Default action is like, set unlike=true to unlike
+
+</details>
+
+<details>
+<summary><b>11. Favorite / Unfavorite</b></summary>
+
+Favorite a note or unfavorite it, with smart detection of current status to avoid duplicate operations.
+
+**Feature Description:**
+
+- Favorite or unfavorite a specified note
+- Smart detection: skips favoriting if already favorited, skips unfavoriting if not favorited
+- Requires feed_id and xsec_token
+
+**⚠️ Important Note:**
+
+- Must login first to use this feature
+- Default action is favorite, set unfavorite=true to unfavorite
+
+</details>
+
 **RedNote Basic Operation Knowledge**
 
 - **Title: (Very Important) RedNote requires titles to not exceed 20 characters**
@@ -617,7 +672,7 @@ Usage steps:
 
 - Use MCP Inspector to test connection
 - Test Ping Server functionality to verify connection
-- Check if List Tools returns 6 tools
+- Check if List Tools returns 13 tools
 
 </details>
 
@@ -696,14 +751,39 @@ Basic configuration template:
 After successful connection, you can use the following MCP tools:
 
 - `check_login_status` - Check RedNote login status (no parameters)
+- `get_login_qrcode` - Get login QR code, returns Base64 image and timeout (no parameters)
+- `delete_cookies` - Delete cookies file, reset login status, requires re-login after deletion (no parameters)
 - `publish_content` - Publish image-text content to RedNote (required: title, content, images)
-  - `images`: Supports HTTP links or local absolute paths, local paths recommended
+  - `images`: Image path list (minimum 1), supports HTTP links or local absolute paths, local paths recommended
+  - `tags`: Topic tags list (optional), e.g. `["food", "travel", "lifestyle"]`
+  - `schedule_at`: Scheduled publish time (optional), ISO8601 format, supports 1 hour to 14 days ahead
+  - `is_original`: Declare as original content (optional), default is not declared
+  - `visibility`: Visibility scope (optional), supports `public` (default), `self-only`, `friends-only`
 - `publish_with_video` - Publish video content to RedNote (required: title, content, video)
-  - `video`: Only supports local video file absolute paths
+  - `video`: Local video file absolute path (single file only)
+  - `tags`: Topic tags list (optional), e.g. `["food", "travel", "lifestyle"]`
+  - `schedule_at`: Scheduled publish time (optional), ISO8601 format, supports 1 hour to 14 days ahead
+  - `visibility`: Visibility scope (optional), supports `public` (default), `self-only`, `friends-only`
 - `list_feeds` - Get RedNote homepage recommendation list (no parameters)
 - `search_feeds` - Search RedNote content (required: keyword)
-- `get_feed_detail` - Get post details (required: feed_id, xsec_token)
+  - `filters`: Filter options (optional)
+    - `sort_by`: Sort by - `comprehensive` (default) | `latest` | `most liked` | `most comments` | `most saved`
+    - `note_type`: Note type - `unlimited` (default) | `video` | `image-text`
+    - `publish_time`: Publish time - `unlimited` (default) | `last day` | `last week` | `last 6 months`
+    - `search_scope`: Search scope - `unlimited` (default) | `viewed` | `not viewed` | `followed`
+    - `location`: Location - `unlimited` (default) | `same city` | `nearby`
+- `get_feed_detail` - Get post details including interaction data and comments (required: feed_id, xsec_token)
+  - `load_all_comments`: Whether to load all comments (optional), default false returns only first 10 top-level comments
+  - `limit`: Limit number of top-level comments to load (optional), only effective when load_all_comments=true, default 20
+  - `click_more_replies`: Whether to expand nested replies (optional), only effective when load_all_comments=true, default false
+  - `reply_limit`: Skip comments with too many replies (optional), only effective when click_more_replies=true, default 10
+  - `scroll_speed`: Scroll speed (optional), `slow` | `normal` | `fast`, only effective when load_all_comments=true
 - `post_comment_to_feed` - Post comments to RedNote posts (required: feed_id, xsec_token, content)
+- `reply_comment_in_feed` - Reply to a specific comment under a note (required: feed_id, xsec_token, content, and at least one of comment_id or user_id)
+- `like_feed` - Like / unlike a note (required: feed_id, xsec_token)
+  - `unlike`: Whether to unlike (optional), true to unlike, default is like
+- `favorite_feed` - Favorite / unfavorite a note (required: feed_id, xsec_token)
+  - `unfavorite`: Whether to unfavorite (optional), true to unfavorite, default is favorite
 - `user_profile` - Get user profile information (required: user_id, xsec_token)
 
 ### 2.4. Usage Examples


### PR DESCRIPTION
## Summary

- 同步 README_EN.md 的 MCP Tools 文档与 README.md 保持一致
- 主要功能区域新增 3 个功能介绍：Reply to Comments, Like/Unlike, Favorite/Unfavorite
- MCP 工具列表从 8 个补全至 13 个，新增 `get_login_qrcode`、`delete_cookies`、`reply_comment_in_feed`、`like_feed`、`favorite_feed`
- 补全已有工具的可选参数说明（`publish_content`、`publish_with_video`、`search_feeds`、`get_feed_detail`）
- 修正 MCP Inspector 工具数量描述（6 → 13）

## Test plan

- [ ] 确认 README_EN 的 13 个工具与 README 中文版一致
- [ ] 确认英文翻译准确
- [ ] 检查 Markdown 渲染效果正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)