### PR TITLE
fix: 自动处理海外用户 cookie 同意弹窗

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -31,6 +31,7 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 	// 导航到详情页
 	page.MustNavigate(url)
 	page.MustWaitDOMStable()
+	dismissCookieConsent(page)
 	time.Sleep(1 * time.Second)
 
 	// 检测页面是否可访问
@@ -90,6 +91,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	// 导航到详情页
 	page.MustNavigate(url)
 	page.MustWaitDOMStable()
+	dismissCookieConsent(page)
 	time.Sleep(1 * time.Second)
 
 	// 检测页面是否可访问
@@ -181,7 +183,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// === 2. 获取当前评论数量 ===
 		currentCount := getCommentCount(page)
 		logrus.Infof("当前评论数: %d", currentCount)
-		
+
 		if currentCount != lastCommentCount {
 			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
 			lastCommentCount = currentCount
@@ -202,7 +204,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// === 4. 先滚动到最后一个评论（触发懒加载）===
 		if currentCount > 0 {
 			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-			
+
 			// 使用 Go 获取所有评论元素
 			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
 			if err == nil && len(elements) > 0 {
@@ -231,7 +233,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		if commentID != "" {
 			selector := fmt.Sprintf("#comment-%s", commentID)
 			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-			
+
 			// 使用 Timeout 避免长时间等待
 			el, err := page.Timeout(2 * time.Second).Element(selector)
 			if err == nil && el != nil {
@@ -244,7 +246,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// 通过 userID 查找
 		if userID != "" {
 			logrus.Infof("尝试通过 userID 查找: %s", userID)
-			
+
 			// 使用 Timeout 避免长时间等待
 			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
 			if err == nil && len(elements) > 0 {
@@ -262,7 +264,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 				logrus.Infof("获取评论元素失败或超时: %v", err)
 			}
 		}
-		
+
 		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
 
 		// === 7. 等待内容加载 ===

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -89,6 +89,7 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 		func() error {
 			page.MustNavigate(url)
 			page.MustWaitDOMStable()
+			dismissCookieConsent(page)
 			return nil
 		},
 		retry.Attempts(3),

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -19,6 +19,7 @@ func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 
 	pp.MustNavigate("https://www.xiaohongshu.com")
 	pp.MustWaitDOMStable()
+	dismissCookieConsent(pp)
 
 	return &FeedsListAction{page: pp}
 }

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -50,6 +50,7 @@ func (a *interactAction) preparePage(ctx context.Context, actionType interactAct
 
 	page.MustNavigate(url)
 	page.MustWaitDOMStable()
+	dismissCookieConsent(page)
 	time.Sleep(1 * time.Second)
 
 	return page

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -19,6 +19,7 @@ func NewLogin(page *rod.Page) *LoginAction {
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	pp := a.page.Context(ctx)
 	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	dismissCookieConsent(pp)
 
 	time.Sleep(1 * time.Second)
 
@@ -39,6 +40,7 @@ func (a *LoginAction) Login(ctx context.Context) error {
 
 	// 导航到小红书首页，这会触发二维码弹窗
 	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	dismissCookieConsent(pp)
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
@@ -61,6 +63,7 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 
 	// 导航到小红书首页，这会触发二维码弹窗
 	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	dismissCookieConsent(pp)
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -21,6 +21,8 @@ func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 		MustWaitLoad().
 		MustElement(`div#app`)
 
+	dismissCookieConsent(page)
+
 	return nil
 }
 

--- a/xiaohongshu/popup.go
+++ b/xiaohongshu/popup.go
@@ -9,11 +9,15 @@ import (
 // dismissCookieConsent 处理海外用户访问时出现的 cookie 同意弹窗
 // 非阻塞：如果没有弹窗则立即返回
 func dismissCookieConsent(page *rod.Page) {
-	has, btn, err := page.Has(".cookie-banner__btn--primary")
-	if err != nil {
+	// 检测 cookie 同意弹窗是否存在
+	hasBanner, _, _ := page.Has("div.cookie-banner")
+	if !hasBanner {
 		return
 	}
-	if !has {
+
+	has, btn, err := page.Has(".cookie-banner__btn--primary")
+	if err != nil || !has {
+		logrus.Debug("检测到 cookie 弹窗容器，但未找到接受按钮（selector 可能已变更）")
 		return
 	}
 

--- a/xiaohongshu/popup.go
+++ b/xiaohongshu/popup.go
@@ -1,0 +1,31 @@
+package xiaohongshu
+
+import (
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/sirupsen/logrus"
+)
+
+// dismissCookieConsent 处理海外用户访问时出现的 cookie 同意弹窗
+// 非阻塞：如果没有弹窗则立即返回
+func dismissCookieConsent(page *rod.Page) {
+	has, btn, err := page.Has(".cookie-banner__btn--primary")
+	if err != nil {
+		return
+	}
+	if !has {
+		return
+	}
+
+	logrus.Info("检测到 cookie 同意弹窗，自动点击接受")
+
+	if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		logrus.Warnf("点击 cookie 同意按钮失败: %v，尝试移除弹窗", err)
+		// 兜底：直接移除弹窗容器
+		if hasBanner, banner, _ := page.Has("div.cookie-banner"); hasBanner {
+			if err := banner.Remove(); err != nil {
+				logrus.Warnf("移除 cookie 弹窗容器失败: %v", err)
+			}
+		}
+	}
+}

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -48,6 +48,7 @@ func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 	if err := pp.WaitLoad(); err != nil {
 		logrus.Warnf("等待页面加载出现问题: %v，继续尝试", err)
 	}
+	dismissCookieConsent(pp)
 	time.Sleep(2 * time.Second)
 
 	// 等待页面稳定

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -36,6 +36,7 @@ func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
 	if err := pp.WaitLoad(); err != nil {
 		logrus.Warnf("等待页面加载出现问题: %v，继续尝试", err)
 	}
+	dismissCookieConsent(pp)
 	time.Sleep(2 * time.Second)
 
 	if err := pp.WaitDOMStable(time.Second, 0.1); err != nil {

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -171,6 +171,7 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
 	page.MustWaitStable()
+	dismissCookieConsent(page)
 
 	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
 

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -25,6 +25,7 @@ func (u *UserProfileAction) UserProfile(ctx context.Context, userID, xsecToken s
 	searchURL := makeUserProfileURL(userID, xsecToken)
 	page.MustNavigate(searchURL)
 	page.MustWaitStable()
+	dismissCookieConsent(page)
 
 	return u.extractUserProfileData(page)
 }


### PR DESCRIPTION
## Summary

- 修复 #532：海外用户访问小红书时 GDPR cookie consent 弹窗在无头模式下阻塞所有操作
- 新增 `dismissCookieConsent()` 函数（`xiaohongshu/popup.go`），在页面导航后自动检测并点击 "Accept all cookies"
- 覆盖全部 13 个导航点（10 个文件），国内用户无影响（函数为 no-op）

## 实现方式

- 使用 go-rod 原生 API（`page.Has()` + `Click()`），无 JS 注入
- 点击失败时兜底移除弹窗 DOM 元素
- 遵循已有的 `removePopCover()` 模式

## 验证日志（海外网络 + 无头模式）

```
time="2026-03-14T22:43:47+01:00" level=info msg="Registered 13 MCP tools"
time="2026-03-14T22:43:47+01:00" level=info msg="MCP Server initialized with official SDK"
time="2026-03-14T22:43:47+01:00" level=info msg="启动 HTTP 服务器: :18060"
time="2026-03-14T22:43:57+01:00" level=warning msg="failed to load cookies: failed to read cookies from tmp file: open cookies.json: no such file or directory"
time="2026-03-14T22:44:03+01:00" level=info msg="检测到 cookie 同意弹窗，自动点击接受"
time="2026-03-14T22:44:04+01:00" level=info msg="GET /api/v1/feeds/list ai-report 200"
```

## Test plan

- [x] 海外网络 + 无头模式：`list_feeds` 正常返回，日志显示弹窗被自动处理
- [x] 海外网络 + 非无头模式：`check_login_status` 和 `list_feeds` 正常返回
- [x] 国内网络（VPN）：正常返回，无副作用
- [x] `go build` 编译通过
- [x] 单元测试通过（`go test ./pkg/...`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)