### PR TITLE
fix: 评论少时 reply_comment_in_feed 找不到评论

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -172,67 +172,12 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		logrus.Infof("=== 查找尝试 %d/%d ===", attempt+1, maxAttempts)
 
-		// === 1. 检查是否到达底部 ===
-		if checkEndContainer(page) {
-			logrus.Info("已到达评论底部，未找到目标评论")
-			break
-		}
-
-		// === 2. 获取当前评论数量 ===
-		currentCount := getCommentCount(page)
-		logrus.Infof("当前评论数: %d", currentCount)
-		
-		if currentCount != lastCommentCount {
-			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
-			lastCommentCount = currentCount
-			stagnantChecks = 0
-		} else {
-			stagnantChecks++
-			if stagnantChecks%5 == 0 {
-				logrus.Infof("评论数停滞 %d 次", stagnantChecks)
-			}
-		}
-
-		// === 3. 停滞检测 ===
-		if stagnantChecks >= 10 {
-			logrus.Info("评论数量停滞超过10次，可能已加载完所有评论")
-			break
-		}
-
-		// === 4. 先滚动到最后一个评论（触发懒加载）===
-		if currentCount > 0 {
-			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-			
-			// 使用 Go 获取所有评论元素
-			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
-			if err == nil && len(elements) > 0 {
-				// 滚动到最后一个评论
-				lastComment := elements[len(elements)-1]
-				err := lastComment.ScrollIntoView()
-				if err != nil {
-					logrus.Warnf("滚动到最后一个评论失败: %v", err)
-				}
-			} else {
-				logrus.Warnf("未找到评论元素: %v", err)
-			}
-			time.Sleep(300 * time.Millisecond)
-		}
-
-		// === 5. 继续向下滚动 ===
-		logrus.Infof("继续向下滚动...")
-		_, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`)
-		if err != nil {
-			logrus.Warnf("滚动失败: %v", err)
-		}
-		time.Sleep(500 * time.Millisecond)
-
-		// === 6. 滚动后立即查找（边滚动边查找）===
+		// === 1. 先查找评论（在检查 endContainer 之前）===
 		// 优先通过 commentID 查找（使用 Timeout 避免长时间等待）
 		if commentID != "" {
 			selector := fmt.Sprintf("#comment-%s", commentID)
 			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-			
-			// 使用 Timeout 避免长时间等待
+
 			el, err := page.Timeout(2 * time.Second).Element(selector)
 			if err == nil && el != nil {
 				logrus.Infof("✓ 通过 commentID 找到评论: %s (尝试 %d 次)", commentID, attempt+1)
@@ -244,13 +189,11 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// 通过 userID 查找
 		if userID != "" {
 			logrus.Infof("尝试通过 userID 查找: %s", userID)
-			
-			// 使用 Timeout 避免长时间等待
+
 			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
 			if err == nil && len(elements) > 0 {
 				logrus.Infof("找到 %d 个评论元素", len(elements))
 				for i, el := range elements {
-					// 快速检查，不等待
 					userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID))
 					if err == nil && userEl != nil {
 						logrus.Infof("✓ 通过 userID 在第 %d 个元素中找到评论: %s (尝试 %d 次)", i+1, userID, attempt+1)
@@ -262,7 +205,59 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 				logrus.Infof("获取评论元素失败或超时: %v", err)
 			}
 		}
-		
+
+		// === 2. 检查是否到达底部 ===
+		if checkEndContainer(page) {
+			logrus.Info("已到达评论底部，未找到目标评论")
+			break
+		}
+
+		// === 3. 获取当前评论数量 ===
+		currentCount := getCommentCount(page)
+		logrus.Infof("当前评论数: %d", currentCount)
+
+		if currentCount != lastCommentCount {
+			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
+			lastCommentCount = currentCount
+			stagnantChecks = 0
+		} else {
+			stagnantChecks++
+			if stagnantChecks%5 == 0 {
+				logrus.Infof("评论数停滞 %d 次", stagnantChecks)
+			}
+		}
+
+		// === 4. 停滞检测 ===
+		if stagnantChecks >= 10 {
+			logrus.Info("评论数量停滞超过10次，可能已加载完所有评论")
+			break
+		}
+
+		// === 5. 滚动到最后一个评论（触发懒加载）===
+		if currentCount > 0 {
+			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
+
+			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
+			if err == nil && len(elements) > 0 {
+				lastComment := elements[len(elements)-1]
+				err := lastComment.ScrollIntoView()
+				if err != nil {
+					logrus.Warnf("滚动到最后一个评论失败: %v", err)
+				}
+			} else {
+				logrus.Warnf("未找到评论元素: %v", err)
+			}
+			time.Sleep(300 * time.Millisecond)
+		}
+
+		// === 6. 继续向下滚动 ===
+		logrus.Infof("继续向下滚动...")
+		_, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`)
+		if err != nil {
+			logrus.Warnf("滚动失败: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+
 		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
 
 		// === 7. 等待内容加载 ===


### PR DESCRIPTION
## Summary

- 将 `findCommentElement` 中查找评论的逻辑移到 `checkEndContainer` 检测**之前**
- 修复评论数较少的帖子上 `reply_comment_in_feed` 始终报"未找到评论"的问题

## 原因

当帖子评论很少时（如 3 条），页面加载后 end container 直接可见，`checkEndContainer` 在第一次循环就返回 `true`，导致在查找评论之前就退出了循环。

评论多的帖子不受影响，因为 end container 不在初始视口内。

## 改动

`xiaohongshu/comment_feed.go` — `findCommentElement` 函数：
- 将 commentID / userID 查找逻辑从步骤 6 移到步骤 1（循环体最前面）
- 其余滚动、停滞检测、懒加载逻辑不变

Fixes #591