### PR TITLE
feat: 支持 stdio 传输模式

### DIFF
--- a/app_server.go
+++ b/app_server.go
@@ -33,8 +33,23 @@ func NewAppServer(xiaohongshuService *XiaohongshuService) *AppServer {
 	return appServer
 }
 
-// Start 启动服务器
-func (s *AppServer) Start(port string) error {
+// Start 启动服务器，支持 http 和 stdio 两种传输模式
+func (s *AppServer) Start(port string, transport string) error {
+	if transport == "stdio" {
+		return s.startStdio()
+	}
+	return s.startHTTP(port)
+}
+
+// startStdio 以 stdio 模式启动，通过标准输入输出与客户端通信
+func (s *AppServer) startStdio() error {
+	logrus.SetOutput(os.Stderr) // 日志输出到 stderr，避免污染 stdio 通信
+	logrus.Infof("以 stdio 模式启动 MCP 服务器")
+	return s.mcpServer.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+// startHTTP 以 HTTP 模式启动
+func (s *AppServer) startHTTP(port string) error {
 	s.router = setupRoutes(s)
 
 	s.httpServer = &http.Server{

--- a/main.go
+++ b/main.go
@@ -10,13 +10,15 @@ import (
 
 func main() {
 	var (
-		headless bool
-		binPath  string // 浏览器二进制文件路径
-		port     string
+		headless  bool
+		binPath   string // 浏览器二进制文件路径
+		port      string
+		transport string // 传输模式: http 或 stdio
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
+	flag.StringVar(&transport, "transport", "http", "传输模式: http 或 stdio")
 	flag.Parse()
 
 	if len(binPath) == 0 {
@@ -31,7 +33,7 @@ func main() {
 
 	// 创建并启动应用服务器
 	appServer := NewAppServer(xiaohongshuService)
-	if err := appServer.Start(port); err != nil {
+	if err := appServer.Start(port, transport); err != nil {
 		logrus.Fatalf("failed to run server: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- 新增 `-transport` 参数，支持 `http`（默认，向后兼容）和 `stdio` 两种传输模式
- stdio 模式下，MCP 服务器通过标准输入/输出与客户端通信，无需启动 HTTP 服务器
- 日志输出到 stderr，避免污染 stdio 通信通道

## 动机

当前仅支持 HTTP (Streamable HTTP) 传输模式，用户需要手动启动后台服务并配置端口。

加入 stdio 支持后，Claude Code、Cursor 等 AI 客户端可以直接启动并管理 MCP 进程生命周期，大幅简化配置流程：

**之前（HTTP 模式）：**
```bash
# 1. 手动启动后台服务
./xiaohongshu-mcp &

# 2. 在 Claude Code 中配置 HTTP 连接
claude mcp add xiaohongshu --transport http http://localhost:18060/mcp
```

**之后（stdio 模式）：**
```bash
# 一条命令搞定，Claude Code 自动管理进程
claude mcp add xiaohongshu -t stdio -- /path/to/xiaohongshu-mcp -transport stdio
```

## 改动

仅修改 2 个文件，新增 ~20 行代码：

- `main.go`: 新增 `-transport` CLI 参数
- `app_server.go`: 将 `Start()` 拆分为 `startHTTP()` 和 `startStdio()` 两个方法

HTTP 模式完全不受影响，所有现有功能保持向后兼容。

## 测试

- [x] `go build` 编译通过
- [x] `./xiaohongshu-mcp --help` 显示新参数
- [x] stdio 模式启动成功，13 个工具正常注册
- [x] HTTP 模式（默认）行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)