### PR TITLE
feat: 添加批量收藏 API

### DIFF
--- a/handlers_api.go
+++ b/handlers_api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
@@ -292,4 +293,49 @@ func (s *AppServer) myProfileHandler(c *gin.Context) {
 
 	c.Set("account", "ai-report")
 	respondSuccess(c, map[string]any{"data": result}, "获取我的主页成功")
+}
+
+// batchFavoriteFeedHandler 批量收藏笔记（并发优化）
+func (s *AppServer) batchFavoriteFeedHandler(c *gin.Context) {
+	var req BatchFavoriteFeedRequest
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	// 转换为 BatchFavoriteRequest
+	batchFeeds := make([]BatchFavoriteRequest, len(req.Feeds))
+	for i, f := range req.Feeds {
+		batchFeeds[i] = BatchFavoriteRequest{
+			FeedID:    f.FeedID,
+			XsecToken: f.XsecToken,
+			Action:    f.Action,
+		}
+	}
+
+	// 执行批量收藏
+	results, err := s.xiaohongshuService.BatchFavoriteFeed(c.Request.Context(), batchFeeds)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "BATCH_FAVORITE_FAILED",
+			"批量收藏失败", err.Error())
+		return
+	}
+
+	// 统计结果
+	successCount := 0
+	for _, r := range results {
+		if r.Success {
+			successCount++
+		}
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, map[string]any{
+		"total":   len(results),
+		"success": successCount,
+		"failed":  len(results) - successCount,
+		"results": results,
+	}, fmt.Sprintf("批量收藏完成：成功 %d/%d", successCount, len(results)))
 }

--- a/routes.go
+++ b/routes.go
@@ -51,6 +51,9 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.POST("/feeds/comment", appServer.postCommentHandler)
 		api.POST("/feeds/comment/reply", appServer.replyCommentHandler)
 		api.GET("/user/me", appServer.myProfileHandler)
+
+		// 互动操作（新增 HTTP REST API）
+		api.POST("/feeds/favorite/batch", appServer.batchFavoriteFeedHandler) // 批量收藏（并发优化）
 	}
 
 	return router

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -520,6 +521,85 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 		return nil, err
 	}
 	return &ActionResult{FeedID: feedID, Success: true, Message: "取消收藏成功或未收藏"}, nil
+}
+
+// BatchFavoriteFeed 批量收藏笔记（并发优化，最多 3 个并发）
+func (s *XiaohongshuService) BatchFavoriteFeed(ctx context.Context, feeds []BatchFavoriteRequest) ([]BatchFavoriteResult, error) {
+	results := make([]BatchFavoriteResult, len(feeds))
+
+	// 使用 goroutine 并发收藏，最多同时 3 个（避免浏览器负载过高）
+	maxConcurrency := 3
+	semaphore := make(chan struct{}, maxConcurrency)
+
+	var wg sync.WaitGroup
+
+	for i, feed := range feeds {
+		// 获取信号量（限流）
+		semaphore <- struct{}{}
+
+		wg.Add(1)
+		go func(idx int, req BatchFavoriteRequest) {
+			defer wg.Done()
+			defer func() {
+				<-semaphore // 释放信号量
+			}()
+
+			results[idx] = BatchFavoriteResult{FeedID: req.FeedID}
+
+			// 创建带超时的上下文（单个收藏最多 60 秒）
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, 60*time.Second)
+			defer cancel()
+
+			// 创建独立的浏览器实例（避免并发冲突）
+			b := newBrowser()
+			defer b.Close() // 确保浏览器关闭
+
+			// Panic 恢复
+			defer func() {
+				if r := recover(); r != nil {
+					actionName := "收藏"
+					if req.Action == "unfavorite" {
+						actionName = "取消收藏"
+					}
+					logrus.Errorf("%s %s 时发生 panic: %v", actionName, req.FeedID, r)
+					results[idx].Success = false
+					results[idx].Error = fmt.Sprintf("panic: %v", r)
+					results[idx].Message = actionName + "失败"
+				}
+			}()
+
+			page := b.NewPage()
+			defer page.Close()
+
+			action := xiaohongshu.NewFavoriteAction(page)
+			var err error
+			var actionName string
+
+			if req.Action == "unfavorite" {
+				err = action.Unfavorite(ctxWithTimeout, req.FeedID, req.XsecToken)
+				actionName = "取消收藏"
+			} else {
+				err = action.Favorite(ctxWithTimeout, req.FeedID, req.XsecToken)
+				actionName = "收藏"
+			}
+
+			if err != nil {
+				results[idx].Success = false
+				results[idx].Error = err.Error()
+				results[idx].Message = actionName + "失败"
+				logrus.Warnf("%s %s 失败：%v", actionName, req.FeedID, err)
+			} else {
+				results[idx].Success = true
+				results[idx].Message = actionName + "成功"
+				logrus.Infof("%s %s 成功", actionName, req.FeedID)
+			}
+		}(i, feed)
+	}
+
+	// 等待所有 goroutine 完成
+	wg.Wait()
+
+	return results, nil
 }
 
 // ReplyCommentToFeed 回复指定评论

--- a/types.go
+++ b/types.go
@@ -109,3 +109,30 @@ type ActionResult struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
 }
+
+// BatchFavoriteFeedRequest 批量收藏笔记请求
+type BatchFavoriteFeedRequest struct {
+	Feeds []BatchFavoriteItem `json:"feeds" binding:"required,min=1,max=50"`
+}
+
+// BatchFavoriteItem 批量收藏单项
+type BatchFavoriteItem struct {
+	FeedID    string `json:"feed_id" binding:"required"`
+	XsecToken string `json:"xsec_token" binding:"required"` // 敏感信息，请勿记录到日志
+	Action    string `json:"action,omitempty"`              // "favorite"=收藏, "unfavorite"=取消收藏，默认收藏
+}
+
+// BatchFavoriteRequest 批量收藏请求（内部使用）
+type BatchFavoriteRequest struct {
+	FeedID    string `json:"feed_id"`
+	XsecToken string `json:"xsec_token"` // 敏感信息，请勿记录到日志
+	Action    string `json:"action"`     // "favorite"=收藏, "unfavorite"=取消收藏，默认收藏
+}
+
+// BatchFavoriteResult 批量收藏结果
+type BatchFavoriteResult struct {
+	FeedID  string `json:"feed_id"`
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Error   string `json:"error,omitempty"`
+}


### PR DESCRIPTION
功能:
- 批量收藏/取消收藏笔记（最多50个，并发3个）
- 支持每个 feed 独立的 xsec_token
- 使用 action 字段控制操作 (favorite/unfavorite)

API:
POST /api/v1/feeds/favorite/batch
{
  "feeds": [ {"feed_id": "xxx", "xsec_token": "xxx", "action": "favorite"}, {"feed_id": "yyy", "xsec_token": "yyy", "action": "unfavorite"} ] }

技术细节:
- 并发控制（最多3个同时进行）
- Panic 恢复
- 单请求60秒超时
- XsecToken 敏感信息注释