### PR TITLE
Feat/add save draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,9 @@ npx mcporter list xiaohongshu-mcp
 - `list_local_drafts` - 读取创作中心本地草稿（来自浏览器 IndexedDB `draft-database-v1`）
   - `type`: 草稿类型（可选）`image`（默认）| `video` | `article` | `audio`
   - `limit`: 返回数量上限（可选，<=0 表示不限）
+- `get_local_draft_detail` - 按 draft_id 读取单条草稿完整内容（来自浏览器 IndexedDB `draft-database-v1`）
+  - `draft_id`: 草稿 ID（必填，与 `list_local_drafts` 返回的 draft_id 一致）
+  - `type`: 草稿类型（可选）`image` | `video` | `article` | `audio`，不填则在各 store 中依次查找
 
 ### 2.4. 使用示例
 

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ npx mcporter list xiaohongshu-mcp
   - `type`: `image`（默认）| `video`
   - 图文必需：`title`, `content`, `images`
   - 视频必需：`title`, `content`, `video`
-  - 可选：`tags`, `schedule_at`, `is_original`, `visibility`, `products`
+  - 可选：`tags`, `schedule_at`, `is_original`, `visibility`, `products`（其中 `local` 模式会忽略 `schedule_at`）
 - `list_local_drafts` - 读取创作中心本地草稿（来自浏览器 IndexedDB `draft-database-v1`）
   - `type`: 草稿类型（可选）`image`（默认）| `video` | `article` | `audio`
   - `limit`: 返回数量上限（可选，<=0 表示不限）

--- a/README.md
+++ b/README.md
@@ -892,6 +892,9 @@ npx mcporter list xiaohongshu-mcp
   - 图文必需：`title`, `content`, `images`
   - 视频必需：`title`, `content`, `video`
   - 可选：`tags`, `schedule_at`, `is_original`, `visibility`, `products`
+- `list_local_drafts` - 读取创作中心本地草稿（来自浏览器 IndexedDB `draft-database-v1`）
+  - `type`: 草稿类型（可选）`image`（默认）| `video` | `article` | `audio`
+  - `limit`: 返回数量上限（可选，<=0 表示不限）
 
 ### 2.4. 使用示例
 

--- a/README.md
+++ b/README.md
@@ -884,6 +884,14 @@ npx mcporter list xiaohongshu-mcp
 - `favorite_feed` - 收藏/取消收藏（必需：feed_id, xsec_token）
   - `unfavorite`: 是否取消收藏（可选），true 为取消收藏，默认为收藏
 - `user_profile` - 获取用户个人主页信息（必需：user_id, xsec_token）
+- `save_draft` - 暂存内容（两种模式：云端暂存/本地暂存）
+  - `mode`: `cloud`（默认）| `local`
+    - `cloud`: 通过“发布但仅自己可见”实现云端暂存（稳定，不依赖页面草稿按钮）
+    - `local`: 通过点击发布按钮旁边的“暂存离开”保存到草稿箱（依赖页面能力）
+  - `type`: `image`（默认）| `video`
+  - 图文必需：`title`, `content`, `images`
+  - 视频必需：`title`, `content`, `video`
+  - 可选：`tags`, `schedule_at`, `is_original`, `visibility`, `products`
 
 ### 2.4. 使用示例
 

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -3,6 +3,7 @@ package browser
 import (
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/headless_browser"
@@ -39,6 +40,20 @@ func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
 	cfg := &browserConfig{}
 	for _, opt := range options {
 		opt(cfg)
+	}
+
+	// 固定 Chrome user-data-dir 到持久化目录，保证 IndexedDB（mode=local 暂存）不会因为新建浏览器/容器重启而丢失。
+	// headless_browser 内部可能会读取这些环境变量来拼接 chrome 启动参数。
+	if userDataDir := os.Getenv("XHS_USER_DATA_DIR"); userDataDir != "" {
+		userDataDir = filepath.Clean(userDataDir)
+		if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+			logrus.Warnf("failed to create XHS_USER_DATA_DIR=%s: %v", userDataDir, err)
+		} else {
+			// 兼容多种可能的环境变量命名（以 headless_browser 实现为准）
+			_ = os.Setenv("ROD_BROWSER_USER_DATA_DIR", userDataDir)
+			_ = os.Setenv("ROD_USER_DATA_DIR", userDataDir)
+			_ = os.Setenv("CHROME_USER_DATA_DIR", userDataDir)
+		}
 	}
 
 	opts := []headless_browser.Option{

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -746,31 +746,38 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 // --- XHS drafts MCP (save via web automation) ---
 
 type SaveDraftArgs struct {
-	Title      string   `json:"title"`
-	Content    string   `json:"content"`
-	Images     []string `json:"images,omitempty"`
-	Video      string   `json:"video,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
-	ScheduleAt string   `json:"schedule_at,omitempty"`
-	IsOriginal bool     `json:"is_original,omitempty"`
-	Visibility string   `json:"visibility,omitempty"`
-	Products   []string `json:"products,omitempty"`
+	Title      string   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
+	Content    string   `json:"content" jsonschema:"正文内容"`
+	Images     []string `json:"images,omitempty" jsonschema:"图文模式下的图片路径列表（至少1张）。支持本地绝对路径或HTTP链接（如服务端支持下载）"`
+	Video      string   `json:"video,omitempty" jsonschema:"视频模式下的视频文件本地绝对路径（仅单个视频）"`
+	Tags       []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选）"`
+	ScheduleAt string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601 格式"`
+	IsOriginal bool     `json:"is_original,omitempty" jsonschema:"是否声明原创（可选）"`
+	Visibility string   `json:"visibility,omitempty" jsonschema:"可见范围（可选），cloud模式下会强制覆盖为仅自己可见"`
+	Products   []string `json:"products,omitempty" jsonschema:"商品关键词列表（可选），用于绑定带货商品"`
 
 	// Type: image|video
-	Type string `json:"type"`
+	Type string `json:"type" jsonschema:"内容类型：image(默认)|video"`
+
+	// Mode:
+	// - cloud: 通过“仅自己可见”发布来实现云端暂存（稳定，不依赖页面草稿按钮）
+	// - local: 点击发布按钮旁边的“暂存离开”保存到草稿箱（依赖页面能力）
+	Mode string `json:"mode" jsonschema:"【必填】暂存模式：cloud（仅自己可见发布，云端暂存）；local（点击暂存离开，保存到草稿箱）"`
 }
 
 func (s *AppServer) handleSaveDraft(ctx context.Context, args SaveDraftArgs) *MCPToolResult {
-	// NOTE: 按需求调整：save_draft 不再走“暂存/存草稿”按钮，而是执行“发布”但强制设置为“仅自己可见”
-	// 这样可规避页面文案变化导致的草稿按钮定位失败，但会产生真实发布（私密可见）。
-	logrus.Info("MCP: 私密发布（使用 save_draft 接口，强制仅自己可见）")
+	// save_draft 支持两种模式：
+	// - cloud: 私密发布（仅自己可见）作为“云端暂存”
+	// - local: 点击“暂存离开”保存到草稿箱
+	logrus.Infof("MCP: save_draft mode=%s type=%s", args.Mode, args.Type)
 
 	if args.Type == "" {
 		args.Type = "image"
 	}
 
-	// 强制仅自己可见（覆盖传入的 visibility）
-	args.Visibility = "仅自己可见"
+	if args.Mode == "" {
+		args.Mode = "cloud"
+	}
 
 	switch args.Type {
 	case "image":
@@ -784,10 +791,19 @@ func (s *AppServer) handleSaveDraft(ctx context.Context, args SaveDraftArgs) *MC
 			Visibility: args.Visibility,
 			Products:   args.Products,
 		}
-		if _, err := s.xiaohongshuService.PublishContent(ctx, req); err != nil {
-			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "私密发布失败: " + err.Error()}}, IsError: true}
+		if args.Mode == "local" {
+			if err := s.xiaohongshuService.SaveLocalImageDraft(ctx, req); err != nil {
+				return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "本地暂存失败: " + err.Error()}}, IsError: true}
+			}
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已点击“暂存离开”，草稿已保存到草稿箱（如页面提供该能力）"}}}
 		}
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已发布为仅自己可见（通过 save_draft 执行私密发布）"}}}
+
+		// cloud: 强制仅自己可见（覆盖传入的 visibility）
+		req.Visibility = "仅自己可见"
+		if _, err := s.xiaohongshuService.PublishContent(ctx, req); err != nil {
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "云端暂存失败(私密发布): " + err.Error()}}, IsError: true}
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "云端暂存完成：已发布为仅自己可见"}}}
 	case "video":
 		req := &PublishVideoRequest{
 			Title:      args.Title,
@@ -798,10 +814,19 @@ func (s *AppServer) handleSaveDraft(ctx context.Context, args SaveDraftArgs) *MC
 			Visibility: args.Visibility,
 			Products:   args.Products,
 		}
-		if _, err := s.xiaohongshuService.PublishVideo(ctx, req); err != nil {
-			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "私密发布失败: " + err.Error()}}, IsError: true}
+		if args.Mode == "local" {
+			if err := s.xiaohongshuService.SaveLocalVideoDraft(ctx, req); err != nil {
+				return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "本地暂存失败: " + err.Error()}}, IsError: true}
+			}
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已点击“暂存离开”，草稿已保存到草稿箱（如页面提供该能力）"}}}
 		}
-		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已发布为仅自己可见（通过 save_draft 执行私密发布）"}}}
+
+		// cloud: 强制仅自己可见（覆盖传入的 visibility）
+		req.Visibility = "仅自己可见"
+		if _, err := s.xiaohongshuService.PublishVideo(ctx, req); err != nil {
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "云端暂存失败(私密发布): " + err.Error()}}, IsError: true}
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "云端暂存完成：已发布为仅自己可见"}}}
 	default:
 		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "不支持的 type: " + args.Type}}, IsError: true}
 	}

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -865,3 +865,17 @@ func (s *AppServer) handleListLocalDrafts(ctx context.Context, args ListLocalDra
 		Content: []MCPContent{{Type: "text", Text: string(b)}},
 	}
 }
+
+func (s *AppServer) handleGetLocalDraftDetail(ctx context.Context, args GetLocalDraftDetailArgs) *MCPToolResult {
+	logrus.Infof("MCP: get_local_draft_detail draft_id=%s type=%s", args.DraftID, args.Type)
+	raw, err := s.xiaohongshuService.GetLocalDraftDetail(ctx, args.DraftID, args.Type)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "读取草稿详情失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(raw)}},
+	}
+}

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -875,7 +875,45 @@ func (s *AppServer) handleGetLocalDraftDetail(ctx context.Context, args GetLocal
 			IsError: true,
 		}
 	}
-	return &MCPToolResult{
-		Content: []MCPContent{{Type: "text", Text: string(raw)}},
+
+	type localDraftDetailResp struct {
+		Found   bool            `json:"found"`
+		Store   string          `json:"store"`
+		DraftID string          `json:"draft_id"`
+		Type    string          `json:"type"`
+		Value   json.RawMessage `json:"value"`
 	}
+
+	var resp localDraftDetailResp
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		// 兜底：返回结构化 JSON（不使用 markdown）。
+		out := map[string]any{
+			"found":  false,
+			"error":  "json_unmarshal_failed",
+			"raw":    string(raw),
+			"reason": err.Error(),
+		}
+		b, _ := json.MarshalIndent(out, "", "  ")
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: string(b)}}}
+	}
+
+	// resp.Value 是 json.RawMessage，会保持 value 的原始 JSON 结构（只要它在 indexedDB value 中是 JSON）。
+	type outResp struct {
+		Found   bool            `json:"found"`
+		Store   string          `json:"store"`
+		DraftID string          `json:"draft_id"`
+		Type    string          `json:"type"`
+		Value   json.RawMessage `json:"value,omitempty"`
+	}
+
+	out := outResp{
+		Found:   resp.Found,
+		Store:   resp.Store,
+		DraftID: resp.DraftID,
+		Type:    resp.Type,
+		Value:   resp.Value,
+	}
+
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: string(b)}}}
 }

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -742,3 +742,67 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 		}},
 	}
 }
+
+// --- XHS drafts MCP (save via web automation) ---
+
+type SaveDraftArgs struct {
+	Title      string   `json:"title"`
+	Content    string   `json:"content"`
+	Images     []string `json:"images,omitempty"`
+	Video      string   `json:"video,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	ScheduleAt string   `json:"schedule_at,omitempty"`
+	IsOriginal bool     `json:"is_original,omitempty"`
+	Visibility string   `json:"visibility,omitempty"`
+	Products   []string `json:"products,omitempty"`
+
+	// Type: image|video
+	Type string `json:"type"`
+}
+
+func (s *AppServer) handleSaveDraft(ctx context.Context, args SaveDraftArgs) *MCPToolResult {
+	// NOTE: 按需求调整：save_draft 不再走“暂存/存草稿”按钮，而是执行“发布”但强制设置为“仅自己可见”
+	// 这样可规避页面文案变化导致的草稿按钮定位失败，但会产生真实发布（私密可见）。
+	logrus.Info("MCP: 私密发布（使用 save_draft 接口，强制仅自己可见）")
+
+	if args.Type == "" {
+		args.Type = "image"
+	}
+
+	// 强制仅自己可见（覆盖传入的 visibility）
+	args.Visibility = "仅自己可见"
+
+	switch args.Type {
+	case "image":
+		req := &PublishRequest{
+			Title:      args.Title,
+			Content:    args.Content,
+			Images:     args.Images,
+			Tags:       args.Tags,
+			ScheduleAt: args.ScheduleAt,
+			IsOriginal: args.IsOriginal,
+			Visibility: args.Visibility,
+			Products:   args.Products,
+		}
+		if _, err := s.xiaohongshuService.PublishContent(ctx, req); err != nil {
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "私密发布失败: " + err.Error()}}, IsError: true}
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已发布为仅自己可见（通过 save_draft 执行私密发布）"}}}
+	case "video":
+		req := &PublishVideoRequest{
+			Title:      args.Title,
+			Content:    args.Content,
+			Video:      args.Video,
+			Tags:       args.Tags,
+			ScheduleAt: args.ScheduleAt,
+			Visibility: args.Visibility,
+			Products:   args.Products,
+		}
+		if _, err := s.xiaohongshuService.PublishVideo(ctx, req); err != nil {
+			return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "私密发布失败: " + err.Error()}}, IsError: true}
+		}
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "已发布为仅自己可见（通过 save_draft 执行私密发布）"}}}
+	default:
+		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "不支持的 type: " + args.Type}}, IsError: true}
+	}
+}

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -831,3 +831,37 @@ func (s *AppServer) handleSaveDraft(ctx context.Context, args SaveDraftArgs) *MC
 		return &MCPToolResult{Content: []MCPContent{{Type: "text", Text: "不支持的 type: " + args.Type}}, IsError: true}
 	}
 }
+
+func (s *AppServer) handleListLocalDrafts(ctx context.Context, args ListLocalDraftsArgs) *MCPToolResult {
+	draftType := strings.TrimSpace(args.Type)
+	if draftType == "" {
+		draftType = "image"
+	}
+
+	switch draftType {
+	case "image", "video", "article", "audio":
+	default:
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "不支持的 type: " + draftType + "（仅支持 image|video|article|audio）"}},
+			IsError: true,
+		}
+	}
+
+	limit := args.Limit
+	if limit < 0 {
+		limit = 0
+	}
+
+	result, err := s.xiaohongshuService.ListLocalDrafts(ctx, draftType, limit)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "读取本地草稿失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	b, _ := json.MarshalIndent(result, "", "  ")
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(b)}},
+	}
+}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -103,7 +103,13 @@ type FavoriteFeedArgs struct {
 // ListLocalDraftsArgs 读取本地草稿参数
 type ListLocalDraftsArgs struct {
 	Type  string `json:"type,omitempty" jsonschema:"草稿类型（可选）：image(默认)|video|article|audio"`
-	Limit int    `json:"limit,omitempty" jsonschema:"返回数量上限（可选，<=0 表示不限）"`
+	Limit int    `json:"limit,omitempty" jsonschema:"返回数量上限（可选，填 0 或负数表示不限）"`
+}
+
+// GetLocalDraftDetailArgs 获取本地草稿详情参数
+type GetLocalDraftDetailArgs struct {
+	DraftID string `json:"draft_id" jsonschema:"草稿 ID（与 list_local_drafts 返回的 draft_id 一致）"`
+	Type    string `json:"type,omitempty" jsonschema:"可选：image|video|article|audio；不填则在各 draft store 中依次查找"`
 }
 
 // InitMCPServer 初始化 MCP Server
@@ -481,7 +487,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 15)
+	// 工具 16: 读取本地草稿详情
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_local_draft_detail",
+			Description: "按 draft_id 从本机浏览器 IndexedDB（draft-database-v1）读取单条草稿完整内容（JSON）。可选 type 限定 image|video|article|audio。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Local Draft Detail",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_local_draft_detail", func(ctx context.Context, req *mcp.CallToolRequest, args GetLocalDraftDetailArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleGetLocalDraftDetail(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 16)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -100,6 +100,12 @@ type FavoriteFeedArgs struct {
 	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
+// ListLocalDraftsArgs 读取本地草稿参数
+type ListLocalDraftsArgs struct {
+	Type  string `json:"type,omitempty" jsonschema:"草稿类型（可选）：image(默认)|video|article|audio"`
+	Limit int    `json:"limit,omitempty" jsonschema:"返回数量上限（可选，<=0 表示不限）"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -459,7 +465,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 14)
+	// 工具 15: 读取本地草稿
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "list_local_drafts",
+			Description: "读取创作中心本地草稿（来自浏览器 IndexedDB: draft-database-v1）",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Local Drafts",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("list_local_drafts", func(ctx context.Context, req *mcp.CallToolRequest, args ListLocalDraftsArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleListLocalDrafts(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 15)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -443,7 +443,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	// 工具 14: 保存草稿
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "save_draft",
+			Description: "保存草稿（通过仅个人可见发布）",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Save Draft",
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		withPanicRecovery("save_draft", func(ctx context.Context, req *mcp.CallToolRequest, args SaveDraftArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleSaveDraft(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -447,7 +447,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "save_draft",
-			Description: "保存草稿（通过仅个人可见发布）",
+			Description: "保存草稿（两种模式：cloud=仅自己可见发布作为云端暂存；local=点击“暂存离开”保存到草稿箱）",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Save Draft",
 				DestructiveHint: boolPtr(true),

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -278,11 +279,14 @@ func (s *XiaohongshuService) SaveLocalImageDraft(ctx context.Context, req *Publi
 		Products:     req.Products,
 	}
 
-	b := newBrowser()
-	defer b.Close()
-
+	// 复用同一个 Chrome 实例，确保 IndexedDB 能在后续 list_local_drafts 里读到。
+	draftBrowserMu.Lock()
+	b := getDraftBrowser()
 	page := b.NewPage()
-	defer page.Close()
+	defer func() {
+		_ = page.Close()
+		draftBrowserMu.Unlock()
+	}()
 
 	action, err := xiaohongshu.NewPublishImageAction(page)
 	if err != nil {
@@ -412,11 +416,14 @@ func (s *XiaohongshuService) SaveLocalVideoDraft(ctx context.Context, req *Publi
 		Products:     req.Products,
 	}
 
-	b := newBrowser()
-	defer b.Close()
-
+	// 复用同一个 Chrome 实例，确保 IndexedDB 能在后续 list_local_drafts 里读到。
+	draftBrowserMu.Lock()
+	b := getDraftBrowser()
 	page := b.NewPage()
-	defer page.Close()
+	defer func() {
+		_ = page.Close()
+		draftBrowserMu.Unlock()
+	}()
 
 	action, err := xiaohongshu.NewPublishVideoAction(page)
 	if err != nil {
@@ -700,11 +707,14 @@ func (s *XiaohongshuService) GetMyProfile(ctx context.Context) (*UserProfileResp
 
 // ListLocalDrafts 读取创作中心 IndexedDB 本地草稿
 func (s *XiaohongshuService) ListLocalDrafts(ctx context.Context, draftType string, limit int) (*DraftsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
+	// 复用同一个 Chrome 实例，确保读到由 save_draft 写入的 IndexedDB。
+	draftBrowserMu.Lock()
+	b := getDraftBrowser()
 	page := b.NewPage()
-	defer page.Close()
+	defer func() {
+		_ = page.Close()
+		draftBrowserMu.Unlock()
+	}()
 
 	action := xiaohongshu.NewDraftAction(page)
 	drafts, err := action.ListLocalDrafts(ctx, draftType, limit)
@@ -717,4 +727,33 @@ func (s *XiaohongshuService) ListLocalDrafts(ctx context.Context, draftType stri
 		Count:  len(drafts),
 		Drafts: drafts,
 	}, nil
+}
+
+// GetLocalDraftDetail 读取单条本地草稿详情（IndexedDB）
+func (s *XiaohongshuService) GetLocalDraftDetail(ctx context.Context, draftID, draftType string) (json.RawMessage, error) {
+	// 复用同一个 Chrome 实例，确保读到由 save_draft 写入的 IndexedDB。
+	draftBrowserMu.Lock()
+	b := getDraftBrowser()
+	page := b.NewPage()
+	defer func() {
+		_ = page.Close()
+		draftBrowserMu.Unlock()
+	}()
+
+	action := xiaohongshu.NewDraftAction(page)
+	return action.GetLocalDraftDetail(ctx, draftID, draftType)
+}
+
+// draftBrowser 复用用于本地草稿读写：解决每次 newBrowser()+Close() 导致 IndexedDB 写入落在临时 profile、后续读不到的问题。
+var (
+	draftBrowserOnce sync.Once
+	draftBrowser     *headless_browser.Browser
+	draftBrowserMu   sync.Mutex
+)
+
+func getDraftBrowser() *headless_browser.Browser {
+	draftBrowserOnce.Do(func() {
+		draftBrowser = newBrowser()
+	})
+	return draftBrowser
 }

--- a/service.go
+++ b/service.go
@@ -258,15 +258,9 @@ func (s *XiaohongshuService) SaveLocalImageDraft(ctx context.Context, req *Publi
 		return err
 	}
 
-	// 本地暂存：不强制要求/不建议设置定时发布；如调用方传了也沿用解析，避免参数无效造成困惑
-	var scheduleTime *time.Time
-	if req.ScheduleAt != "" {
-		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
-		if err != nil {
-			return fmt.Errorf("定时发布时间格式错误，请使用 ISO8601 格式: %v", err)
-		}
-		scheduleTime = &t
-	}
+	// 本地暂存忽略 schedule_at：页面的“暂存离开”路径不一定支持/正确处理定时发布 UI。
+	// 这里强制不传 scheduleTime，避免因 UI 不匹配导致暂存失败。
+	var scheduleTime *time.Time = nil
 
 	content := xiaohongshu.PublishImageContent{
 		Title:        req.Title,
@@ -397,14 +391,8 @@ func (s *XiaohongshuService) SaveLocalVideoDraft(ctx context.Context, req *Publi
 		return fmt.Errorf("视频文件不存在或不可访问: %v", err)
 	}
 
-	var scheduleTime *time.Time
-	if req.ScheduleAt != "" {
-		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
-		if err != nil {
-			return fmt.Errorf("定时发布时间格式错误，请使用 ISO8601 格式: %v", err)
-		}
-		scheduleTime = &t
-	}
+	// 本地暂存忽略 schedule_at：同 SaveLocalImageDraft。
+	var scheduleTime *time.Time = nil
 
 	content := xiaohongshu.PublishVideoContent{
 		Title:        req.Title,

--- a/service.go
+++ b/service.go
@@ -93,6 +93,13 @@ type UserProfileResponse struct {
 	Feeds         []xiaohongshu.Feed             `json:"feeds"`
 }
 
+// DraftsListResponse 本地草稿列表响应
+type DraftsListResponse struct {
+	Type   string                 `json:"type"`
+	Count  int                    `json:"count"`
+	Drafts []xiaohongshu.LocalDraft `json:"drafts"`
+}
+
 // DeleteCookies 删除 cookies 文件，用于登录重置
 func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
 	cookiePath := cookies.GetCookiesFilePath()
@@ -689,4 +696,25 @@ func (s *XiaohongshuService) GetMyProfile(ctx context.Context) (*UserProfileResp
 	}
 
 	return response, nil
+}
+
+// ListLocalDrafts 读取创作中心 IndexedDB 本地草稿
+func (s *XiaohongshuService) ListLocalDrafts(ctx context.Context, draftType string, limit int) (*DraftsListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewDraftAction(page)
+	drafts, err := action.ListLocalDrafts(ctx, draftType, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DraftsListResponse{
+		Type:   draftType,
+		Count:  len(drafts),
+		Drafts: drafts,
+	}, nil
 }

--- a/service.go
+++ b/service.go
@@ -238,6 +238,53 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 	return response, nil
 }
 
+// SaveLocalImageDraft 本地暂存图文草稿：点击“暂存离开”（不发布）
+func (s *XiaohongshuService) SaveLocalImageDraft(ctx context.Context, req *PublishRequest) error {
+	// 标题长度校验（小红书限制：最大20个字）
+	if xhsutil.CalcTitleLength(req.Title) > 20 {
+		return fmt.Errorf("标题长度超过限制")
+	}
+
+	imagePaths, err := s.processImages(req.Images)
+	if err != nil {
+		return err
+	}
+
+	// 本地暂存：不强制要求/不建议设置定时发布；如调用方传了也沿用解析，避免参数无效造成困惑
+	var scheduleTime *time.Time
+	if req.ScheduleAt != "" {
+		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
+		if err != nil {
+			return fmt.Errorf("定时发布时间格式错误，请使用 ISO8601 格式: %v", err)
+		}
+		scheduleTime = &t
+	}
+
+	content := xiaohongshu.PublishImageContent{
+		Title:        req.Title,
+		Content:      req.Content,
+		Tags:         req.Tags,
+		ImagePaths:   imagePaths,
+		ScheduleTime: scheduleTime,
+		IsOriginal:   req.IsOriginal,
+		Visibility:   req.Visibility,
+		Products:     req.Products,
+	}
+
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action, err := xiaohongshu.NewPublishImageAction(page)
+	if err != nil {
+		return err
+	}
+
+	return action.SaveLocalDraft(ctx, content)
+}
+
 // processImages 处理图片列表，支持URL下载和本地路径
 func (s *XiaohongshuService) processImages(images []string) ([]string, error) {
 	processor := downloader.NewImageProcessor()
@@ -325,6 +372,51 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 		Status:  "发布完成",
 	}
 	return resp, nil
+}
+
+// SaveLocalVideoDraft 本地暂存视频草稿：点击“暂存离开”（不发布）
+func (s *XiaohongshuService) SaveLocalVideoDraft(ctx context.Context, req *PublishVideoRequest) error {
+	if xhsutil.CalcTitleLength(req.Title) > 20 {
+		return fmt.Errorf("标题长度超过限制")
+	}
+	if req.Video == "" {
+		return fmt.Errorf("必须提供本地视频文件")
+	}
+	if _, err := os.Stat(req.Video); err != nil {
+		return fmt.Errorf("视频文件不存在或不可访问: %v", err)
+	}
+
+	var scheduleTime *time.Time
+	if req.ScheduleAt != "" {
+		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
+		if err != nil {
+			return fmt.Errorf("定时发布时间格式错误，请使用 ISO8601 格式: %v", err)
+		}
+		scheduleTime = &t
+	}
+
+	content := xiaohongshu.PublishVideoContent{
+		Title:        req.Title,
+		Content:      req.Content,
+		Tags:         req.Tags,
+		VideoPath:    req.Video,
+		ScheduleTime: scheduleTime,
+		Visibility:   req.Visibility,
+		Products:     req.Products,
+	}
+
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action, err := xiaohongshu.NewPublishVideoAction(page)
+	if err != nil {
+		return err
+	}
+
+	return action.SaveLocalVideoDraft(ctx, content)
 }
 
 // publishVideo 执行视频发布

--- a/xiaohongshu/drafts.go
+++ b/xiaohongshu/drafts.go
@@ -1,0 +1,256 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/pkg/errors"
+)
+
+// LocalDraft IndexedDB 中的本地草稿简要信息
+type LocalDraft struct {
+	DraftID        string `json:"draft_id"`
+	UID            string `json:"uid,omitempty"`
+	Type           string `json:"type"`
+	Title          string `json:"title,omitempty"`
+	ContentPreview string `json:"content_preview,omitempty"`
+	ImageCount     int    `json:"image_count,omitempty"`
+	UpdatedAt      int64  `json:"updated_at,omitempty"`
+}
+
+type DraftAction struct {
+	page *rod.Page
+}
+
+func NewDraftAction(page *rod.Page) *DraftAction {
+	pp := page.Timeout(120 * time.Second)
+	return &DraftAction{page: pp}
+}
+
+// ListLocalDrafts 从 creator.xiaohongshu.com 的 IndexedDB(draft-database-v1) 读取本地草稿。
+// draftType 支持: image|video|article|audio，limit<=0 表示不限。
+func (d *DraftAction) ListLocalDrafts(ctx context.Context, draftType string, limit int) ([]LocalDraft, error) {
+	page := d.page.Context(ctx)
+
+	// 先导航到创作中心，确保同源上下文可访问 IndexedDB
+	page.MustNavigate("https://creator.xiaohongshu.com/").MustWaitLoad()
+
+	result, err := page.Eval(`(draftType, limit) => {
+		const storeNameMap = {
+			image: "image-draft",
+			video: "video-draft",
+			article: "article-draft",
+			audio: "audio-draft",
+		};
+		const storeName = storeNameMap[draftType] || "image-draft";
+		const maxCount = Number.isFinite(limit) ? limit : 0;
+
+		const pick = (obj, path, defVal = "") => {
+			try {
+				const parts = path.split(".");
+				let cur = obj;
+				for (const p of parts) {
+					if (cur == null) return defVal;
+					cur = cur[p];
+				}
+				return cur == null ? defVal : cur;
+			} catch {
+				return defVal;
+			}
+		};
+
+		return new Promise((resolve, reject) => {
+			const req = indexedDB.open("draft-database-v1");
+			req.onerror = () => reject(new Error("open draft-database-v1 failed"));
+			req.onsuccess = () => {
+				try {
+					const db = req.result;
+					if (!db.objectStoreNames.contains(storeName)) {
+						resolve(JSON.stringify([]));
+						return;
+					}
+
+					const tx = db.transaction(storeName, "readonly");
+					const store = tx.objectStore(storeName);
+					const items = [];
+
+					const cursorReq = store.openCursor();
+					cursorReq.onerror = () => reject(new Error("openCursor failed"));
+					cursorReq.onsuccess = (e) => {
+						const cursor = e.target.result;
+						if (!cursor) {
+							items.sort((a, b) => (b.updated_at || 0) - (a.updated_at || 0));
+							const sliced = maxCount > 0 ? items.slice(0, maxCount) : items;
+							resolve(JSON.stringify(sliced));
+							return;
+						}
+
+						const key = cursor.key;
+						const v = cursor.value || {};
+						const content = v.content || {};
+						const articleStore = content.articleStore || {};
+						const draftStore = content.draftStore || {};
+						const imgList = Array.isArray(draftStore.imgList) ? draftStore.imgList : [];
+
+						const title = String(
+							articleStore.articleTitle ||
+							draftStore.title ||
+							v.title ||
+							"",
+						);
+						const body = String(
+							articleStore.articleContent ||
+							draftStore.desc ||
+							v.content ||
+							"",
+						);
+
+						items.push({
+							draft_id: String(v.draftId || key || ""),
+							uid: String(v.uid || ""),
+							type: String(draftType),
+							title,
+							content_preview: body ? body.slice(0, 120) : "",
+							image_count: imgList.length,
+							updated_at: Number(v.timeStamp || v.updateTime || v.updatedAt || 0),
+						});
+						cursor.continue();
+					};
+				} catch (e) {
+					reject(e);
+				}
+			};
+		});
+	}`, draftType, limit)
+	if err != nil {
+		return nil, errors.Wrap(err, "读取草稿 IndexedDB 失败")
+	}
+
+	raw := result.Value.String()
+	var drafts []LocalDraft
+	if err := json.Unmarshal([]byte(raw), &drafts); err != nil {
+		return nil, errors.Wrap(err, "解析草稿数据失败")
+	}
+	return drafts, nil
+}
+
+// GetLocalDraftDetail 按 draft_id 从 draft-database-v1 读取单条草稿完整内容（value 已做 JSON 友好化，File/Blob 转为摘要）。
+// draftType 为空则在 image-draft、video-draft、article-draft、audio-draft 中依次查找；否则只查对应 store。
+func (d *DraftAction) GetLocalDraftDetail(ctx context.Context, draftID, draftType string) (json.RawMessage, error) {
+	if draftID == "" {
+		return nil, errors.New("draft_id 不能为空")
+	}
+	page := d.page.Context(ctx)
+	page.MustNavigate("https://creator.xiaohongshu.com/").MustWaitLoad()
+
+	result, err := page.Eval(`(draftId, draftType) => {
+		const storeNameMap = {
+			image: "image-draft",
+			video: "video-draft",
+			article: "article-draft",
+			audio: "audio-draft",
+		};
+		const order = (draftType && storeNameMap[draftType])
+			? [storeNameMap[draftType]]
+			: ["image-draft", "video-draft", "article-draft", "audio-draft"];
+
+		function logicalType(storeName) {
+			for (const k of Object.keys(storeNameMap)) {
+				if (storeNameMap[k] === storeName) return k;
+			}
+			return "";
+		}
+
+		function sanitize(v) {
+			if (v == null) return v;
+			const t = typeof v;
+			if (t === "function" || t === "symbol") return undefined;
+			if (v instanceof File) return { __kind: "File", name: v.name, size: v.size, type: v.type };
+			if (v instanceof Blob) return { __kind: "Blob", size: v.size, type: v.type };
+			if (Array.isArray(v)) return v.map(sanitize).filter(x => x !== undefined);
+			if (t === "object") {
+				const o = {};
+				for (const k of Object.keys(v)) {
+					try {
+						const s = sanitize(v[k]);
+						if (s !== undefined) o[k] = s;
+					} catch (e) {}
+				}
+				return o;
+			}
+			return v;
+		}
+
+		return new Promise((resolve, reject) => {
+			const openReq = indexedDB.open("draft-database-v1");
+			openReq.onerror = () => reject(new Error("open draft-database-v1 failed"));
+			openReq.onsuccess = () => {
+				const db = openReq.result;
+				function tryNext(i) {
+					if (i >= order.length) {
+						db.close();
+						resolve(JSON.stringify({ found: false, draft_id: String(draftId) }));
+						return;
+					}
+					const storeName = order[i];
+					if (!db.objectStoreNames.contains(storeName)) {
+						tryNext(i + 1);
+						return;
+					}
+					const tx = db.transaction(storeName, "readonly");
+					const store = tx.objectStore(storeName);
+					const g = store.get(draftId);
+					g.onerror = () => { try { db.close(); } catch (e) {} reject(g.error); };
+					g.onsuccess = () => {
+						let val = g.result;
+						if (val != null) {
+							db.close();
+							resolve(JSON.stringify({
+								found: true,
+								store: storeName,
+								draft_id: String(draftId),
+								type: logicalType(storeName),
+								value: sanitize(val),
+							}));
+							return;
+						}
+						const cur = store.openCursor();
+						cur.onerror = () => { try { db.close(); } catch (e) {} reject(cur.error); };
+						cur.onsuccess = (e) => {
+							const c = e.target.result;
+							if (!c) {
+								tryNext(i + 1);
+								return;
+							}
+							const v = c.value || {};
+							if (String(v.draftId || "") === String(draftId) || String(c.key || "") === String(draftId)) {
+								db.close();
+								resolve(JSON.stringify({
+									found: true,
+									store: storeName,
+									draft_id: String(draftId),
+									type: logicalType(storeName),
+									value: sanitize(v),
+								}));
+								return;
+							}
+							c.continue();
+						};
+					};
+				}
+				tryNext(0);
+			};
+		});
+	}`, draftID, draftType)
+	if err != nil {
+		return nil, errors.Wrap(err, "读取草稿详情失败")
+	}
+	raw := result.Value.String()
+	if raw == "" {
+		return nil, errors.New("未拿到草稿详情")
+	}
+	return json.RawMessage(raw), nil
+}
+

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -384,7 +384,7 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	}
 	if err := titleElem.Input(title); err != nil {
 		return errors.Wrap(err, "输入标题失败")
-	}
+		}
 
 	time.Sleep(500 * time.Millisecond)
 	if err := checkTitleMaxLength(page); err != nil {
@@ -402,7 +402,7 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	}
 	if err := waitAndClickTitleInput(titleElem); err != nil {
 		return err
-	}
+			}
 	if err := inputTags(contentElem, tags); err != nil {
 		return err
 	}
@@ -424,8 +424,8 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	if isOriginal {
 		if err := setOriginal(page); err != nil {
 			slog.Warn("设置原创声明失败，继续暂存", "error", err)
+			}
 		}
-	}
 	if err := bindProducts(page, products); err != nil {
 		return errors.Wrap(err, "绑定商品失败")
 	}
@@ -435,8 +435,8 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	}
 
 	time.Sleep(2 * time.Second)
-	return nil
-}
+			return nil
+		}
 
 func clickStashLeaveButton(page *rod.Page) error {
 	container, _ := page.Element(".publish-page-publish-btn")

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -384,7 +384,7 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	}
 	if err := titleElem.Input(title); err != nil {
 		return errors.Wrap(err, "输入标题失败")
-		}
+	}
 
 	time.Sleep(500 * time.Millisecond)
 	if err := checkTitleMaxLength(page); err != nil {
@@ -424,19 +424,26 @@ func submitLocalDraft(page *rod.Page, title, content string, tags []string, sche
 	if isOriginal {
 		if err := setOriginal(page); err != nil {
 			slog.Warn("设置原创声明失败，继续暂存", "error", err)
-			}
 		}
+	}
 	if err := bindProducts(page, products); err != nil {
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
+	startMs := time.Now().UnixMilli()
 	if err := clickStashLeaveButton(page); err != nil {
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
-			return nil
-		}
+	// 点击“暂存离开”后轮询 IndexedDB，直到 draft 写入成功或超时。
+	// 这样避免固定 sleep 导致 list_local_drafts 读不到刚保存的草稿。
+	if err := waitForLocalDraftWritten(page, "image-draft", title, startMs, 60*time.Second); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+	return nil
+}
 
 func clickStashLeaveButton(page *rod.Page) error {
 	container, _ := page.Element(".publish-page-publish-btn")
@@ -463,7 +470,8 @@ func clickStashLeaveButton(page *rod.Page) error {
 		if t == "" {
 			continue
 		}
-		if t == "暂存离开" || strings.Contains(t, "暂存") {
+		// 仅匹配精确文案，避免“暂存”相关按钮因页面结构变化误触。
+		if t == "暂存离开" {
 			if err := b.Click(proto.InputMouseButtonLeft, 1); err != nil {
 				continue
 			}
@@ -472,6 +480,122 @@ func clickStashLeaveButton(page *rod.Page) error {
 		}
 	}
 	return errors.New("未找到“暂存离开”按钮（页面可能无该能力或结构变更）")
+}
+
+// waitForLocalDraftWritten 轮询等待 IndexedDB 里出现刚保存的草稿记录。
+// 通过 updated_at >= startMs 且（title 为空时放宽）或 title 匹配来判断“写入成功”。
+func waitForLocalDraftWritten(page *rod.Page, storeName, title string, startMs int64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	targetTitle := strings.TrimSpace(title)
+	var lastErr error
+
+	slog.Info("等待本地草稿写入 IndexedDB", "store", storeName, "title", targetTitle, "timeout", timeout.String())
+	lastLog := time.Now().Add(-10 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if time.Since(lastLog) >= 10*time.Second {
+			slog.Info("仍在等待本地草稿写入", "store", storeName, "title", targetTitle)
+			lastLog = time.Now()
+		}
+		// 给 JS Promise 加“硬超时”，避免 IndexedDB 回调迟迟不触发导致 Go 卡死。
+		found, err := page.Eval(`(draftType, targetTitle, startMs) => {
+			const normalizeTs = (ts) => {
+				const n = Number(ts || 0);
+				if (!Number.isFinite(n)) return 0;
+				// 兼容秒/毫秒：小于 1e12 认为是秒
+				return n > 0 && n < 1e12 ? n * 1000 : n;
+			};
+
+			const promiseTimeoutMs = 8000;
+			let settled = false;
+
+			function pickTitle(v) {
+				try {
+					const content = v && v.content ? v.content : {};
+					const articleStore = content.articleStore || {};
+					const draftStore = content.draftStore || {};
+					const t = articleStore.articleTitle || draftStore.title || v.title || '';
+					return String(t).trim();
+				} catch (e) {
+					return '';
+				}
+			}
+
+			return new Promise((resolve, reject) => {
+				setTimeout(() => {
+					if (settled) return;
+					settled = true;
+					// 轮询层面由 Go 决定是否重试；这里避免卡死，直接判定本轮未写入
+					resolve(false);
+				}, promiseTimeoutMs);
+
+				const req = indexedDB.open("draft-database-v1");
+				req.onerror = () => {
+					if (settled) return;
+					settled = true;
+					resolve(false);
+				};
+				req.onsuccess = () => {
+					const db = req.result;
+					try {
+						if (!db.objectStoreNames.contains(draftType)) {
+							db.close();
+							resolve(false);
+							return;
+						}
+						const tx = db.transaction(draftType, "readonly");
+						const store = tx.objectStore(draftType);
+						const cursorReq = store.openCursor();
+						cursorReq.onerror = () => {
+							try { db.close(); } catch (_) {}
+							if (settled) return;
+							settled = true;
+							resolve(false);
+						};
+						cursorReq.onsuccess = (e) => {
+							const cursor = e.target.result;
+							if (!cursor) {
+								db.close();
+								resolve(false);
+								return;
+							}
+
+							const v = cursor.value || {};
+							const upd = normalizeTs(v.timeStamp || v.updateTime || v.updatedAt || 0);
+							if (upd >= startMs) {
+								const t = pickTitle(v);
+								// targetTitle 为空时只要时间足够新就认为写入成功
+								if (!targetTitle || t === targetTitle) {
+									settled = true;
+									db.close();
+									resolve(true);
+									return;
+								}
+							}
+							cursor.continue();
+						};
+					} catch (e) {
+						try { db.close(); } catch (_) {}
+						reject(e);
+					}
+				};
+			});
+		}`, storeName, targetTitle, startMs)
+
+		// found.Value 的具体类型是 gson.JSON，不能与 nil 比较。
+		if err == nil && found != nil && found.Value.Bool() {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if lastErr != nil {
+		return errors.Wrap(lastErr, "等待本地草稿写入 IndexedDB 失败（超时）")
+	}
+	return errors.New("等待本地草稿写入 IndexedDB 失败（超时）")
 }
 
 // waitAndClickTitleInput 在填写正文后等待 1 秒并回点标题输入框，增强后续交互稳定性

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -94,6 +94,33 @@ func (p *PublishAction) Publish(ctx context.Context, content PublishImageContent
 	return nil
 }
 
+// SaveLocalDraft 本地暂存图文草稿：点击“暂存离开”（不发布）
+func (p *PublishAction) SaveLocalDraft(ctx context.Context, content PublishImageContent) error {
+	if len(content.ImagePaths) == 0 {
+		return errors.New("图片不能为空")
+	}
+
+	page := p.page.Context(ctx)
+
+	if err := uploadImages(page, content.ImagePaths); err != nil {
+		return errors.Wrap(err, "小红书上传图片失败")
+	}
+
+	tags := content.Tags
+	if len(tags) >= 10 {
+		logrus.Warnf("标签数量超过10，截取前10个标签")
+		tags = tags[:10]
+	}
+
+	logrus.Infof("本地暂存: title=%s, images=%v, tags=%v, schedule=%v, original=%v, visibility=%s, products=%v", content.Title, len(content.ImagePaths), tags, content.ScheduleTime, content.IsOriginal, content.Visibility, content.Products)
+
+	if err := submitLocalDraft(page, content.Title, content.Content, tags, content.ScheduleTime, content.IsOriginal, content.Visibility, content.Products); err != nil {
+		return errors.Wrap(err, "小红书本地暂存失败")
+	}
+
+	return nil
+}
+
 func removePopCover(page *rod.Page) {
 
 	// 先移除弹窗封面
@@ -348,6 +375,103 @@ func submitPublish(page *rod.Page, title, content string, tags []string, schedul
 
 	time.Sleep(3 * time.Second)
 	return nil
+}
+
+func submitLocalDraft(page *rod.Page, title, content string, tags []string, scheduleTime *time.Time, isOriginal bool, visibility string, products []string) error {
+	titleElem, err := page.Element("div.d-input input")
+	if err != nil {
+		return errors.Wrap(err, "查找标题输入框失败")
+	}
+	if err := titleElem.Input(title); err != nil {
+		return errors.Wrap(err, "输入标题失败")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	if err := checkTitleMaxLength(page); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+
+	contentElem, ok := getContentElement(page)
+	if !ok {
+		return errors.New("没有找到内容输入框")
+	}
+	if err := contentElem.Input(content); err != nil {
+		return errors.Wrap(err, "输入正文失败")
+	}
+	if err := waitAndClickTitleInput(titleElem); err != nil {
+		return err
+	}
+	if err := inputTags(contentElem, tags); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+	if err := checkContentMaxLength(page); err != nil {
+		return err
+	}
+
+	// 本地暂存：尽量沿用设置项（如页面支持）
+	if scheduleTime != nil {
+		if err := setSchedulePublish(page, *scheduleTime); err != nil {
+			return errors.Wrap(err, "设置定时发布失败")
+		}
+	}
+	if err := setVisibility(page, visibility); err != nil {
+		return errors.Wrap(err, "设置可见范围失败")
+	}
+	if isOriginal {
+		if err := setOriginal(page); err != nil {
+			slog.Warn("设置原创声明失败，继续暂存", "error", err)
+		}
+	}
+	if err := bindProducts(page, products); err != nil {
+		return errors.Wrap(err, "绑定商品失败")
+	}
+
+	if err := clickStashLeaveButton(page); err != nil {
+		return err
+	}
+
+	time.Sleep(2 * time.Second)
+	return nil
+}
+
+func clickStashLeaveButton(page *rod.Page) error {
+	container, _ := page.Element(".publish-page-publish-btn")
+	var buttons []*rod.Element
+	if container != nil {
+		btns, err := container.Elements("button")
+		if err == nil {
+			buttons = append(buttons, btns...)
+		}
+	}
+	if len(buttons) == 0 {
+		btns, err := page.Elements("button")
+		if err == nil {
+			buttons = append(buttons, btns...)
+		}
+	}
+
+	for _, b := range buttons {
+		txt, err := b.Text()
+		if err != nil {
+			continue
+		}
+		t := strings.TrimSpace(txt)
+		if t == "" {
+			continue
+		}
+		if t == "暂存离开" || strings.Contains(t, "暂存") {
+			if err := b.Click(proto.InputMouseButtonLeft, 1); err != nil {
+				continue
+			}
+			slog.Info("已点击暂存离开", "text", t)
+			return nil
+		}
+	}
+	return errors.New("未找到“暂存离开”按钮（页面可能无该能力或结构变更）")
 }
 
 // waitAndClickTitleInput 在填写正文后等待 1 秒并回点标题输入框，增强后续交互稳定性

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -70,6 +70,24 @@ func (p *PublishAction) PublishVideo(ctx context.Context, content PublishVideoCo
 	return nil
 }
 
+// SaveLocalVideoDraft 本地暂存视频草稿：点击“暂存离开”（不发布）
+func (p *PublishAction) SaveLocalVideoDraft(ctx context.Context, content PublishVideoContent) error {
+	if content.VideoPath == "" {
+		return errors.New("视频不能为空")
+	}
+
+	page := p.page.Context(ctx)
+
+	if err := uploadVideo(page, content.VideoPath); err != nil {
+		return errors.Wrap(err, "小红书上传视频失败")
+	}
+
+	if err := submitLocalVideoDraft(page, content.Title, content.Content, content.Tags, content.ScheduleTime, content.Visibility, content.Products); err != nil {
+		return errors.Wrap(err, "小红书本地暂存失败")
+	}
+	return nil
+}
+
 // uploadVideo 上传单个本地视频
 func uploadVideo(page *rod.Page, videoPath string) error {
 	pp := page.Timeout(5 * time.Minute) // 视频处理耗时更长
@@ -190,5 +208,60 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string, sc
 	}
 
 	time.Sleep(3 * time.Second)
+	return nil
+}
+
+func submitLocalVideoDraft(page *rod.Page, title, content string, tags []string, scheduleTime *time.Time, visibility string, products []string) error {
+	// 标题
+	titleElem, err := page.Element("div.d-input input")
+	if err != nil {
+		return errors.Wrap(err, "查找标题输入框失败")
+	}
+	if err := titleElem.Input(title); err != nil {
+		return errors.Wrap(err, "输入标题失败")
+	}
+	time.Sleep(1 * time.Second)
+
+	// 正文 + 标签
+	contentElem, ok := getContentElement(page)
+	if !ok {
+		return errors.New("没有找到内容输入框")
+	}
+	if err := contentElem.Input(content); err != nil {
+		return errors.Wrap(err, "输入正文失败")
+	}
+	if err := waitAndClickTitleInput(titleElem); err != nil {
+		return err
+	}
+	if err := inputTags(contentElem, tags); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// 处理定时发布（如页面支持）
+	if scheduleTime != nil {
+		if err := setSchedulePublish(page, *scheduleTime); err != nil {
+			return errors.Wrap(err, "设置定时发布失败")
+		}
+		slog.Info("定时发布设置完成", "schedule_time", scheduleTime.Format("2006-01-02 15:04"))
+	}
+
+	// 设置可见范围
+	if err := setVisibility(page, visibility); err != nil {
+		return errors.Wrap(err, "设置可见范围失败")
+	}
+
+	// 绑定商品
+	if err := bindProducts(page, products); err != nil {
+		return errors.Wrap(err, "绑定商品失败")
+	}
+
+	// 点击“暂存离开”
+	if err := clickStashLeaveButton(page); err != nil {
+		return err
+	}
+
+	time.Sleep(2 * time.Second)
 	return nil
 }

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -258,10 +258,16 @@ func submitLocalVideoDraft(page *rod.Page, title, content string, tags []string,
 	}
 
 	// 点击“暂存离开”
+	startMs := time.Now().UnixMilli()
 	if err := clickStashLeaveButton(page); err != nil {
 		return err
 	}
 
-	time.Sleep(2 * time.Second)
+	// 点击后轮询 IndexedDB，直到草稿写入成功或超时。
+	if err := waitForLocalDraftWritten(page, "video-draft", title, startMs, 60*time.Second); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
 	return nil
 }

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -196,15 +196,15 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string, sc
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
-	// 等待发布按钮可点击
-	btn, err := waitForPublishButtonClickable(page)
-	if err != nil {
-		return err
-	}
+		// 等待发布按钮可点击
+		btn, err := waitForPublishButtonClickable(page)
+		if err != nil {
+			return err
+		}
 
-	// 点击发布
-	if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return errors.Wrap(err, "点击发布按钮失败")
+		// 点击发布
+		if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+			return errors.Wrap(err, "点击发布按钮失败")
 	}
 
 	time.Sleep(3 * time.Second)


### PR DESCRIPTION
## Summary
新增小红书草稿能力，提供 3 个 MCP 工具：
- `save_draft`：保存草稿（`cloud/local` 两种模式）
- `list_local_drafts`：读取本地草稿列表
- `get_local_draft_detail`：按 `draft_id` 读取本地草稿详情

## 动机
补齐草稿完整工作流（保存 -> 列表 -> 详情），支持通过 MCP 对本地草稿进行管理与读取。

## 改动
- MCP 层新增 3 个草稿工具及参数定义
- 新增 IndexedDB 草稿读取实现（列表 + 详情）
- 新增本地暂存服务与发布流程联动
- 增加浏览器 profile 持久化支持，保证本地草稿可持续读取
- 更新 `README` 的草稿工具说明

## 测试
- 编译与容器启动通过
- MCP 工具注册数从 13 增至 16
- `save_draft(local)` 可执行
- `list_local_drafts` 与 `get_local_draft_detail` 可调用并返回结果

fixes #348 