### PR TITLE
feat(mcp): 新增视频帖子转写能力（provider API）

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,12 @@
 services:
   xiaohongshu-mcp:
-    # Docker Hub 镜像（默认）
-    image: xpzouying/xiaohongshu-mcp
+    # 默认使用本地源码构建，确保包含当前分支最新 MCP 工具（如 transcribe_feed_video）
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: xiaohongshu-mcp:dev1-local
+    # Docker Hub 镜像（如需快速验证可切换）
+    # image: xpzouying/xiaohongshu-mcp
     # 阿里云镜像源（国内用户推荐，拉取更快）
     # image: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp
     container_name: xiaohongshu-mcp
@@ -11,8 +16,77 @@ services:
     volumes:
       - ./data:/app/data
       - ./images:/app/images
+      - ../third_party:/app/third_party
     environment:
-      - ROD_BROWSER_BIN=/usr/bin/google-chrome
       - COOKIES_PATH=/app/data/cookies.json
+      - VIDEO_TRANSCRIBE_PROVIDER=${VIDEO_TRANSCRIBE_PROVIDER:-dashscope}
+      - DASHSCOPE_API_KEY=${DASHSCOPE_API_KEY:-}
+      - DASHSCOPE_VIDEO_MODEL=${DASHSCOPE_VIDEO_MODEL:-qwen3.5-flash}
+      - ZHIPUAI_API_KEY=${ZHIPUAI_API_KEY:-}
+      - BIGMODEL_API_KEY=${BIGMODEL_API_KEY:-}
+      - GLM_VIDEO_MODEL=${GLM_VIDEO_MODEL:-glm-4.6v-flash}
     ports:
       - "18060:18060"
+
+  redis:
+    image: redis:7-alpine
+    container_name: content-remix-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  content-remix-api:
+    build:
+      context: ..
+      dockerfile: apps/content-remix/backend/Dockerfile
+    container_name: content-remix-api
+    restart: unless-stopped
+    depends_on:
+      - redis
+      - xiaohongshu-mcp
+    environment:
+      - CONTENT_REMIX_MCP_URL=http://xiaohongshu-mcp:18060/mcp
+      - CONTENT_REMIX_REDIS_URL=redis://redis:6379/0
+      - CONTENT_REMIX_DATA_DIR=/app/data/content-remix/jobs
+      - CONTENT_REMIX_CANDIDATE_LIMIT_DEFAULT=10
+      - CONTENT_REMIX_CANDIDATE_LIMIT_MAX=20
+      - CONTENT_REMIX_MAX_PARALLEL_CALLS=3
+      - CONTENT_REMIX_REQUEST_TIMEOUT_SECONDS=60
+    volumes:
+      - ./data:/app/data
+    ports:
+      - "18061:18061"
+
+  content-remix-worker:
+    build:
+      context: ..
+      dockerfile: apps/content-remix/backend/Dockerfile
+    container_name: content-remix-worker
+    restart: unless-stopped
+    depends_on:
+      - redis
+      - xiaohongshu-mcp
+    command: ["celery", "-A", "app.celery_worker.celery_app", "worker", "--loglevel=INFO"]
+    environment:
+      - CONTENT_REMIX_MCP_URL=http://xiaohongshu-mcp:18060/mcp
+      - CONTENT_REMIX_REDIS_URL=redis://redis:6379/0
+      - CONTENT_REMIX_DATA_DIR=/app/data/content-remix/jobs
+      - CONTENT_REMIX_CANDIDATE_LIMIT_DEFAULT=10
+      - CONTENT_REMIX_CANDIDATE_LIMIT_MAX=20
+      - CONTENT_REMIX_MAX_PARALLEL_CALLS=3
+      - CONTENT_REMIX_REQUEST_TIMEOUT_SECONDS=60
+    volumes:
+      - ./data:/app/data
+
+  content-remix-web:
+    build:
+      context: ..
+      dockerfile: apps/content-remix/web/Dockerfile
+    container_name: content-remix-web
+    restart: unless-stopped
+    depends_on:
+      - content-remix-api
+    environment:
+      - VITE_REMIX_API_BASE=http://localhost:18061
+    ports:
+      - "5173:5173"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,7 @@
 services:
   xiaohongshu-mcp:
-    # 默认使用本地源码构建，确保包含当前分支最新 MCP 工具（如 transcribe_feed_video）
-    build:
-      context: ..
-      dockerfile: Dockerfile
-    image: xiaohongshu-mcp:dev1-local
-    # Docker Hub 镜像（如需快速验证可切换）
-    # image: xpzouying/xiaohongshu-mcp
+    # Docker Hub 镜像（默认）
+    image: xpzouying/xiaohongshu-mcp
     # 阿里云镜像源（国内用户推荐，拉取更快）
     # image: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp
     container_name: xiaohongshu-mcp
@@ -16,77 +11,8 @@ services:
     volumes:
       - ./data:/app/data
       - ./images:/app/images
-      - ../third_party:/app/third_party
     environment:
+      - ROD_BROWSER_BIN=/usr/bin/google-chrome
       - COOKIES_PATH=/app/data/cookies.json
-      - VIDEO_TRANSCRIBE_PROVIDER=${VIDEO_TRANSCRIBE_PROVIDER:-dashscope}
-      - DASHSCOPE_API_KEY=${DASHSCOPE_API_KEY:-}
-      - DASHSCOPE_VIDEO_MODEL=${DASHSCOPE_VIDEO_MODEL:-qwen3.5-flash}
-      - ZHIPUAI_API_KEY=${ZHIPUAI_API_KEY:-}
-      - BIGMODEL_API_KEY=${BIGMODEL_API_KEY:-}
-      - GLM_VIDEO_MODEL=${GLM_VIDEO_MODEL:-glm-4.6v-flash}
     ports:
       - "18060:18060"
-
-  redis:
-    image: redis:7-alpine
-    container_name: content-remix-redis
-    restart: unless-stopped
-    ports:
-      - "6379:6379"
-
-  content-remix-api:
-    build:
-      context: ..
-      dockerfile: apps/content-remix/backend/Dockerfile
-    container_name: content-remix-api
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - xiaohongshu-mcp
-    environment:
-      - CONTENT_REMIX_MCP_URL=http://xiaohongshu-mcp:18060/mcp
-      - CONTENT_REMIX_REDIS_URL=redis://redis:6379/0
-      - CONTENT_REMIX_DATA_DIR=/app/data/content-remix/jobs
-      - CONTENT_REMIX_CANDIDATE_LIMIT_DEFAULT=10
-      - CONTENT_REMIX_CANDIDATE_LIMIT_MAX=20
-      - CONTENT_REMIX_MAX_PARALLEL_CALLS=3
-      - CONTENT_REMIX_REQUEST_TIMEOUT_SECONDS=60
-    volumes:
-      - ./data:/app/data
-    ports:
-      - "18061:18061"
-
-  content-remix-worker:
-    build:
-      context: ..
-      dockerfile: apps/content-remix/backend/Dockerfile
-    container_name: content-remix-worker
-    restart: unless-stopped
-    depends_on:
-      - redis
-      - xiaohongshu-mcp
-    command: ["celery", "-A", "app.celery_worker.celery_app", "worker", "--loglevel=INFO"]
-    environment:
-      - CONTENT_REMIX_MCP_URL=http://xiaohongshu-mcp:18060/mcp
-      - CONTENT_REMIX_REDIS_URL=redis://redis:6379/0
-      - CONTENT_REMIX_DATA_DIR=/app/data/content-remix/jobs
-      - CONTENT_REMIX_CANDIDATE_LIMIT_DEFAULT=10
-      - CONTENT_REMIX_CANDIDATE_LIMIT_MAX=20
-      - CONTENT_REMIX_MAX_PARALLEL_CALLS=3
-      - CONTENT_REMIX_REQUEST_TIMEOUT_SECONDS=60
-    volumes:
-      - ./data:/app/data
-
-  content-remix-web:
-    build:
-      context: ..
-      dockerfile: apps/content-remix/web/Dockerfile
-    container_name: content-remix-web
-    restart: unless-stopped
-    depends_on:
-      - content-remix-api
-    environment:
-      - VITE_REMIX_API_BASE=http://localhost:18061
-    ports:
-      - "5173:5173"

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -475,6 +475,93 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 	}
 }
 
+// handleTranscribeFeedVideo 转写视频帖子
+func (s *AppServer) handleTranscribeFeedVideo(ctx context.Context, args map[string]any) *MCPToolResult {
+	logrus.Info("MCP: 转写视频帖子")
+
+	feedID, ok := args["feed_id"].(string)
+	if !ok || feedID == "" {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "转写失败: 缺少feed_id参数",
+			}},
+			IsError: true,
+		}
+	}
+
+	xsecToken, ok := args["xsec_token"].(string)
+	if !ok || xsecToken == "" {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "转写失败: 缺少xsec_token参数",
+			}},
+			IsError: true,
+		}
+	}
+
+	model, _ := args["model"].(string)
+	provider, _ := args["provider"].(string)
+	apiKey, _ := args["api_key"].(string)
+	language, _ := args["language"].(string)
+	outputDir, _ := args["output_dir"].(string)
+
+	keepArtifacts := false
+	if raw, exists := args["keep_artifacts"]; exists {
+		switch v := raw.(type) {
+		case bool:
+			keepArtifacts = v
+		case string:
+			if parsed, err := strconv.ParseBool(v); err == nil {
+				keepArtifacts = parsed
+			}
+		case float64:
+			keepArtifacts = v != 0
+		}
+	}
+
+	logrus.Infof("MCP: 转写视频帖子 - Feed ID: %s, provider=%s, model=%s, language=%s, keepArtifacts=%v", feedID, provider, model, language, keepArtifacts)
+
+	result, err := s.xiaohongshuService.TranscribeFeedVideo(ctx, &TranscribeFeedVideoRequest{
+		FeedID:        feedID,
+		XsecToken:     xsecToken,
+		Provider:      provider,
+		APIKey:        apiKey,
+		Model:         model,
+		Language:      language,
+		OutputDir:     outputDir,
+		KeepArtifacts: keepArtifacts,
+	})
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "转写失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("转写成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleUserProfile 获取用户主页
 func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取用户主页")

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -6,12 +6,56 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sirupsen/logrus"
 )
 
 // Helper functions for annotation pointers
 func boolPtr(b bool) *bool { return &b }
+
+func transcribeFeedVideoInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"feed_id": {
+				Type:        "string",
+				Description: "小红书视频笔记ID，从Feed列表获取",
+			},
+			"xsec_token": {
+				Type:        "string",
+				Description: "访问令牌，从Feed列表的xsecToken字段获取",
+			},
+			"provider": {
+				Type:        "string",
+				Description: "转写服务商（可选）：dashscope(默认) 或 glm；可用环境变量 VIDEO_TRANSCRIBE_PROVIDER 覆盖",
+				Enum:        []any{"dashscope", "glm"},
+			},
+			"api_key": {
+				Type:        "string",
+				Description: "转写 API Key（可选）。传入时优先于环境变量；不传时按 provider 使用 DASHSCOPE_API_KEY 或 ZHIPUAI_API_KEY/BIGMODEL_API_KEY",
+			},
+			"model": {
+				Type:        "string",
+				Description: "模型名（可选）。dashscope 默认 qwen3.5-flash，glm 默认 glm-4.6v-flash",
+				Enum:        []any{"qwen3.5-flash", "qwen3.5-plus", "glm-4.6v-flash"},
+			},
+			"language": {
+				Type:        "string",
+				Description: "转写语言（可选），如 zh、en。不填默认自动识别",
+			},
+			"output_dir": {
+				Type:        "string",
+				Description: "输出目录（可选），不填默认写入 /tmp/xhs_transcripts/...",
+			},
+			"keep_artifacts": {
+				Type:        "boolean",
+				Description: "兼容参数（可选）；当前链路无本地中间视频文件，默认 false",
+			},
+		},
+		Required: []string{"feed_id", "xsec_token"},
+	}
+}
 
 // MCP 工具参数结构体定义
 
@@ -62,6 +106,18 @@ type FeedDetailArgs struct {
 	ClickMoreReplies bool   `json:"click_more_replies,omitempty" jsonschema:"【仅当load_all_comments为true时生效】是否展开二级回复。true展开子评论，false不展开（默认）"`
 	ReplyLimit       int    `json:"reply_limit,omitempty" jsonschema:"【仅当click_more_replies为true时生效】跳过回复数过多的评论。例如10表示跳过超过10条回复的，默认10"`
 	ScrollSpeed      string `json:"scroll_speed,omitempty" jsonschema:"【仅当load_all_comments为true时生效】滚动速度slow慢速、normal正常、fast快速"`
+}
+
+// TranscribeFeedVideoArgs 转写视频帖子的参数
+type TranscribeFeedVideoArgs struct {
+	FeedID        string `json:"feed_id" jsonschema:"小红书视频笔记ID，从Feed列表获取"`
+	XsecToken     string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	Provider      string `json:"provider,omitempty" jsonschema:"转写服务商（可选）：dashscope(默认) 或 glm；可用环境变量 VIDEO_TRANSCRIBE_PROVIDER 覆盖"`
+	APIKey        string `json:"api_key,omitempty" jsonschema:"转写 API Key（可选）。传入时优先于环境变量；不传时按 provider 使用 DASHSCOPE_API_KEY 或 ZHIPUAI_API_KEY/BIGMODEL_API_KEY"`
+	Model         string `json:"model,omitempty" jsonschema:"模型名（可选）。dashscope 默认 qwen3.5-flash，glm 默认 glm-4.6v-flash"`
+	Language      string `json:"language,omitempty" jsonschema:"转写语言（可选），如 zh、en。不填默认自动识别"`
+	OutputDir     string `json:"output_dir,omitempty" jsonschema:"输出目录（可选），不填默认写入 /tmp/xhs_transcripts/..."`
+	KeepArtifacts bool   `json:"keep_artifacts,omitempty" jsonschema:"兼容参数（可选）；当前链路无本地中间视频文件，默认 false"`
 }
 
 // UserProfileArgs 获取用户主页的参数
@@ -325,6 +381,33 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
+	// 工具 8: 转写视频帖子（MCP-only）
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "transcribe_feed_video",
+			Description: "转写小红书视频帖子内容，返回全文文本与 SRT 文件路径（MCP 专用能力）",
+			InputSchema: transcribeFeedVideoInputSchema(),
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Transcribe Feed Video",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("transcribe_feed_video", func(ctx context.Context, req *mcp.CallToolRequest, args TranscribeFeedVideoArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"feed_id":        args.FeedID,
+				"xsec_token":     args.XsecToken,
+				"provider":       args.Provider,
+				"api_key":        args.APIKey,
+				"model":          args.Model,
+				"language":       args.Language,
+				"output_dir":     args.OutputDir,
+				"keep_artifacts": args.KeepArtifacts,
+			}
+			result := appServer.handleTranscribeFeedVideo(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
 	// 工具 9: 发表评论
 	mcp.AddTool(server,
 		&mcp.Tool{
@@ -443,7 +526,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/pkg/transcribe/transcribe.go
+++ b/pkg/transcribe/transcribe.go
@@ -1,0 +1,592 @@
+package transcribe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultOutputFolder         = "xhs_transcripts"
+	defaultProvider             = "dashscope"
+	providerDashScope           = "dashscope"
+	providerGLM                 = "glm"
+	defaultDashScopeModel       = "qwen3.5-flash"
+	defaultDashScopeEndpoint    = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+	defaultDashScopeVideoFPS    = 2
+	defaultGLMModel             = "glm-4.6v-flash"
+	defaultGLMChatEndpoint      = "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+	defaultGLMRequestTimeout    = 300 * time.Second
+	defaultGLMRetryTimes        = 5
+	maxSubtitleCharsPerLine     = 26
+	defaultSubtitleSegmentSec   = 4
+	defaultSubtitleLanguageHint = "auto"
+)
+
+var (
+	transcriptFieldPattern = regexp.MustCompile(`(?s)"transcript_text"\s*:\s*"(.*?)"\s*,\s*"(?:srt_text|srt|language)"`)
+	srtFieldPattern        = regexp.MustCompile(`(?s)"srt_text"\s*:\s*"(.*?)"\s*(?:,\s*"language"|\s*})`)
+	srtTimestampPattern    = regexp.MustCompile(`\d{2}:\d{2}:\d{2},\d{3}\s+-->\s+\d{2}:\d{2}:\d{2},\d{3}`)
+)
+
+// Request 视频转写请求。
+type Request struct {
+	FeedID        string
+	VideoURL      string
+	Provider      string
+	Model         string
+	Language      string
+	OutputDir     string
+	KeepArtifacts bool
+	APIKey        string
+	Endpoint      string
+}
+
+// Result 视频转写结果。
+type Result struct {
+	FeedID           string
+	TranscriptText   string
+	TXTPath          string
+	SRTPath          string
+	OutputDir        string
+	LanguageUsed     string
+	ArtifactsCleaned bool
+}
+
+// RemoveArtifacts 删除临时文件。
+func RemoveArtifacts(paths []string) error {
+	for _, p := range paths {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// TranscribeVideo 执行视频转写。
+func TranscribeVideo(ctx context.Context, req Request) (*Result, error) {
+	if strings.TrimSpace(req.VideoURL) == "" {
+		return nil, fmt.Errorf("VALIDATION_ERROR: video_url 不能为空")
+	}
+
+	provider, err := resolveProvider(req.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey, err := resolveAPIKey(provider, req.APIKey)
+	if err != nil {
+		return nil, err
+	}
+	model := resolveModel(provider, req.Model)
+	endpoint := resolveEndpoint(provider, req.Endpoint)
+
+	outputDir := strings.TrimSpace(req.OutputDir)
+	if outputDir == "" {
+		feedID := strings.TrimSpace(req.FeedID)
+		if feedID == "" {
+			feedID = "unknown_feed"
+		}
+		outputDir = filepath.Join(os.TempDir(), defaultOutputFolder, feedID, time.Now().Format("20060102150405"))
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("TRANSCRIBE_ERROR: 创建输出目录失败: %w", err)
+	}
+
+	transcriptText, subtitleText, err := transcribeVideoViaProvider(ctx, req.VideoURL, provider, apiKey, model, req.Language, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(transcriptText) == "" {
+		return nil, fmt.Errorf("TRANSCRIBE_ERROR: 模型返回空转写文本")
+	}
+	if strings.TrimSpace(subtitleText) == "" {
+		subtitleText = BuildFallbackSRT(transcriptText)
+	}
+
+	outputPrefix := filepath.Join(outputDir, "transcript")
+	txtPath := outputPrefix + ".txt"
+	srtPath := outputPrefix + ".srt"
+
+	if err := os.WriteFile(txtPath, []byte(transcriptText), 0o644); err != nil {
+		return nil, fmt.Errorf("TRANSCRIBE_ERROR: 写入 txt 结果失败: %w", err)
+	}
+	if err := os.WriteFile(srtPath, []byte(subtitleText), 0o644); err != nil {
+		return nil, fmt.Errorf("TRANSCRIBE_ERROR: 写入 srt 结果失败: %w", err)
+	}
+
+	cleaned := !req.KeepArtifacts
+
+	languageUsed := strings.TrimSpace(req.Language)
+	if languageUsed == "" {
+		languageUsed = defaultSubtitleLanguageHint
+	}
+
+	return &Result{
+		FeedID:           req.FeedID,
+		TranscriptText:   transcriptText,
+		TXTPath:          txtPath,
+		SRTPath:          srtPath,
+		OutputDir:        outputDir,
+		LanguageUsed:     languageUsed,
+		ArtifactsCleaned: cleaned,
+	}, nil
+}
+
+func resolveProvider(custom string) (string, error) {
+	provider := strings.ToLower(strings.TrimSpace(custom))
+	if provider == "" {
+		if envProvider := strings.ToLower(strings.TrimSpace(os.Getenv("VIDEO_TRANSCRIBE_PROVIDER"))); envProvider != "" {
+			provider = envProvider
+		} else {
+			provider = defaultProvider
+		}
+	}
+	switch provider {
+	case providerDashScope, providerGLM:
+		return provider, nil
+	default:
+		return "", fmt.Errorf("VALIDATION_ERROR: provider 仅支持 dashscope 或 glm")
+	}
+}
+
+func resolveAPIKey(provider, custom string) (string, error) {
+	if trimmed := strings.TrimSpace(custom); trimmed != "" {
+		return trimmed, nil
+	}
+	switch provider {
+	case providerDashScope:
+		if envKey := strings.TrimSpace(os.Getenv("DASHSCOPE_API_KEY")); envKey != "" {
+			return envKey, nil
+		}
+		return "", fmt.Errorf("DEPENDENCY_ERROR: 未配置阿里云百炼 API Key，请设置 DASHSCOPE_API_KEY")
+	case providerGLM:
+		if envKey := strings.TrimSpace(os.Getenv("ZHIPUAI_API_KEY")); envKey != "" {
+			return envKey, nil
+		}
+		if envKey := strings.TrimSpace(os.Getenv("BIGMODEL_API_KEY")); envKey != "" {
+			return envKey, nil
+		}
+		return "", fmt.Errorf("DEPENDENCY_ERROR: 未配置 GLM API Key，请设置 ZHIPUAI_API_KEY 或 BIGMODEL_API_KEY")
+	default:
+		return "", fmt.Errorf("VALIDATION_ERROR: provider 仅支持 dashscope 或 glm")
+	}
+}
+
+func resolveModel(provider, custom string) string {
+	if trimmed := strings.TrimSpace(custom); trimmed != "" {
+		return trimmed
+	}
+	switch provider {
+	case providerDashScope:
+		if envModel := strings.TrimSpace(os.Getenv("DASHSCOPE_VIDEO_MODEL")); envModel != "" {
+			return envModel
+		}
+		return defaultDashScopeModel
+	case providerGLM:
+		if envModel := strings.TrimSpace(os.Getenv("GLM_VIDEO_MODEL")); envModel != "" {
+			return envModel
+		}
+		return defaultGLMModel
+	default:
+		return defaultDashScopeModel
+	}
+}
+
+func resolveEndpoint(provider, custom string) string {
+	if trimmed := strings.TrimSpace(custom); trimmed != "" {
+		return trimmed
+	}
+	switch provider {
+	case providerDashScope:
+		if envEndpoint := strings.TrimSpace(os.Getenv("DASHSCOPE_VIDEO_API_ENDPOINT")); envEndpoint != "" {
+			return envEndpoint
+		}
+		return defaultDashScopeEndpoint
+	case providerGLM:
+		if envEndpoint := strings.TrimSpace(os.Getenv("GLM_VIDEO_API_ENDPOINT")); envEndpoint != "" {
+			return envEndpoint
+		}
+		return defaultGLMChatEndpoint
+	default:
+		return defaultDashScopeEndpoint
+	}
+}
+
+func transcribeVideoViaProvider(ctx context.Context, videoURL, provider, apiKey, model, language, endpoint string) (string, string, error) {
+	prompt := BuildTranscribePrompt(language)
+	payload, err := buildProviderPayload(provider, model, videoURL, prompt)
+	if err != nil {
+		return "", "", err
+	}
+
+	rawBody, err := callTranscribeAPI(ctx, provider, apiKey, endpoint, payload)
+	if err != nil {
+		return "", "", err
+	}
+	return parseGLMResponse(rawBody)
+}
+
+func buildProviderPayload(provider, model, videoURL, prompt string) ([]byte, error) {
+	switch provider {
+	case providerDashScope:
+		payload := map[string]any{
+			"model": model,
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{
+							"type": "video_url",
+							"video_url": map[string]string{
+								"url": videoURL,
+							},
+							"fps": defaultDashScopeVideoFPS,
+						},
+						{
+							"type": "text",
+							"text": prompt,
+						},
+					},
+				},
+			},
+			"stream": false,
+		}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("TRANSCRIBE_ERROR: 序列化 DashScope 请求失败: %w", err)
+		}
+		return payloadBytes, nil
+	case providerGLM:
+		payload := map[string]any{
+			"model": model,
+			"messages": []map[string]any{
+				{
+					"role": "user",
+					"content": []map[string]any{
+						{
+							"type": "video_url",
+							"video_url": map[string]string{
+								"url": videoURL,
+							},
+						},
+						{
+							"type": "text",
+							"text": prompt,
+						},
+					},
+				},
+			},
+			"thinking": map[string]string{
+				"type": "disabled",
+			},
+			"stream": false,
+		}
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("TRANSCRIBE_ERROR: 序列化 GLM 请求失败: %w", err)
+		}
+		return payloadBytes, nil
+	default:
+		return nil, fmt.Errorf("VALIDATION_ERROR: provider 仅支持 dashscope 或 glm")
+	}
+}
+
+func callTranscribeAPI(ctx context.Context, provider, apiKey, endpoint string, payloadBytes []byte) ([]byte, error) {
+	client := &http.Client{Timeout: defaultGLMRequestTimeout}
+	lastErr := fmt.Errorf("%s_API_ERROR: 未发起请求", strings.ToUpper(provider))
+	for attempt := 1; attempt <= defaultGLMRetryTimes; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payloadBytes))
+		if err != nil {
+			return nil, fmt.Errorf("%s_API_ERROR: 构建请求失败: %w", strings.ToUpper(provider), err)
+		}
+		request.Header.Set("Authorization", "Bearer "+apiKey)
+		request.Header.Set("Content-Type", "application/json")
+
+		response, err := client.Do(request)
+		if err != nil {
+			lastErr = fmt.Errorf("%s_API_ERROR: 调用失败: %w", strings.ToUpper(provider), err)
+			if attempt < defaultGLMRetryTimes {
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			break
+		}
+
+		rawBody, readErr := io.ReadAll(response.Body)
+		response.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("%s_API_ERROR: 读取响应失败: %w", strings.ToUpper(provider), readErr)
+			if attempt < defaultGLMRetryTimes {
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			break
+		}
+
+		if response.StatusCode == http.StatusOK {
+			return rawBody, nil
+		}
+
+		message := parseGLMError(rawBody)
+		lastErr = fmt.Errorf("%s_API_ERROR: status=%d, message=%s", strings.ToUpper(provider), response.StatusCode, message)
+		if (response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError) && attempt < defaultGLMRetryTimes {
+			time.Sleep(time.Duration(attempt*2) * time.Second)
+			continue
+		}
+		break
+	}
+	return nil, lastErr
+}
+
+func BuildTranscribePrompt(language string) string {
+	languageHint := strings.TrimSpace(language)
+	if languageHint == "" {
+		languageHint = "auto"
+	}
+	return fmt.Sprintf(`请分析视频中的语音内容并返回严格 JSON，不要输出 markdown 或解释文字。
+JSON 格式如下：
+{"transcript_text":"完整转写文本","srt_text":"标准SRT字幕","language":"识别语言"}
+要求：
+1) transcript_text 必须为完整文本，按自然段组织。
+2) srt_text 必须为标准 SRT 格式（编号、时间戳、字幕行）。
+3) 若无法准确生成时间戳，srt_text 可留空字符串。
+4) 输出语言优先使用：%s。`, languageHint)
+}
+
+func parseGLMResponse(rawBody []byte) (string, string, error) {
+	type apiError struct {
+		Code    any    `json:"code"`
+		Message string `json:"message"`
+	}
+	type choice struct {
+		Message struct {
+			Content any `json:"content"`
+		} `json:"message"`
+	}
+	type response struct {
+		Error   *apiError `json:"error"`
+		Choices []choice  `json:"choices"`
+	}
+
+	var parsed response
+	if err := json.Unmarshal(rawBody, &parsed); err != nil {
+		return "", "", fmt.Errorf("GLM_API_ERROR: 解析响应失败: %w", err)
+	}
+	if parsed.Error != nil {
+		return "", "", fmt.Errorf("GLM_API_ERROR: %s", strings.TrimSpace(parsed.Error.Message))
+	}
+	if len(parsed.Choices) == 0 {
+		return "", "", fmt.Errorf("GLM_API_ERROR: choices 为空")
+	}
+
+	rawContent := extractMessageContent(parsed.Choices[0].Message.Content)
+	if strings.TrimSpace(rawContent) == "" {
+		return "", "", fmt.Errorf("GLM_API_ERROR: 返回内容为空")
+	}
+	transcriptText, subtitleText, parseOK := parseStructuredTranscription(rawContent)
+	if !parseOK {
+		transcriptText = strings.TrimSpace(rawContent)
+	}
+	if strings.TrimSpace(transcriptText) == "" {
+		return "", "", fmt.Errorf("GLM_API_ERROR: 解析后转写文本为空")
+	}
+	if strings.TrimSpace(subtitleText) == "" || !isLikelySRT(subtitleText) {
+		subtitleText = BuildFallbackSRT(transcriptText)
+	}
+	return transcriptText, subtitleText, nil
+}
+
+func extractMessageContent(content any) string {
+	switch value := content.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []any:
+		lines := make([]string, 0, len(value))
+		for _, item := range value {
+			switch typedItem := item.(type) {
+			case string:
+				lines = append(lines, strings.TrimSpace(typedItem))
+			case map[string]any:
+				if textValue, ok := typedItem["text"].(string); ok {
+					lines = append(lines, strings.TrimSpace(textValue))
+				}
+			}
+		}
+		return strings.TrimSpace(strings.Join(lines, "\n"))
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", value))
+	}
+}
+
+func parseStructuredTranscription(raw string) (string, string, bool) {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.TrimPrefix(cleaned, "```json")
+	cleaned = strings.TrimPrefix(cleaned, "```")
+	cleaned = strings.TrimSuffix(cleaned, "```")
+	cleaned = strings.TrimSpace(cleaned)
+
+	startIndex := strings.Index(cleaned, "{")
+	endIndex := strings.LastIndex(cleaned, "}")
+	if startIndex >= 0 && endIndex > startIndex {
+		cleaned = cleaned[startIndex : endIndex+1]
+	}
+
+	type payload struct {
+		TranscriptText string `json:"transcript_text"`
+		SRTText        string `json:"srt_text"`
+		Transcript     string `json:"transcript"`
+		SRT            string `json:"srt"`
+		Text           string `json:"text"`
+	}
+	var parsed payload
+	if err := json.Unmarshal([]byte(cleaned), &parsed); err != nil {
+		transcriptText := extractFieldByPattern(cleaned, transcriptFieldPattern)
+		subtitleText := extractFieldByPattern(cleaned, srtFieldPattern)
+		if transcriptText == "" {
+			return "", "", false
+		}
+		return transcriptText, subtitleText, true
+	}
+
+	transcriptText := strings.TrimSpace(parsed.TranscriptText)
+	if transcriptText == "" {
+		transcriptText = strings.TrimSpace(parsed.Transcript)
+	}
+	if transcriptText == "" {
+		transcriptText = strings.TrimSpace(parsed.Text)
+	}
+	if transcriptText == "" {
+		return "", "", false
+	}
+
+	subtitleText := strings.TrimSpace(parsed.SRTText)
+	if subtitleText == "" {
+		subtitleText = strings.TrimSpace(parsed.SRT)
+	}
+	return transcriptText, subtitleText, true
+}
+
+func extractFieldByPattern(input string, pattern *regexp.Regexp) string {
+	matches := pattern.FindStringSubmatch(input)
+	if len(matches) < 2 {
+		return ""
+	}
+	value := strings.TrimSpace(matches[1])
+	value = strings.ReplaceAll(value, `\n`, "\n")
+	value = strings.ReplaceAll(value, `\t`, "\t")
+	value = strings.ReplaceAll(value, `\"`, `"`)
+	value = strings.ReplaceAll(value, `\\`, `\`)
+	return strings.TrimSpace(value)
+}
+
+func BuildFallbackSRT(transcript string) string {
+	cleanedTranscript := strings.TrimSpace(transcript)
+	if cleanedTranscript == "" {
+		return ""
+	}
+	normalized := strings.ReplaceAll(cleanedTranscript, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	normalized = regexp.MustCompile(`\n+`).ReplaceAllString(normalized, "\n")
+
+	parts := make([]string, 0)
+	for _, paragraph := range strings.Split(normalized, "\n") {
+		paragraph = strings.TrimSpace(paragraph)
+		if paragraph == "" {
+			continue
+		}
+		parts = append(parts, splitByRuneLength(paragraph, maxSubtitleCharsPerLine)...)
+	}
+	if len(parts) == 0 {
+		parts = append(parts, splitByRuneLength(normalized, maxSubtitleCharsPerLine)...)
+	}
+
+	var builder strings.Builder
+	startSeconds := 0
+	for index, textLine := range parts {
+		if strings.TrimSpace(textLine) == "" {
+			continue
+		}
+		endSeconds := startSeconds + defaultSubtitleSegmentSec
+		builder.WriteString(strconv.Itoa(index + 1))
+		builder.WriteString("\n")
+		builder.WriteString(formatSRTTimestamp(startSeconds))
+		builder.WriteString(" --> ")
+		builder.WriteString(formatSRTTimestamp(endSeconds))
+		builder.WriteString("\n")
+		builder.WriteString(textLine)
+		builder.WriteString("\n\n")
+		startSeconds = endSeconds
+	}
+	return strings.TrimSpace(builder.String()) + "\n"
+}
+
+func splitByRuneLength(text string, maxLength int) []string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" || maxLength <= 0 {
+		return nil
+	}
+	runes := []rune(trimmed)
+	if len(runes) <= maxLength {
+		return []string{trimmed}
+	}
+
+	lines := make([]string, 0, len(runes)/maxLength+1)
+	startIndex := 0
+	for startIndex < len(runes) {
+		endIndex := startIndex + maxLength
+		if endIndex > len(runes) {
+			endIndex = len(runes)
+		}
+		lines = append(lines, strings.TrimSpace(string(runes[startIndex:endIndex])))
+		startIndex = endIndex
+	}
+	return lines
+}
+
+func formatSRTTimestamp(totalSeconds int) string {
+	if totalSeconds < 0 {
+		totalSeconds = 0
+	}
+	hours := totalSeconds / 3600
+	minutes := (totalSeconds % 3600) / 60
+	seconds := totalSeconds % 60
+	return fmt.Sprintf("%02d:%02d:%02d,000", hours, minutes, seconds)
+}
+
+func parseGLMError(rawBody []byte) string {
+	type apiError struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	var parsed apiError
+	if err := json.Unmarshal(rawBody, &parsed); err == nil && strings.TrimSpace(parsed.Error.Message) != "" {
+		return strings.TrimSpace(parsed.Error.Message)
+	}
+	bodyText := strings.TrimSpace(string(rawBody))
+	if len(bodyText) > 200 {
+		return bodyText[:200]
+	}
+	return bodyText
+}
+
+func isLikelySRT(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	return srtTimestampPattern.MatchString(trimmed)
+}

--- a/pkg/transcribe/transcribe.go
+++ b/pkg/transcribe/transcribe.go
@@ -25,8 +25,8 @@ const (
 	defaultDashScopeVideoFPS    = 2
 	defaultGLMModel             = "glm-4.6v-flash"
 	defaultGLMChatEndpoint      = "https://open.bigmodel.cn/api/paas/v4/chat/completions"
-	defaultGLMRequestTimeout    = 300 * time.Second
-	defaultGLMRetryTimes        = 5
+	defaultRequestTimeout       = 300 * time.Second
+	defaultRetryTimes           = 5
 	maxSubtitleCharsPerLine     = 26
 	defaultSubtitleSegmentSec   = 4
 	defaultSubtitleLanguageHint = "auto"
@@ -36,6 +36,7 @@ var (
 	transcriptFieldPattern = regexp.MustCompile(`(?s)"transcript_text"\s*:\s*"(.*?)"\s*,\s*"(?:srt_text|srt|language)"`)
 	srtFieldPattern        = regexp.MustCompile(`(?s)"srt_text"\s*:\s*"(.*?)"\s*(?:,\s*"language"|\s*})`)
 	srtTimestampPattern    = regexp.MustCompile(`\d{2}:\d{2}:\d{2},\d{3}\s+-->\s+\d{2}:\d{2}:\d{2},\d{3}`)
+	multipleNewlines       = regexp.MustCompile(`\n+`)
 )
 
 // Request 视频转写请求。
@@ -236,7 +237,7 @@ func transcribeVideoViaProvider(ctx context.Context, videoURL, provider, apiKey,
 	if err != nil {
 		return "", "", err
 	}
-	return parseGLMResponse(rawBody)
+	return parseTranscriptionResponse(rawBody)
 }
 
 func buildProviderPayload(provider, model, videoURL, prompt string) ([]byte, error) {
@@ -305,9 +306,9 @@ func buildProviderPayload(provider, model, videoURL, prompt string) ([]byte, err
 }
 
 func callTranscribeAPI(ctx context.Context, provider, apiKey, endpoint string, payloadBytes []byte) ([]byte, error) {
-	client := &http.Client{Timeout: defaultGLMRequestTimeout}
+	client := &http.Client{Timeout: defaultRequestTimeout}
 	lastErr := fmt.Errorf("%s_API_ERROR: 未发起请求", strings.ToUpper(provider))
-	for attempt := 1; attempt <= defaultGLMRetryTimes; attempt++ {
+	for attempt := 1; attempt <= defaultRetryTimes; attempt++ {
 		request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payloadBytes))
 		if err != nil {
 			return nil, fmt.Errorf("%s_API_ERROR: 构建请求失败: %w", strings.ToUpper(provider), err)
@@ -318,7 +319,7 @@ func callTranscribeAPI(ctx context.Context, provider, apiKey, endpoint string, p
 		response, err := client.Do(request)
 		if err != nil {
 			lastErr = fmt.Errorf("%s_API_ERROR: 调用失败: %w", strings.ToUpper(provider), err)
-			if attempt < defaultGLMRetryTimes {
+			if attempt < defaultRetryTimes {
 				time.Sleep(time.Duration(attempt) * time.Second)
 				continue
 			}
@@ -329,7 +330,7 @@ func callTranscribeAPI(ctx context.Context, provider, apiKey, endpoint string, p
 		response.Body.Close()
 		if readErr != nil {
 			lastErr = fmt.Errorf("%s_API_ERROR: 读取响应失败: %w", strings.ToUpper(provider), readErr)
-			if attempt < defaultGLMRetryTimes {
+			if attempt < defaultRetryTimes {
 				time.Sleep(time.Duration(attempt) * time.Second)
 				continue
 			}
@@ -340,9 +341,9 @@ func callTranscribeAPI(ctx context.Context, provider, apiKey, endpoint string, p
 			return rawBody, nil
 		}
 
-		message := parseGLMError(rawBody)
+		message := parseProviderError(rawBody)
 		lastErr = fmt.Errorf("%s_API_ERROR: status=%d, message=%s", strings.ToUpper(provider), response.StatusCode, message)
-		if (response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError) && attempt < defaultGLMRetryTimes {
+		if (response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError) && attempt < defaultRetryTimes {
 			time.Sleep(time.Duration(attempt*2) * time.Second)
 			continue
 		}
@@ -366,7 +367,7 @@ JSON 格式如下：
 4) 输出语言优先使用：%s。`, languageHint)
 }
 
-func parseGLMResponse(rawBody []byte) (string, string, error) {
+func parseTranscriptionResponse(rawBody []byte) (string, string, error) {
 	type apiError struct {
 		Code    any    `json:"code"`
 		Message string `json:"message"`
@@ -499,7 +500,7 @@ func BuildFallbackSRT(transcript string) string {
 	}
 	normalized := strings.ReplaceAll(cleanedTranscript, "\r\n", "\n")
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
-	normalized = regexp.MustCompile(`\n+`).ReplaceAllString(normalized, "\n")
+	normalized = multipleNewlines.ReplaceAllString(normalized, "\n")
 
 	parts := make([]string, 0)
 	for _, paragraph := range strings.Split(normalized, "\n") {
@@ -566,7 +567,7 @@ func formatSRTTimestamp(totalSeconds int) string {
 	return fmt.Sprintf("%02d:%02d:%02d,000", hours, minutes, seconds)
 }
 
-func parseGLMError(rawBody []byte) string {
+func parseProviderError(rawBody []byte) string {
 	type apiError struct {
 		Error struct {
 			Message string `json:"message"`

--- a/pkg/transcribe/transcribe_test.go
+++ b/pkg/transcribe/transcribe_test.go
@@ -254,7 +254,7 @@ func TestExtractMessageContent(t *testing.T) {
 	require.Contains(t, result, "第二段")
 }
 
-func TestParseGLMResponse(t *testing.T) {
+func TestParseTranscriptionResponse(t *testing.T) {
 	mockResponse := map[string]any{
 		"choices": []any{
 			map[string]any{
@@ -267,13 +267,13 @@ func TestParseGLMResponse(t *testing.T) {
 	raw, err := json.Marshal(mockResponse)
 	require.NoError(t, err)
 
-	transcriptText, subtitleText, err := parseGLMResponse(raw)
+	transcriptText, subtitleText, err := parseTranscriptionResponse(raw)
 	require.NoError(t, err)
 	require.Equal(t, "你好", transcriptText)
 	require.Contains(t, subtitleText, "00:00:00,000 --> 00:00:04,000")
 }
 
-func TestParseGLMResponse_InvalidSRTFallback(t *testing.T) {
+func TestParseTranscriptionResponse_InvalidSRTFallback(t *testing.T) {
 	mockResponse := map[string]any{
 		"choices": []any{
 			map[string]any{
@@ -286,7 +286,7 @@ func TestParseGLMResponse_InvalidSRTFallback(t *testing.T) {
 	raw, err := json.Marshal(mockResponse)
 	require.NoError(t, err)
 
-	_, subtitleText, err := parseGLMResponse(raw)
+	_, subtitleText, err := parseTranscriptionResponse(raw)
 	require.NoError(t, err)
 	require.Contains(t, subtitleText, "00:00:00,000 --> 00:00:04,000")
 	require.NotContains(t, subtitleText, "0.00 -- --")

--- a/pkg/transcribe/transcribe_test.go
+++ b/pkg/transcribe/transcribe_test.go
@@ -1,0 +1,293 @@
+package transcribe
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveArtifacts(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := tmpDir + "/a.tmp"
+	file2 := tmpDir + "/b.tmp"
+
+	require.NoError(t, os.WriteFile(file1, []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte("b"), 0o644))
+
+	require.NoError(t, RemoveArtifacts([]string{file1, file2}))
+	_, err1 := os.Stat(file1)
+	_, err2 := os.Stat(file2)
+	require.Error(t, err1)
+	require.Error(t, err2)
+}
+
+func TestResolveAPIKey(t *testing.T) {
+	cases := []struct {
+		name          string
+		provider      string
+		custom        string
+		dashEnv       string
+		zhipuEnv      string
+		bigModelEnv   string
+		expectedKey   string
+		expectFailure bool
+	}{
+		{
+			name:        "custom key has highest priority",
+			provider:    providerDashScope,
+			custom:      "custom-key",
+			dashEnv:     "dash-env",
+			zhipuEnv:    "zhipu-env",
+			bigModelEnv: "bigmodel-env",
+			expectedKey: "custom-key",
+		},
+		{
+			name:        "dashscope env used",
+			provider:    providerDashScope,
+			dashEnv:     "dash-env",
+			expectedKey: "dash-env",
+		},
+		{
+			name:        "glm env used",
+			provider:    providerGLM,
+			zhipuEnv:    "zhipu-env",
+			bigModelEnv: "bigmodel-env",
+			expectedKey: "zhipu-env",
+		},
+		{
+			name:          "glm fallback bigmodel env",
+			provider:      providerGLM,
+			bigModelEnv:   "bigmodel-env",
+			expectedKey:   "bigmodel-env",
+			expectFailure: false,
+		},
+		{
+			name:          "no key returns error",
+			provider:      providerDashScope,
+			expectFailure: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("DASHSCOPE_API_KEY", testCase.dashEnv)
+			t.Setenv("ZHIPUAI_API_KEY", testCase.zhipuEnv)
+			t.Setenv("BIGMODEL_API_KEY", testCase.bigModelEnv)
+
+			key, err := resolveAPIKey(testCase.provider, testCase.custom)
+			if testCase.expectFailure {
+				require.Error(t, err)
+				require.Empty(t, key)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedKey, key)
+		})
+	}
+}
+
+func TestResolveGLMModel(t *testing.T) {
+	cases := []struct {
+		name        string
+		provider    string
+		custom      string
+		glmEnvModel string
+		dashEnvMode string
+		expectModel string
+	}{
+		{
+			name:        "custom model wins",
+			provider:    providerDashScope,
+			custom:      "glm-custom",
+			glmEnvModel: "glm-env",
+			dashEnvMode: "qwen-env",
+			expectModel: "glm-custom",
+		},
+		{
+			name:        "dashscope env model used",
+			provider:    providerDashScope,
+			dashEnvMode: "qwen-env",
+			expectModel: "qwen-env",
+		},
+		{
+			name:        "glm env model used",
+			provider:    providerGLM,
+			glmEnvModel: "glm-env",
+			expectModel: "glm-env",
+		},
+		{
+			name:        "dashscope default model",
+			provider:    providerDashScope,
+			expectModel: defaultDashScopeModel,
+		},
+		{
+			name:        "glm default model",
+			provider:    providerGLM,
+			expectModel: defaultGLMModel,
+		},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("GLM_VIDEO_MODEL", testCase.glmEnvModel)
+			t.Setenv("DASHSCOPE_VIDEO_MODEL", testCase.dashEnvMode)
+			got := resolveModel(testCase.provider, testCase.custom)
+			require.Equal(t, testCase.expectModel, got)
+		})
+	}
+}
+
+func TestResolveProvider(t *testing.T) {
+	t.Setenv("VIDEO_TRANSCRIBE_PROVIDER", "")
+	got, err := resolveProvider("")
+	require.NoError(t, err)
+	require.Equal(t, providerDashScope, got)
+
+	got, err = resolveProvider("glm")
+	require.NoError(t, err)
+	require.Equal(t, providerGLM, got)
+
+	_, err = resolveProvider("unknown")
+	require.Error(t, err)
+}
+
+func TestBuildProviderPayload_UsesVideoURL(t *testing.T) {
+	videoURL := "http://sns-video-bd.xhscdn.com/stream/1/110/259/demo.mp4"
+	prompt := "test prompt"
+
+	for _, provider := range []string{providerDashScope, providerGLM} {
+		payloadBytes, err := buildProviderPayload(provider, "test-model", videoURL, prompt)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+
+		messages, ok := payload["messages"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, messages)
+		message, ok := messages[0].(map[string]any)
+		require.True(t, ok)
+		content, ok := message["content"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, content)
+		videoItem, ok := content[0].(map[string]any)
+		require.True(t, ok)
+		videoObj, ok := videoItem["video_url"].(map[string]any)
+		require.True(t, ok)
+
+		gotURL, ok := videoObj["url"].(string)
+		require.True(t, ok)
+		require.Equal(t, videoURL, gotURL)
+	}
+}
+
+func TestParseStructuredTranscription(t *testing.T) {
+	cases := []struct {
+		name               string
+		raw                string
+		expectTranscript   string
+		expectSRTContains  string
+		expectParseSuccess bool
+	}{
+		{
+			name:               "plain json",
+			raw:                `{"transcript_text":"第一句","srt_text":"1\n00:00:00,000 --> 00:00:04,000\n第一句"}`,
+			expectTranscript:   "第一句",
+			expectSRTContains:  "00:00:00,000 --> 00:00:04,000",
+			expectParseSuccess: true,
+		},
+		{
+			name:               "markdown fenced json",
+			raw:                "```json\n{\"transcript\":\"第二句\"}\n```",
+			expectTranscript:   "第二句",
+			expectParseSuccess: true,
+		},
+		{
+			name:               "invalid json",
+			raw:                "这是一段纯文本，不是JSON",
+			expectParseSuccess: false,
+		},
+		{
+			name:               "pseudo json with raw newlines",
+			raw:                "```json\n{\n  \"transcript_text\": \"第一行\n第二行\",\n  \"srt_text\": \"1\\n00:00:00,000 --> 00:00:04,000\\n第一行\"\n}\n```",
+			expectTranscript:   "第一行\n第二行",
+			expectSRTContains:  "00:00:00,000 --> 00:00:04,000",
+			expectParseSuccess: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			transcriptText, subtitleText, ok := parseStructuredTranscription(testCase.raw)
+			require.Equal(t, testCase.expectParseSuccess, ok)
+			if !ok {
+				return
+			}
+			require.Equal(t, testCase.expectTranscript, transcriptText)
+			if testCase.expectSRTContains != "" {
+				require.Contains(t, subtitleText, testCase.expectSRTContains)
+			}
+		})
+	}
+}
+
+func TestBuildFallbackSRT(t *testing.T) {
+	subtitle := BuildFallbackSRT("第一句。\n第二句。")
+	require.Contains(t, subtitle, "1\n00:00:00,000 --> 00:00:04,000")
+	require.Contains(t, subtitle, "2\n00:00:04,000 --> 00:00:08,000")
+	require.Contains(t, subtitle, "第一句。")
+	require.Contains(t, subtitle, "第二句。")
+}
+
+func TestExtractMessageContent(t *testing.T) {
+	content := []any{
+		map[string]any{"text": "第一段"},
+		"第二段",
+	}
+	result := extractMessageContent(content)
+	require.Contains(t, result, "第一段")
+	require.Contains(t, result, "第二段")
+}
+
+func TestParseGLMResponse(t *testing.T) {
+	mockResponse := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"content": `{"transcript_text":"你好","srt_text":"1\n00:00:00,000 --> 00:00:04,000\n你好"}`,
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(mockResponse)
+	require.NoError(t, err)
+
+	transcriptText, subtitleText, err := parseGLMResponse(raw)
+	require.NoError(t, err)
+	require.Equal(t, "你好", transcriptText)
+	require.Contains(t, subtitleText, "00:00:00,000 --> 00:00:04,000")
+}
+
+func TestParseGLMResponse_InvalidSRTFallback(t *testing.T) {
+	mockResponse := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"content": `{"transcript_text":"你好世界","srt_text":"1 0.00 -- -- 你好世界"}`,
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(mockResponse)
+	require.NoError(t, err)
+
+	_, subtitleText, err := parseGLMResponse(raw)
+	require.NoError(t, err)
+	require.Contains(t, subtitleText, "00:00:00,000 --> 00:00:04,000")
+	require.NotContains(t, subtitleText, "0.00 -- --")
+}

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -14,6 +15,7 @@ import (
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/pkg/downloader"
+	"github.com/xpzouying/xiaohongshu-mcp/pkg/transcribe"
 	"github.com/xpzouying/xiaohongshu-mcp/pkg/xhsutil"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
@@ -78,6 +80,29 @@ type PublishVideoResponse struct {
 	Video   string `json:"video"`
 	Status  string `json:"status"`
 	PostID  string `json:"post_id,omitempty"`
+}
+
+// TranscribeFeedVideoRequest 视频转写请求
+type TranscribeFeedVideoRequest struct {
+	FeedID        string `json:"feed_id"`
+	XsecToken     string `json:"xsec_token"`
+	Provider      string `json:"provider,omitempty"`
+	APIKey        string `json:"api_key,omitempty"`
+	Model         string `json:"model,omitempty"`
+	Language      string `json:"language,omitempty"`
+	OutputDir     string `json:"output_dir,omitempty"`
+	KeepArtifacts bool   `json:"keep_artifacts,omitempty"`
+}
+
+// TranscribeFeedVideoResponse 视频转写响应
+type TranscribeFeedVideoResponse struct {
+	FeedID           string `json:"feed_id"`
+	TranscriptText   string `json:"transcript_text"`
+	TXTPath          string `json:"txt_path"`
+	SRTPath          string `json:"srt_path"`
+	OutputDir        string `json:"output_dir"`
+	LanguageUsed     string `json:"language_used"`
+	ArtifactsCleaned bool   `json:"artifacts_cleaned"`
 }
 
 // FeedsListResponse Feeds列表响应
@@ -419,6 +444,63 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 	}
 
 	return response, nil
+}
+
+// TranscribeFeedVideo 转写 feed 视频内容
+func (s *XiaohongshuService) TranscribeFeedVideo(ctx context.Context, req *TranscribeFeedVideoRequest) (*TranscribeFeedVideoResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("VALIDATION_ERROR: 请求参数不能为空")
+	}
+	if req.FeedID == "" {
+		return nil, fmt.Errorf("VALIDATION_ERROR: feed_id 不能为空")
+	}
+	if req.XsecToken == "" {
+		return nil, fmt.Errorf("VALIDATION_ERROR: xsec_token 不能为空")
+	}
+
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewFeedDetailAction(page)
+	detail, err := action.GetFeedDetailWithConfig(ctx, req.FeedID, req.XsecToken, false, xiaohongshu.DefaultCommentLoadConfig())
+	if err != nil {
+		return nil, fmt.Errorf("VIDEO_RESOLVE_ERROR: 获取帖子详情失败: %w", err)
+	}
+
+	videoURL := xiaohongshu.ResolveVideoURLFromDetail(detail.Note)
+	if videoURL == "" {
+		videoURL, _ = xiaohongshu.ResolveVideoURLFromPage(page)
+	}
+	if videoURL == "" {
+		return nil, fmt.Errorf("VIDEO_RESOLVE_ERROR: 未解析到视频地址，当前帖子可能不是视频或页面结构已变化")
+	}
+
+	transcribeResult, err := transcribe.TranscribeVideo(ctx, transcribe.Request{
+		FeedID:        req.FeedID,
+		VideoURL:      videoURL,
+		Provider:      strings.TrimSpace(req.Provider),
+		APIKey:        strings.TrimSpace(req.APIKey),
+		Model:         strings.TrimSpace(req.Model),
+		Language:      req.Language,
+		OutputDir:     req.OutputDir,
+		KeepArtifacts: req.KeepArtifacts,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &TranscribeFeedVideoResponse{
+		FeedID:           transcribeResult.FeedID,
+		TranscriptText:   transcribeResult.TranscriptText,
+		TXTPath:          transcribeResult.TXTPath,
+		SRTPath:          transcribeResult.SRTPath,
+		OutputDir:        transcribeResult.OutputDir,
+		LanguageUsed:     transcribeResult.LanguageUsed,
+		ArtifactsCleaned: transcribeResult.ArtifactsCleaned,
+	}, nil
 }
 
 // UserProfile 获取用户信息

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -103,6 +103,7 @@ type FeedDetail struct {
 	User         User              `json:"user"`
 	InteractInfo InteractInfo      `json:"interactInfo"`
 	ImageList    []DetailImageInfo `json:"imageList"`
+	Video        *DetailVideo      `json:"video,omitempty"`
 }
 
 // DetailImageInfo 表示详情页的图片信息
@@ -112,6 +113,31 @@ type DetailImageInfo struct {
 	URLDefault string `json:"urlDefault"`
 	URLPre     string `json:"urlPre"`
 	LivePhoto  bool   `json:"livePhoto,omitempty"`
+}
+
+// DetailVideo 表示详情页的视频信息
+type DetailVideo struct {
+	Media DetailVideoMedia `json:"media"`
+}
+
+// DetailVideoMedia 表示视频媒体信息
+type DetailVideoMedia struct {
+	Stream         DetailVideoStream `json:"stream"`
+	OriginVideoKey string            `json:"originVideoKey"`
+}
+
+// DetailVideoStream 表示不同编码的视频流
+type DetailVideoStream struct {
+	H264 []DetailVideoStreamItem `json:"h264"`
+	H265 []DetailVideoStreamItem `json:"h265"`
+	H266 []DetailVideoStreamItem `json:"h266"`
+	AV1  []DetailVideoStreamItem `json:"av1"`
+}
+
+// DetailVideoStreamItem 表示单个视频流地址
+type DetailVideoStreamItem struct {
+	MasterURL  string   `json:"masterUrl"`
+	BackupURLs []string `json:"backupUrls"`
 }
 
 // CommentList 表示评论列表

--- a/xiaohongshu/video_url.go
+++ b/xiaohongshu/video_url.go
@@ -1,0 +1,64 @@
+package xiaohongshu
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+// ResolveVideoURLFromDetail 从详情结构中解析视频 URL。
+func ResolveVideoURLFromDetail(note FeedDetail) string {
+	if note.Video == nil {
+		return ""
+	}
+
+	streamCandidates := [][]DetailVideoStreamItem{
+		note.Video.Media.Stream.H264,
+		note.Video.Media.Stream.H265,
+		note.Video.Media.Stream.H266,
+		note.Video.Media.Stream.AV1,
+	}
+
+	for _, items := range streamCandidates {
+		for _, item := range items {
+			if trimmed := strings.TrimSpace(item.MasterURL); trimmed != "" {
+				return trimmed
+			}
+			for _, backup := range item.BackupURLs {
+				if trimmed := strings.TrimSpace(backup); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+
+	return strings.TrimSpace(note.Video.Media.OriginVideoKey)
+}
+
+// ResolveVideoURLFromPage 从页面 video 元素兜底解析视频 URL。
+func ResolveVideoURLFromPage(page *rod.Page) (string, error) {
+	if page == nil {
+		return "", fmt.Errorf("page is nil")
+	}
+
+	videoEl, err := page.Timeout(3 * time.Second).Element("video")
+	if err != nil {
+		return "", err
+	}
+
+	src, err := videoEl.Attribute("src")
+	if err == nil && src != nil && strings.TrimSpace(*src) != "" {
+		return strings.TrimSpace(*src), nil
+	}
+
+	currentSrc, err := videoEl.Property("currentSrc")
+	if err == nil {
+		if val := strings.TrimSpace(currentSrc.String()); val != "" && val != "null" {
+			return val, nil
+		}
+	}
+
+	return "", fmt.Errorf("video url not found on page")
+}

--- a/xiaohongshu/video_url_test.go
+++ b/xiaohongshu/video_url_test.go
@@ -1,0 +1,70 @@
+package xiaohongshu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVideoURLFromDetail(t *testing.T) {
+	tests := []struct {
+		name     string
+		note     FeedDetail
+		expected string
+	}{
+		{
+			name: "优先 h264 masterUrl",
+			note: FeedDetail{
+				Video: &DetailVideo{
+					Media: DetailVideoMedia{
+						Stream: DetailVideoStream{
+							H264: []DetailVideoStreamItem{
+								{MasterURL: "https://example.com/h264.m3u8"},
+							},
+						},
+						OriginVideoKey: "https://example.com/origin.mp4",
+					},
+				},
+			},
+			expected: "https://example.com/h264.m3u8",
+		},
+		{
+			name: "h264 缺失时回退 h265 masterUrl",
+			note: FeedDetail{
+				Video: &DetailVideo{
+					Media: DetailVideoMedia{
+						Stream: DetailVideoStream{
+							H265: []DetailVideoStreamItem{
+								{MasterURL: "https://example.com/h265.m3u8"},
+							},
+						},
+					},
+				},
+			},
+			expected: "https://example.com/h265.m3u8",
+		},
+		{
+			name: "stream 缺失时回退 originVideoKey",
+			note: FeedDetail{
+				Video: &DetailVideo{
+					Media: DetailVideoMedia{
+						OriginVideoKey: "https://example.com/origin.mp4",
+					},
+				},
+			},
+			expected: "https://example.com/origin.mp4",
+		},
+		{
+			name:     "非视频帖子返回空字符串",
+			note:     FeedDetail{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ResolveVideoURLFromDetail(tt.note)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## 变更说明

本 PR 仅包含一个功能：**MCP 视频帖子转写能力（基于 provider API）**。

核心点：

- 新增 MCP 工具能力：`transcribe_feed_video`
  - 必填：`feed_id`、`xsec_token`
  - 可选：`provider`、`api_key`、`model`、`language`、`output_dir`、`keep_artifacts`
- 通过 `feed_id + xsec_token` 解析小红书视频 URL，再直接调用 provider API（`dashscope` / `glm`）
- 增加 provider/model/api key 的解析逻辑
- 增加响应解析与 SRT 回退生成逻辑
- 补充测试：provider/model/api-key 解析、payload 构建、响应解析

## 范围控制（One PR, One Feature）

本 PR 仅做 **MCP 视频转写 feature**，不包含其他功能扩展。

## 验证

已本地执行：

```bash
go test ./pkg/transcribe -v
go test ./xiaohongshu -run TestResolveVideoURLFromDetail -v
go test ./... -run '^$'
```

## 演示视频

- 仓库链接：
  - https://github.com/chris258-123/xiaohongshu-mcp/blob/main/docs/demo/pr-524-transcribe-demo.webm
- 原始地址：
  - https://raw.githubusercontent.com/chris258-123/xiaohongshu-mcp/main/docs/demo/pr-524-transcribe-demo.webm