### PR TITLE
docs: add Dify 405 troubleshooting FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,20 @@ npx mcporter list xiaohongshu-mcp
 
 ---
 
+**Q:** 在 Dify 的「Agent 策略（支持 MCP 工具）」或「MCP SSE / StreamableHTTP」里调用一直报 `405`，怎么办？
+**A:**
+
+`xiaohongshu-mcp` 当前提供的是 **Streamable HTTP MCP**（`/mcp`）接口，工具调用走 **POST**。如果客户端按 SSE 方式先发起 GET 握手，会触发 `405 Method Not Allowed`。
+
+排查建议：
+
+1. 在 Dify 中优先选择 **Streamable HTTP / HTTP MCP** 模式（不要选纯 SSE 模式）。
+2. MCP 地址填写：`http://<你的服务地址>:18060/mcp`。
+3. 先用 `curl -X POST http://<你的服务地址>:18060/mcp` 或 MCP Inspector 验证该地址可用。
+4. 如果当前 Dify 插件版本只支持 SSE 握手，请改用支持 Streamable HTTP 的 MCP 客户端（如 Claude Code / Cursor / Cline），或增加一层 MCP 网关适配后再接入 Dify。
+
+---
+
 ## 3. 🌟 实战案例展示 (Community Showcases)
 
 > 💡 **强烈推荐查看**：这些都是社区贡献者的真实使用案例，包含详细的配置步骤和实战经验！

--- a/README_EN.md
+++ b/README_EN.md
@@ -867,6 +867,20 @@ Use xiaohongshu-mcp's video publishing feature.
 
 ---
 
+**Q:** Why do I always get `405` in Dify's "Agent Strategy (MCP tools supported)" or "MCP SSE / StreamableHTTP" plugin?
+**A:**
+
+`xiaohongshu-mcp` currently exposes **Streamable HTTP MCP** on `/mcp`, and tool calls are handled via **POST**. If a client starts with an SSE-style GET handshake, it will return `405 Method Not Allowed`.
+
+Troubleshooting checklist:
+
+1. In Dify, prefer **Streamable HTTP / HTTP MCP** mode (not pure SSE mode).
+2. Set MCP URL to: `http://<your-server>:18060/mcp`.
+3. Verify the endpoint first with `curl -X POST http://<your-server>:18060/mcp` or MCP Inspector.
+4. If your Dify plugin version only supports SSE handshake, use a Streamable HTTP-capable MCP client (Claude Code / Cursor / Cline), or place an MCP gateway adapter in front before connecting Dify.
+
+---
+
 ## 3. 🌟 Community Showcases
 
 > 💡 **Highly Recommended**: These are real-world use cases from community contributors, featuring detailed configuration steps and practical experiences!


### PR DESCRIPTION
## Summary
- add a Chinese FAQ entry explaining why Dify may return `405` when using an SSE handshake against `/mcp`
- document the recommended Streamable HTTP setup (`/mcp` + POST) and quick verification steps
- add matching guidance to `README_EN.md`

## Verification
- `git diff --check`

Closes #315
