### PR TITLE
feat: smart proxy wait for publish

### DIFF
--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -338,6 +338,24 @@ func submitPublish(page *rod.Page, title, content string, tags []string, schedul
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
+	// 在提交发布前等待，确保图片完全上传处理完成
+	// 只有在使用代理的情况下才延长等待时间
+	submitWaitTime := 3 * time.Second // 默认等待 3 秒
+	if os.Getenv("XHS_PROXY") != "" {
+		submitWaitTime = 60 * time.Second // 使用代理时等待 60 秒
+		logrus.Info("检测到代理，延长等待时间以确保图片上传完成")
+	}
+	// 支持通过环境变量自定义等待时间
+	if waitTime := os.Getenv("XHS_PUBLISH_WAIT"); waitTime != "" {
+		if d, err := time.ParseDuration(waitTime); err == nil {
+			submitWaitTime = d
+		}
+	}
+	if submitWaitTime > 5*time.Second {
+		logrus.Infof("等待 %v 后提交发布，确保图片处理完成", submitWaitTime)
+	}
+	time.Sleep(submitWaitTime)
+
 	submitButton, err := page.Element(".publish-page-publish-btn button.bg-red")
 	if err != nil {
 		return errors.Wrap(err, "查找发布按钮失败")


### PR DESCRIPTION
 ## 功能
  智能代理等待：根据是否使用代理自动调整发布前的等待时间

  ## 背景
  在使用慢速代理时，图片上传可能需要更长时间。
  原有代码只等待 3 秒就提交，导致图片未完全上传完成。

  ## 改动
  - 无代理模式：等待 3 秒（快速发布）
  - 检测到 XHS_PROXY：自动延长至 60 秒
  - 支持环境变量 XHS_PUBLISH_WAIT 自定义等待时间

  ## 使用方式
  ```bash
  # 无代理 - 快速发布（3秒）
  ./xiaohongshu-mcp

  # 有代理 - 自动等待60秒
  XHS_PROXY=socks5://user:pass@host:port ./xiaohongshu-mcp

  # 自定义等待时间
  XHS_PUBLISH_WAIT=30s ./xiaohongshu-mcp

  测试

  - ✅ 无代理：3 秒快速发布
  - ✅ 有代理：60 秒确保图片上传完成