### PR TITLE
feat: add login verification code submission tool

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -13,6 +13,27 @@ import (
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
 
+func normalizeVerifyCode(v any) string {
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(strings.Trim(t, `"`))
+	case json.Number:
+		return strings.TrimSpace(t.String())
+	case float64:
+		return strings.TrimSpace(strconv.FormatInt(int64(t), 10))
+	case float32:
+		return strings.TrimSpace(strconv.FormatInt(int64(t), 10))
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case uint64:
+		return strconv.FormatUint(t, 10)
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", v))
+	}
+}
+
 // MCP 工具处理函数
 
 // parseVisibility 从 MCP 参数中解析可见范围
@@ -112,6 +133,28 @@ func (s *AppServer) handleDeleteCookies(ctx context.Context) *MCPToolResult {
 
 	cookiePath := cookies.GetCookiesFilePath()
 	resultText := fmt.Sprintf("Cookies 已成功删除，登录状态已重置。\n\n删除的文件路径: %s\n\n下次操作时，需要重新登录。", cookiePath)
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: resultText,
+		}},
+	}
+}
+
+// handleSubmitLoginVerificationCode 处理提交登录验证码
+func (s *AppServer) handleSubmitLoginVerificationCode(ctx context.Context, rawCode any) *MCPToolResult {
+	logrus.Info("MCP: 提交登录验证码")
+
+	code := normalizeVerifyCode(rawCode)
+	status, err := s.xiaohongshuService.SubmitLoginVerificationCode(ctx, code)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "提交验证码失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	resultText := fmt.Sprintf("✅ 验证码提交成功，当前登录状态：%v\n用户名: %s", status.IsLoggedIn, status.Username)
 	return &MCPToolResult{
 		Content: []MCPContent{{
 			Type: "text",

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -100,6 +100,11 @@ type FavoriteFeedArgs struct {
 	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
+// LoginVerifyCodeArgs 登录验证码参数
+type LoginVerifyCodeArgs struct {
+	Code any `json:"code" jsonschema:"扫码后收到的验证码（支持字符串或数字）"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -197,6 +202,21 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 		withPanicRecovery("delete_cookies", func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
 			result := appServer.handleDeleteCookies(ctx)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 3.5: 提交登录验证码
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "submit_login_verification_code",
+			Description: "提交小红书登录验证码（用于扫码后的人机验证/短信验证码）",
+			Annotations: &mcp.ToolAnnotations{
+				Title: "Submit Login Verification Code",
+			},
+		},
+		withPanicRecovery("submit_login_verification_code", func(ctx context.Context, req *mcp.CallToolRequest, args LoginVerifyCodeArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleSubmitLoginVerificationCode(ctx, args.Code)
 			return convertToMCPResult(result), nil, nil
 		}),
 	)

--- a/service.go
+++ b/service.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/headless_browser"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
@@ -19,11 +22,34 @@ import (
 )
 
 // XiaohongshuService 小红书业务服务
-type XiaohongshuService struct{}
+type XiaohongshuService struct {
+	loginMu       sync.Mutex
+	loginBrowser  *headless_browser.Browser
+	loginPage     *rod.Page
+	loginDeadline time.Time
+}
 
 // NewXiaohongshuService 创建小红书服务实例
 func NewXiaohongshuService() *XiaohongshuService {
 	return &XiaohongshuService{}
+}
+
+func (s *XiaohongshuService) clearLoginSessionLocked() {
+	if s.loginPage != nil {
+		_ = s.loginPage.Close()
+		s.loginPage = nil
+	}
+	if s.loginBrowser != nil {
+		s.loginBrowser.Close()
+		s.loginBrowser = nil
+	}
+	s.loginDeadline = time.Time{}
+}
+
+func (s *XiaohongshuService) clearLoginSession() {
+	s.loginMu.Lock()
+	defer s.loginMu.Unlock()
+	s.clearLoginSessionLocked()
 }
 
 // PublishRequest 发布请求
@@ -128,46 +154,183 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 	b := newBrowser()
 	page := b.NewPage()
 
-	deferFunc := func() {
-		_ = page.Close()
-		b.Close()
-	}
-
 	loginAction := xiaohongshu.NewLogin(page)
 
 	img, loggedIn, err := loginAction.FetchQrcodeImage(ctx)
-	if err != nil || loggedIn {
-		defer deferFunc()
-	}
 	if err != nil {
+		_ = page.Close()
+		b.Close()
 		return nil, err
 	}
 
 	timeout := 4 * time.Minute
 
-	if !loggedIn {
-		go func() {
-			ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			defer deferFunc()
-
-			if loginAction.WaitForLogin(ctxTimeout) {
-				if er := saveCookies(page); er != nil {
-					logrus.Errorf("failed to save cookies: %v", er)
-				}
-			}
-		}()
+	if loggedIn {
+		_ = page.Close()
+		b.Close()
+		return &LoginQrcodeResponse{
+			Timeout:    "0s",
+			Img:        "",
+			IsLoggedIn: true,
+		}, nil
 	}
 
-	return &LoginQrcodeResponse{
-		Timeout: func() string {
-			if loggedIn {
-				return "0s"
+	s.loginMu.Lock()
+	s.clearLoginSessionLocked()
+	s.loginBrowser = b
+	s.loginPage = page
+	s.loginDeadline = time.Now().Add(timeout)
+	s.loginMu.Unlock()
+
+	go func(waitPage *rod.Page, waitBrowser *headless_browser.Browser) {
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		if loginAction.WaitForLogin(ctxTimeout) {
+			if er := saveCookies(waitPage); er != nil {
+				logrus.Errorf("failed to save cookies: %v", er)
 			}
-			return timeout.String()
-		}(),
+		}
+
+		s.loginMu.Lock()
+		defer s.loginMu.Unlock()
+		if s.loginPage == waitPage {
+			s.clearLoginSessionLocked()
+		} else {
+			_ = waitPage.Close()
+			waitBrowser.Close()
+		}
+	}(page, b)
+
+	return &LoginQrcodeResponse{
+		Timeout:    timeout.String(),
 		Img:        img,
-		IsLoggedIn: loggedIn,
+		IsLoggedIn: false,
+	}, nil
+}
+
+// SubmitLoginVerificationCode 提交登录验证码（用于扫码后的人机验证/短信验证码）
+func (s *XiaohongshuService) SubmitLoginVerificationCode(ctx context.Context, code string) (*LoginStatusResponse, error) {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return nil, fmt.Errorf("验证码不能为空")
+	}
+
+	// 兜底：有些场景下验证码提交后会话已被后台流程回收，但实际上已登录。
+	checkAlreadyLoggedIn := func() (*LoginStatusResponse, error) {
+		st, err := s.CheckLoginStatus(ctx)
+		if err == nil && st != nil && st.IsLoggedIn {
+			return st, nil
+		}
+		return nil, err
+	}
+
+	s.loginMu.Lock()
+	page := s.loginPage
+	deadline := s.loginDeadline
+	s.loginMu.Unlock()
+
+	if page == nil {
+		if st, _ := checkAlreadyLoggedIn(); st != nil {
+			return st, nil
+		}
+		return nil, fmt.Errorf("当前没有待验证的登录会话，请先调用 get_login_qrcode")
+	}
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		s.clearLoginSession()
+		if st, _ := checkAlreadyLoggedIn(); st != nil {
+			return st, nil
+		}
+		return nil, fmt.Errorf("登录会话已过期，请重新调用 get_login_qrcode")
+	}
+
+	pp := page.Context(ctx)
+
+	// 使用 rod API 填写验证码，避免大量 JS 注入。
+	inputSelectors := []string{
+		`input[placeholder*="验证码"]`,
+		`input[aria-label*="验证码"]`,
+		`input[inputmode="numeric"]`,
+		`input[type="tel"]`,
+		`input[type="number"]`,
+		`input[type="text"]`,
+	}
+
+	filled := false
+	for _, sel := range inputSelectors {
+		input, findErr := pp.Timeout(2 * time.Second).Element(sel)
+		if findErr != nil || input == nil {
+			continue
+		}
+		if err := input.Input(code); err == nil {
+			filled = true
+			break
+		}
+	}
+	if !filled {
+		if st, _ := checkAlreadyLoggedIn(); st != nil {
+			return st, nil
+		}
+		return nil, fmt.Errorf("未找到验证码输入框，请先调用 get_login_qrcode 并确认页面停留在验证码界面")
+	}
+
+	// 尝试点击确认按钮（若页面需要手动提交）
+	buttonKeywords := []string{"确定", "提交", "下一步", "验证", "确认", "登录"}
+	buttonSelectors := []string{"button", `[role="button"]`, ".btn", ".submit", ".confirm"}
+
+	clicked := false
+	for _, sel := range buttonSelectors {
+		buttons, findErr := pp.Timeout(2 * time.Second).Elements(sel)
+		if findErr != nil || len(buttons) == 0 {
+			continue
+		}
+		for _, btn := range buttons {
+			text, textErr := btn.Text()
+			if textErr != nil {
+				continue
+			}
+			text = strings.TrimSpace(text)
+			if text == "" {
+				continue
+			}
+			for _, kw := range buttonKeywords {
+				if strings.Contains(text, kw) {
+					if err := btn.Click(proto.InputMouseButtonLeft, 1); err == nil {
+						clicked = true
+						break
+					}
+				}
+			}
+			if clicked {
+				break
+			}
+		}
+		if clicked {
+			break
+		}
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+	loginAction := xiaohongshu.NewLogin(page)
+	if !loginAction.WaitForLogin(waitCtx) {
+		// 二次兜底：即使 WaitForLogin 超时，也可能已登录（DOM 变化慢/选择器漂移）
+		if st, _ := checkAlreadyLoggedIn(); st != nil {
+			_ = saveCookies(page)
+			s.clearLoginSession()
+			return st, nil
+		}
+		return nil, fmt.Errorf("验证码已提交，但未检测到登录成功，请确认验证码是否正确")
+	}
+
+	if err := saveCookies(page); err != nil {
+		return nil, fmt.Errorf("登录成功但保存 cookies 失败: %w", err)
+	}
+
+	s.clearLoginSession()
+	return &LoginStatusResponse{
+		IsLoggedIn: true,
+		Username:   configs.Username,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- 新增 MCP 工具 `submit_login_verification_code`，支持扫码后提交验证码完成登录流程。
- 增加登录会话持久化管理（二维码获取与验证码提交复用同一页面/浏览器），并补充会话过期与兜底登录状态检查。
- `code` 参数兼容字符串与数字输入（如 `code=123456`），并将验证码填写/按钮点击逻辑改为 go-rod API（避免大量 JS 注入）。

## Test plan
- [x] 使用 `golang:1.24-bullseye` 容器执行 `go build ./...` 编译通过
- [x] 本地实测 MCP 调用：`submit_login_verification_code code=123456` 可被正确解析（无需额外引号）
- [ ] 在完整 GUI 环境补充一次端到端扫码+验证码录屏（将账号信息打码）

Made with [Cursor](https://cursor.com)