### PR TITLE
feat: 支持获取评论中的图片数据

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -518,7 +518,17 @@ Content-Type: application/json
                 }
               }
             ],
-            "showTags": ["热评"]
+            "showTags": ["热评"],
+            "pictures": [
+              {
+                "url": "https://example.com/comment_image.jpg",
+                "urlDefault": "https://example.com/comment_image_default.jpg",
+                "urlPre": "https://example.com/comment_image_pre.jpg",
+                "width": 1080,
+                "height": 720,
+                "fileId": "abc123def456"
+              }
+            ]
           }
         ],
         "cursor": "next_cursor_value",
@@ -545,6 +555,13 @@ Content-Type: application/json
 - `comments.list[].subCommentCount`: 子评论数量
 - `comments.list[].subComments`: 子评论列表
 - `comments.list[].showTags`: 显示标签（如 "热评"）
+- `comments.list[].pictures`: 评论中附带的图片列表（可选，仅当评论包含图片时返回）
+  - `url`: 图片 URL
+  - `urlDefault`: 默认尺寸图片 URL
+  - `urlPre`: 预览图片 URL
+  - `width`: 图片宽度
+  - `height`: 图片高度
+  - `fileId`: 图片文件 ID
 - `comments.cursor`: 分页游标
 - `comments.hasMore`: 是否有更多评论
 ```

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -123,17 +123,27 @@ type CommentList struct {
 
 // Comment 表示单条评论
 type Comment struct {
-	ID              string    `json:"id"`
-	NoteID          string    `json:"noteId"`
-	Content         string    `json:"content"`
-	LikeCount       string    `json:"likeCount"`
-	CreateTime      int64     `json:"createTime"`
-	IPLocation      string    `json:"ipLocation"`
-	Liked           bool      `json:"liked"`
-	UserInfo        User      `json:"userInfo"`
-	SubCommentCount string    `json:"subCommentCount"`
-	SubComments     []Comment `json:"subComments"`
-	ShowTags        []string  `json:"showTags"`
+	ID              string           `json:"id"`
+	NoteID          string           `json:"noteId"`
+	Content         string           `json:"content"`
+	LikeCount       string           `json:"likeCount"`
+	CreateTime      int64            `json:"createTime"`
+	IPLocation      string           `json:"ipLocation"`
+	Liked           bool             `json:"liked"`
+	UserInfo        User             `json:"userInfo"`
+	SubCommentCount string           `json:"subCommentCount"`
+	SubComments     []Comment        `json:"subComments"`
+	ShowTags        []string         `json:"showTags"`
+	Pictures        []CommentPicture `json:"pictures,omitempty"`
+}
+
+// CommentPicture 表示评论中的图片信息
+type CommentPicture struct {
+	URLDefault string      `json:"urlDefault"`
+	URLPre     string      `json:"urlPre"`
+	Width      int         `json:"width"`
+	Height     int         `json:"height"`
+	InfoList   []ImageInfo `json:"infoList,omitempty"`
 }
 
 // UserProfileResponse 用户详情页完整响应


### PR DESCRIPTION
问题：当前获取笔记评论时，无法获取评论中用户上传的图片数据。

原因：Comment 结构体缺少 pictures 字段定义，json.Unmarshal 反序列化时自动忽略了该数据。

方案：新增 CommentPicture 结构体，包含 urlDefault（默认缩略图）、urlPre（预览大图）等字段。在 Comment 结构体中添加 Pictures []CommentPicture 字段

已通过 MCP Inspector 调用 [get_feed_detail](get_feed_detail) 接口验证：
- 带图片的评论能正确返回 pictures 字段（含 urlDefault、urlPre、width、height、infolist
- 无图片的评论不返回该字段（omitempty）
- 字段结构与小红书 window.__INITIAL_STATE__ 中的真实 JSON 数据完全对齐