### PR TITLE
  feat: 支持调用方配置评论回复的最大尝试次数 (max_attempts)     Feat/configurable max attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ test_*.sh
 
 # Cookies files (contain sensitive login information)
 cookies.json
+xiaohongshu-mcp-darwin-arm64

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -259,7 +259,7 @@ func (s *AppServer) replyCommentHandler(c *gin.Context) {
 		return
 	}
 
-	result, err := s.xiaohongshuService.ReplyCommentToFeed(c.Request.Context(), req.FeedID, req.XsecToken, req.CommentID, req.UserID, req.Content)
+	result, err := s.xiaohongshuService.ReplyCommentToFeed(c.Request.Context(), req.FeedID, req.XsecToken, req.CommentID, req.UserID, req.Content, req.MaxAttempts)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "REPLY_COMMENT_FAILED",
 			"回复评论失败", err.Error())

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -719,10 +719,16 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 		}
 	}
 
+	// 解析可选的 max_attempts 参数
+	maxAttempts := 0
+	if v, ok := args["max_attempts"].(float64); ok {
+		maxAttempts = int(v)
+	}
+
 	logrus.Infof("MCP: 回复评论 - Feed ID: %s, Comment ID: %s, User ID: %s, 内容长度: %d", feedID, commentID, userID, len(content))
 
 	// 回复评论
-	result, err := s.xiaohongshuService.ReplyCommentToFeed(ctx, feedID, xsecToken, commentID, userID, content)
+	result, err := s.xiaohongshuService.ReplyCommentToFeed(ctx, feedID, xsecToken, commentID, userID, content, maxAttempts)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -79,11 +79,12 @@ type PostCommentArgs struct {
 
 // ReplyCommentArgs 回复评论的参数
 type ReplyCommentArgs struct {
-	FeedID    string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
-	XsecToken string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
-	CommentID string `json:"comment_id,omitempty" jsonschema:"目标评论ID，从评论列表获取"`
-	UserID    string `json:"user_id,omitempty" jsonschema:"目标评论用户ID，从评论列表获取"`
-	Content   string `json:"content" jsonschema:"回复内容"`
+	FeedID      string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
+	XsecToken   string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	CommentID   string `json:"comment_id,omitempty" jsonschema:"目标评论ID，从评论列表获取"`
+	UserID      string `json:"user_id,omitempty" jsonschema:"目标评论用户ID，从评论列表获取"`
+	Content     string `json:"content" jsonschema:"回复内容"`
+	MaxAttempts int    `json:"max_attempts,omitempty" jsonschema:"查找评论的最大滚动尝试次数，默认100"`
 }
 
 // LikeFeedArgs 点赞参数

--- a/service.go
+++ b/service.go
@@ -523,7 +523,7 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 }
 
 // ReplyCommentToFeed 回复指定评论
-func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xsecToken, commentID, userID, content string) (*ReplyCommentResponse, error) {
+func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xsecToken, commentID, userID, content string, maxAttempts int) (*ReplyCommentResponse, error) {
 	b := newBrowser()
 	defer b.Close()
 
@@ -532,7 +532,7 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 
 	action := xiaohongshu.NewCommentFeedAction(page)
 
-	if err := action.ReplyToComment(ctx, feedID, xsecToken, commentID, userID, content); err != nil {
+	if err := action.ReplyToComment(ctx, feedID, xsecToken, commentID, userID, content, maxAttempts); err != nil {
 		return nil, err
 	}
 

--- a/types.go
+++ b/types.go
@@ -81,11 +81,12 @@ type PostCommentResponse struct {
 
 // ReplyCommentRequest 回复评论请求
 type ReplyCommentRequest struct {
-	FeedID    string `json:"feed_id" binding:"required"`
-	XsecToken string `json:"xsec_token" binding:"required"`
-	CommentID string `json:"comment_id" binding:"required_without=UserID"`
-	UserID    string `json:"user_id" binding:"required_without=CommentID"`
-	Content   string `json:"content" binding:"required"`
+	FeedID      string `json:"feed_id" binding:"required"`
+	XsecToken   string `json:"xsec_token" binding:"required"`
+	CommentID   string `json:"comment_id" binding:"required_without=UserID"`
+	UserID      string `json:"user_id" binding:"required_without=CommentID"`
+	Content     string `json:"content" binding:"required"`
+	MaxAttempts int    `json:"max_attempts,omitempty"` // 查找评论的最大尝试次数，默认 100
 }
 
 // ReplyCommentResponse 回复评论响应

--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -80,7 +80,7 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 }
 
 // ReplyToComment 回复指定评论
-func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToken, commentID, userID, content string) error {
+func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToken, commentID, userID, content string, maxAttempts int) error {
 	// 增加超时时间，因为需要滚动查找评论
 	// 注意：不使用 Context(ctx)，避免继承外部 context 的超时
 	page := f.page.Timeout(5 * time.Minute)
@@ -101,7 +101,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	time.Sleep(2 * time.Second)
 
 	// 使用 Go 实现的查找逻辑
-	commentEl, err := findCommentElement(page, commentID, userID)
+	commentEl, err := findCommentElement(page, commentID, userID, maxAttempts)
 	if err != nil {
 		return fmt.Errorf("无法找到评论: %w", err)
 	}
@@ -154,10 +154,12 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 }
 
 // findCommentElement 查找指定评论元素（参考 feed_detail.go 的滚动逻辑）
-func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element, error) {
+// maxAttempts 为调用方指定的最大尝试次数，<=0 时使用默认值 100
+func findCommentElement(page *rod.Page, commentID, userID string, maxAttempts int) (*rod.Element, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = 100
+	}
 	logrus.Infof("开始查找评论 - commentID: %s, userID: %s", commentID, userID)
-
-	const maxAttempts = 100
 	const scrollInterval = 800 * time.Millisecond
 
 	// 先滚动到评论区


### PR DESCRIPTION
 Body:                                                         
  ## 背景

  在自动化运营场景下，当评论定位失败时，默认 100 次滚动尝试会在页面上产生大量浏览器操作，容易触发小红书的风控检测（验证码/限流/封号）。调用方需要能控制尝试次数，在找不到评论时快速失败退出，降低风控风险。

  ## 改了什么

  回复评论 API（HTTP 和 MCP）新增可选参数 `max_attempts`，调用方可自行控制查找评论的最大滚动次数。

  使用方式：
  ```json
  {
    "feed_id": "xxx",
    "xsec_token": "xxx",
    "comment_id": "xxx",
    "content": "hello",
    "max_attempts": 20
  }

  不传或传 0 则保持默认 100 次，向后完全兼容。

  改动范围

  - types.go / mcp_server.go：请求结构体加 max_attempts（optional）
  - handlers_api.go / mcp_handlers.go：解析并透传
  - service.go：透传到 action 层
  - comment_feed.go：接收参数，<= 0 时默认 100

  测试结果

  - max_attempts: 3 → 3 次后返回，约 12 秒
  - 不传 → 默认 100 次，行为不变

