### PR TITLE
docs: add Trae list tools failed troubleshooting FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,29 @@ npx mcporter list xiaohongshu-mcp
 
 ---
 
+**Q:** Trae 里报 `list tools failed` / `fetch failed` 怎么排查？
+**A:**
+
+1. 先确认 MCP 服务已经启动：
+   - 终端有日志输出
+   - 浏览器可访问 `http://127.0.0.1:18060/ping`（返回 `pong`）
+2. Trae 配置里 URL 必须是**纯文本 HTTP 地址**，不要粘贴成 Markdown 链接。
+3. 推荐配置示例：
+
+```json
+{
+  "mcpServers": {
+    "xiaohongshu-mcp": {
+      "url": "http://127.0.0.1:18060/mcp"
+    }
+  }
+}
+```
+
+4. 如果 MCP 跑在 Docker / WSL 中，请把 `127.0.0.1` 改成宿主机可达地址（例如 `host.docker.internal` 或宿主机 IPv4）。
+
+---
+
 ## 3. 🌟 实战案例展示 (Community Showcases)
 
 > 💡 **强烈推荐查看**：这些都是社区贡献者的真实使用案例，包含详细的配置步骤和实战经验！

--- a/README_EN.md
+++ b/README_EN.md
@@ -867,6 +867,29 @@ Use xiaohongshu-mcp's video publishing feature.
 
 ---
 
+**Q:** Trae shows `list tools failed` / `fetch failed`. How do I troubleshoot?
+**A:**
+
+1. Confirm the MCP service is running:
+   - You can see logs in terminal
+   - `http://127.0.0.1:18060/ping` returns `pong`
+2. In Trae config, the URL must be a **plain HTTP URL** (not a Markdown link).
+3. Recommended config:
+
+```json
+{
+  "mcpServers": {
+    "xiaohongshu-mcp": {
+      "url": "http://127.0.0.1:18060/mcp"
+    }
+  }
+}
+```
+
+4. If MCP runs in Docker/WSL, replace `127.0.0.1` with a host-reachable address (for example `host.docker.internal` or your host IPv4).
+
+---
+
 ## 3. 🌟 Community Showcases
 
 > 💡 **Highly Recommended**: These are real-world use cases from community contributors, featuring detailed configuration steps and practical experiences!


### PR DESCRIPTION
## Summary\n- add a dedicated FAQ entry for Trae `list tools failed` / `fetch failed` errors\n- provide a known-good Trae MCP config snippet using plain HTTP URL\n- document Docker/WSL host-address fallback guidance\n- mirror the same guidance in both Chinese and English READMEs\n\n## Validation\n- `git diff --check`\n\nCloses #370