### PR TITLE
fix(oauth): add OAuth 2.0 Authorization Server Metadata endpoint

### DIFF
--- a/oauth_handler.go
+++ b/oauth_handler.go
@@ -9,14 +9,14 @@ import (
 // OAuthMetadata represents the OAuth 2.0 Authorization Server Metadata
 type OAuthMetadata struct {
 	Issuer                            string   `json:"issuer"`
-	AuthorizationEndpoint            string   `json:"authorization_endpoint,omitempty"`
-	TokenEndpoint                    string   `json:"token_endpoint,omitempty"`
-	JWKSURI                          string   `json:"jwks_uri,omitempty"`
-	RegistrationEndpoint             string   `json:"registration_endpoint,omitempty"`
-	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
-	ResponseTypesSupported           []string `json:"response_types_supported,omitempty"`
-	ResponseModesSupported           []string `json:"response_modes_supported,omitempty"`
-	GrantTypesSupported              []string `json:"grant_types_supported,omitempty"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint,omitempty"`
+	TokenEndpoint                     string   `json:"token_endpoint,omitempty"`
+	JWKSURI                           string   `json:"jwks_uri,omitempty"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported            []string `json:"response_types_supported,omitempty"`
+	ResponseModesSupported            []string `json:"response_modes_supported,omitempty"`
+	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 }
 
@@ -24,8 +24,9 @@ type OAuthMetadata struct {
 // This endpoint is required for Claude Code and other MCP clients that expect OAuth support
 func oauthMetadataHandler(c *gin.Context) {
 	// Get the base URL from the request
+	// Check both TLS and X-Forwarded-Proto for reverse proxy support
 	scheme := "http"
-	if c.Request.TLS != nil {
+	if c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https" {
 		scheme = "https"
 	}
 	host := c.Request.Host
@@ -41,5 +42,7 @@ func oauthMetadataHandler(c *gin.Context) {
 		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post"},
 	}
 
+	// Cache for 1 hour to reduce repeated requests
+	c.Header("Cache-Control", "max-age=3600")
 	c.JSON(http.StatusOK, metadata)
 }

--- a/oauth_handler.go
+++ b/oauth_handler.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// OAuthMetadata represents the OAuth 2.0 Authorization Server Metadata
+type OAuthMetadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint,omitempty"`
+	TokenEndpoint                    string   `json:"token_endpoint,omitempty"`
+	JWKSURI                          string   `json:"jwks_uri,omitempty"`
+	RegistrationEndpoint             string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported           []string `json:"response_types_supported,omitempty"`
+	ResponseModesSupported           []string `json:"response_modes_supported,omitempty"`
+	GrantTypesSupported              []string `json:"grant_types_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
+// oauthMetadataHandler returns OAuth 2.0 Authorization Server Metadata
+// This endpoint is required for Claude Code and other MCP clients that expect OAuth support
+func oauthMetadataHandler(c *gin.Context) {
+	// Get the base URL from the request
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	host := c.Request.Host
+	baseURL := scheme + "://" + host
+
+	metadata := OAuthMetadata{
+		Issuer:                 baseURL,
+		AuthorizationEndpoint:  baseURL + "/oauth/authorize",
+		TokenEndpoint:          baseURL + "/oauth/token",
+		ScopesSupported:        []string{"mcp", "read", "write"},
+		ResponseTypesSupported: []string{"code"},
+		GrantTypesSupported:    []string{"authorization_code", "client_credentials"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post"},
+	}
+
+	c.JSON(http.StatusOK, metadata)
+}

--- a/routes.go
+++ b/routes.go
@@ -23,6 +23,9 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 	// 健康检查
 	router.GET("/health", healthHandler)
 
+	// OAuth 2.0 Authorization Server Metadata (for Claude Code compatibility)
+	router.GET("/.well-known/oauth-authorization-server", oauthMetadataHandler)
+
 	// MCP 端点 - 使用官方 SDK 的 Streamable HTTP Handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server {


### PR DESCRIPTION
Fixes #525

## Problem
Claude Code and other MCP clients expect OAuth metadata at `/.well-known/oauth-authorization-server` but get HTTP 502.

```
Error: HTTP 502 trying to load OAuth metadata from http://localhost:18060/.well-known/oauth-authorization-server
```

## Fix
Add OAuth 2.0 Authorization Server Metadata endpoint that returns:
- Issuer
- Authorization endpoint
- Token endpoint
- Supported scopes, response types, grant types

## Response Example
```json
{
  "issuer": "http://localhost:18060",
  "authorization_endpoint": "http://localhost:18060/oauth/authorize",
  "token_endpoint": "http://localhost:18060/oauth/token",
  "scopes_supported": ["mcp", "read", "write"],
  "response_types_supported": ["code"],
  "grant_types_supported": ["authorization_code", "client_credentials"]
}
```

## Impact
Claude Code can now connect without 502 errors.

Note: This is a metadata-only endpoint. Actual OAuth flow still uses the existing login/qrcode mechanism.