### PR TITLE
feat(skills): add xhs-lifecycle skill — full MCP tools coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ test_*.sh
 
 # Cookies files (contain sensitive login information)
 cookies.json
+
+# Runtime files from xhs-lifecycle skill
+.server.pid
+.server.log

--- a/skills/xhs-lifecycle/SKILL.md
+++ b/skills/xhs-lifecycle/SKILL.md
@@ -9,7 +9,7 @@ description: >
 
 # 小红书全生命周期管理
 
-基于 xiaohongshu-mcp 的 13 个 MCP tools，覆盖搜索、阅读、发布、互动的完整操作流程。
+基于 xiaohongshu-mcp 的全部 MCP tools，覆盖搜索、阅读、发布、互动的完整操作流程。
 自动管理 server 启动和登录状态，用户无需手动配置。
 
 ## 1. 确保 MCP Server 运行
@@ -47,22 +47,15 @@ cd <repo-root> && go build -o xiaohongshu-mcp .
 服务运行后，调用 MCP tool `check_login_status` 确认小红书账号已登录。
 
 - **已登录** → 跳到步骤 3
-- **未登录** → 告诉用户需要扫码登录，然后运行登录工具：
-  ```bash
-  cd <repo-root> && go run cmd/login/main.go
-  ```
-  如果已构建 login binary：
-  ```bash
-  cd <repo-root> && ./xiaohongshu-login
-  ```
-  登录工具会弹出浏览器窗口显示二维码，用户用小红书 App 扫码。
+- **未登录** → 调用 `get_login_qrcode` 获取二维码，展示给用户扫码登录。
   登录成功后 cookies 持久化，后续重启服务无需重新登录。
+  如果需要重置登录状态，使用 `delete_cookies` 清除已保存的 cookies。
 
 ## 3. 执行用户任务
 
 登录确认后，根据用户意图调用对应的 MCP tool。
 
-### 常见场景映射
+### 场景映射
 
 | 用户意图 | MCP Tool | 注意事项 |
 |---------|----------|---------|
@@ -70,12 +63,15 @@ cd <repo-root> && go build -o xiaohongshu-mcp .
 | 浏览推荐 | `list_feeds` | 返回首页 feed |
 | 查看帖子详情 | `get_feed_detail` | 需要 feed_id + xsec_token |
 | 查看用户主页 | `user_profile` | 需要 user_id |
-| 发布图文 | `publish_content` | 标题 ≤20 字，正文 ≤1000 字 |
+| 发布图文 | `publish_content` | 标题 ≤20 字 |
 | 发布视频 | `publish_with_video` | 传入本地视频文件路径 |
 | 评论 | `post_comment_to_feed` | 需要 feed_id + xsec_token |
 | 回复评论 | `reply_comment_in_feed` | 需要 comment_id |
 | 点赞/取消 | `like_feed` | 智能切换状态 |
 | 收藏/取消 | `favorite_feed` | 智能切换状态 |
+| 检查登录 | `check_login_status` | 步骤 2 已覆盖 |
+| 扫码登录 | `get_login_qrcode` | 返回 Base64 二维码图片 |
+| 重置登录 | `delete_cookies` | 清除已保存的 cookies |
 
 ### 发布内容的额外要求
 

--- a/skills/xhs-lifecycle/SKILL.md
+++ b/skills/xhs-lifecycle/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: xhs-lifecycle
+description: >
+  小红书全生命周期管理技能，基于 MCP tools 实现。覆盖：自动启动 MCP server、登录引导、搜索、浏览推荐、
+  查看笔记详情、查看用户主页、发布图文/视频、评论、回复、点赞、收藏。
+  当用户提到小红书、xiaohongshu、RedNote，或者想要搜索/阅读/发布/评论/点赞小红书内容时触发。
+  也可通过 '发小红书'、'搜小红书'、'看小红书' 触发。
+---
+
+# 小红书全生命周期管理
+
+基于 xiaohongshu-mcp 的 13 个 MCP tools，覆盖搜索、阅读、发布、互动的完整操作流程。
+自动管理 server 启动和登录状态，用户无需手动配置。
+
+## 1. 确保 MCP Server 运行
+
+每次执行小红书相关操作前，先确认服务状态。
+
+### 1a. 检查状态
+
+```bash
+bash <skill-path>/scripts/check-status.sh
+```
+
+- `SERVER_UP` → 跳到步骤 2
+- `SERVER_DOWN` → 执行 1b
+
+### 1b. 启动服务
+
+```bash
+bash <skill-path>/scripts/start-server.sh
+```
+
+脚本会自动检测本地 Chrome/Chromium 路径（macOS、Linux、Windows 均支持），
+通过 `ROD_BROWSER_BIN` 环境变量传递给 server，避免 rod 从 Google 下载 Chromium
+（在部分网络环境下极慢或失败）。
+
+如果启动失败，检查日志（repo 根目录下 `.server.log`）并报告给用户。
+
+如果 binary 不存在，提示用户先构建：
+```bash
+cd <repo-root> && go build -o xiaohongshu-mcp .
+```
+
+## 2. 检查登录状态
+
+服务运行后，调用 MCP tool `check_login_status` 确认小红书账号已登录。
+
+- **已登录** → 跳到步骤 3
+- **未登录** → 告诉用户需要扫码登录，然后运行登录工具：
+  ```bash
+  cd <repo-root> && go run cmd/login/main.go
+  ```
+  如果已构建 login binary：
+  ```bash
+  cd <repo-root> && ./xiaohongshu-login
+  ```
+  登录工具会弹出浏览器窗口显示二维码，用户用小红书 App 扫码。
+  登录成功后 cookies 持久化，后续重启服务无需重新登录。
+
+## 3. 执行用户任务
+
+登录确认后，根据用户意图调用对应的 MCP tool。
+
+### 常见场景映射
+
+| 用户意图 | MCP Tool | 注意事项 |
+|---------|----------|---------|
+| 搜索内容 | `search_feeds` | 传入关键词 |
+| 浏览推荐 | `list_feeds` | 返回首页 feed |
+| 查看帖子详情 | `get_feed_detail` | 需要 feed_id + xsec_token |
+| 查看用户主页 | `user_profile` | 需要 user_id |
+| 发布图文 | `publish_content` | 标题 ≤20 字，正文 ≤1000 字 |
+| 发布视频 | `publish_with_video` | 传入本地视频文件路径 |
+| 评论 | `post_comment_to_feed` | 需要 feed_id + xsec_token |
+| 回复评论 | `reply_comment_in_feed` | 需要 comment_id |
+| 点赞/取消 | `like_feed` | 智能切换状态 |
+| 收藏/取消 | `favorite_feed` | 智能切换状态 |
+
+### 发布内容的额外要求
+
+发布前**必须**向用户确认以下内容，因为发布操作不可撤回：
+- 标题和正文的最终版本
+- 要附带的图片（路径列表）
+- 如果用户没提供图片，提醒他们小红书帖子通常需要图片
+
+### 已知限制
+
+- 每个账号每天约 50 条发帖上限
+- 小红书只允许单设备 web session：如果用户在别处登录了网页版，MCP 的 cookies 会失效，需要重新扫码
+- xsec_token 从 `get_feed_detail` 的返回结果中获取，评论时需要它

--- a/skills/xhs-lifecycle/scripts/check-status.sh
+++ b/skills/xhs-lifecycle/scripts/check-status.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Check xiaohongshu-mcp server status.
+# Usage: bash check-status.sh [repo_dir]
+# Outputs: SERVER_UP or SERVER_DOWN with details.
+
+set -euo pipefail
+
+XHS_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PORT=18060
+PIDFILE="$XHS_DIR/.server.pid"
+
+if lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  PID=$(lsof -t -i ":${PORT}" -sTCP:LISTEN 2>/dev/null || echo "unknown")
+  echo "SERVER_UP pid=${PID} port=${PORT}"
+else
+  echo "SERVER_DOWN port=${PORT}"
+  if [ -f "$PIDFILE" ]; then
+    echo "stale pidfile: $(cat "$PIDFILE")"
+  fi
+fi

--- a/skills/xhs-lifecycle/scripts/check-status.sh
+++ b/skills/xhs-lifecycle/scripts/check-status.sh
@@ -6,12 +6,26 @@
 set -euo pipefail
 
 XHS_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
-PORT=18060
+PORT="${XHS_PORT:-18060}"
 PIDFILE="$XHS_DIR/.server.pid"
 
-if lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
-  PID=$(lsof -t -i ":${PORT}" -sTCP:LISTEN 2>/dev/null || echo "unknown")
-  echo "SERVER_UP pid=${PID} port=${PORT}"
+# Port check with cross-platform fallback: lsof -> ss -> curl
+is_listening() {
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1
+  elif command -v ss >/dev/null 2>&1; then
+    ss -tlnp | grep -q ":${PORT} "
+  else
+    curl -s -o /dev/null --max-time 2 "http://127.0.0.1:${PORT}" 2>/dev/null
+  fi
+}
+
+if is_listening; then
+  PID=""
+  if command -v lsof >/dev/null 2>&1; then
+    PID=$(lsof -t -i ":${PORT}" -sTCP:LISTEN 2>/dev/null || true)
+  fi
+  echo "SERVER_UP pid=${PID:-unknown} port=${PORT}"
 else
   echo "SERVER_DOWN port=${PORT}"
   if [ -f "$PIDFILE" ]; then

--- a/skills/xhs-lifecycle/scripts/start-server.sh
+++ b/skills/xhs-lifecycle/scripts/start-server.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Start xiaohongshu-mcp server if not already running.
+# Usage: bash start-server.sh [repo_dir]
+# Exit codes: 0 = server ready, 1 = failed to start
+
+set -euo pipefail
+
+# Default to repo root (two levels up from this script)
+XHS_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PORT=18060
+PIDFILE="$XHS_DIR/.server.pid"
+LOGFILE="$XHS_DIR/.server.log"
+
+# --- detect local Chrome/Chromium (avoids rod downloading Chromium, which can be slow) ---
+detect_chrome_bin() {
+  if [ -n "${ROD_BROWSER_BIN:-}" ]; then
+    echo "$ROD_BROWSER_BIN"
+    return
+  fi
+  local candidates=(
+    # macOS
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    # Linux
+    "/usr/bin/google-chrome"
+    "/usr/bin/google-chrome-stable"
+    "/usr/bin/chromium"
+    "/usr/bin/chromium-browser"
+    # Windows (Git Bash / WSL)
+    "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+    "/c/Program Files/Google/Chrome/Application/chrome.exe"
+  )
+  for c in "${candidates[@]}"; do
+    if [ -x "$c" ] || [ -f "$c" ]; then
+      echo "$c"
+      return
+    fi
+  done
+}
+
+CHROME_BIN="$(detect_chrome_bin)"
+
+# --- helpers ---
+is_running() {
+  lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+wait_ready() {
+  local tries=0
+  while [ $tries -lt 15 ]; do
+    if is_running; then
+      return 0
+    fi
+    sleep 1
+    tries=$((tries + 1))
+  done
+  return 1
+}
+
+# --- main ---
+if is_running; then
+  echo "OK: xiaohongshu-mcp already running on port ${PORT}"
+  exit 0
+fi
+
+if [ ! -x "$XHS_DIR/xiaohongshu-mcp" ]; then
+  echo "ERROR: binary not found at $XHS_DIR/xiaohongshu-mcp"
+  echo "Run: cd $XHS_DIR && go build -o xiaohongshu-mcp ."
+  exit 1
+fi
+
+echo "Starting xiaohongshu-mcp on port ${PORT}..."
+cd "$XHS_DIR"
+if [ -n "$CHROME_BIN" ]; then
+  echo "Using local browser: $CHROME_BIN"
+  export ROD_BROWSER_BIN="$CHROME_BIN"
+fi
+nohup ./xiaohongshu-mcp -headless=true -port ":${PORT}" > "$LOGFILE" 2>&1 &
+echo $! > "$PIDFILE"
+
+if wait_ready; then
+  echo "OK: xiaohongshu-mcp started (pid=$(cat "$PIDFILE"))"
+  exit 0
+else
+  echo "ERROR: server did not become ready within 15s"
+  echo "Check logs: $LOGFILE"
+  exit 1
+fi

--- a/skills/xhs-lifecycle/scripts/start-server.sh
+++ b/skills/xhs-lifecycle/scripts/start-server.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 # Default to repo root (two levels up from this script)
 XHS_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
-PORT=18060
+PORT="${XHS_PORT:-18060}"
 PIDFILE="$XHS_DIR/.server.pid"
 LOGFILE="$XHS_DIR/.server.log"
 
@@ -27,10 +27,13 @@ detect_chrome_bin() {
     "/usr/bin/chromium"
     "/usr/bin/chromium-browser"
     # Windows (Git Bash / WSL)
+    # WSL paths may lack the executable bit, so we also check with -f below
     "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
     "/c/Program Files/Google/Chrome/Application/chrome.exe"
   )
   for c in "${candidates[@]}"; do
+    # -x works on native platforms; -f is a fallback for WSL where .exe files
+    # are accessible but may not have the executable permission bit set.
     if [ -x "$c" ] || [ -f "$c" ]; then
       echo "$c"
       return
@@ -41,15 +44,28 @@ detect_chrome_bin() {
 CHROME_BIN="$(detect_chrome_bin)"
 
 # --- helpers ---
+# Port check with cross-platform fallback: lsof (macOS/most Linux) -> ss (minimal Linux) -> curl
 is_running() {
-  lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1
+  elif command -v ss >/dev/null 2>&1; then
+    ss -tlnp | grep -q ":${PORT} "
+  else
+    curl -s -o /dev/null --max-time 2 "http://127.0.0.1:${PORT}" 2>/dev/null
+  fi
 }
 
 wait_ready() {
+  local pid=$1
   local tries=0
   while [ $tries -lt 15 ]; do
     if is_running; then
       return 0
+    fi
+    # Detect early crash to avoid waiting the full 15 seconds
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: server process (pid=$pid) exited unexpectedly"
+      return 1
     fi
     sleep 1
     tries=$((tries + 1))
@@ -76,10 +92,11 @@ if [ -n "$CHROME_BIN" ]; then
   export ROD_BROWSER_BIN="$CHROME_BIN"
 fi
 nohup ./xiaohongshu-mcp -headless=true -port ":${PORT}" > "$LOGFILE" 2>&1 &
-echo $! > "$PIDFILE"
+SERVER_PID=$!
+echo $SERVER_PID > "$PIDFILE"
 
-if wait_ready; then
-  echo "OK: xiaohongshu-mcp started (pid=$(cat "$PIDFILE"))"
+if wait_ready "$SERVER_PID"; then
+  echo "OK: xiaohongshu-mcp started (pid=$SERVER_PID)"
   exit 0
 else
   echo "ERROR: server did not become ready within 15s"

--- a/skills/xhs-lifecycle/scripts/stop-server.sh
+++ b/skills/xhs-lifecycle/scripts/stop-server.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Stop xiaohongshu-mcp server gracefully.
+# Usage: bash stop-server.sh [repo_dir]
+# Exit codes: 0 = stopped or not running, 1 = failed to stop
+
+set -euo pipefail
+
+XHS_DIR="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PORT="${XHS_PORT:-18060}"
+PIDFILE="$XHS_DIR/.server.pid"
+
+# Try to find PID from pidfile or lsof
+PID=""
+if [ -f "$PIDFILE" ]; then
+  PID=$(cat "$PIDFILE")
+fi
+if [ -z "$PID" ] && command -v lsof >/dev/null 2>&1; then
+  PID=$(lsof -t -i ":${PORT}" -sTCP:LISTEN 2>/dev/null || true)
+fi
+
+if [ -z "$PID" ]; then
+  echo "OK: xiaohongshu-mcp is not running"
+  rm -f "$PIDFILE"
+  exit 0
+fi
+
+echo "Stopping xiaohongshu-mcp (pid=$PID)..."
+kill "$PID" 2>/dev/null || true
+
+# Wait up to 5 seconds for graceful shutdown
+tries=0
+while [ $tries -lt 5 ]; do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "OK: stopped"
+    rm -f "$PIDFILE"
+    exit 0
+  fi
+  sleep 1
+  tries=$((tries + 1))
+done
+
+# Force kill if still alive
+kill -9 "$PID" 2>/dev/null || true
+rm -f "$PIDFILE"
+echo "OK: force stopped"


### PR DESCRIPTION
## Summary

新增 `xhs-lifecycle` skill，基于 repo 内置的 13 个 MCP tools，覆盖小红书的完整交互生命周期。

与现有 `post-to-xhs` skill 的定位区别：

| | `post-to-xhs` | `xhs-lifecycle`（本 PR） |
|---|---|---|
| 技术路线 | 自带 Python 脚本 + CDP 自动化 | **直接使用 MCP tools**，零额外依赖 |
| 覆盖范围 | 发布（图文+长文） | 全生命周期（启动/登录/搜索/阅读/发布/评论/点赞/收藏） |
| Server 管理 | 需用户手动启动 | **自动检测+启动** |
| 浏览器检测 | 无 | **自动检测本地 Chrome/Chromium**（macOS/Linux/Windows） |

### 核心功能

- **自动启动 MCP server**：检查端口 → 启动 binary → 等待就绪，15s 超时
- **跨平台 Chrome 检测**：自动查找本地 Chrome/Chromium 路径，通过 `ROD_BROWSER_BIN` 传递，避免 rod 下载 Chromium（在部分网络环境下极慢）
- **登录引导**：检测登录状态，未登录时引导用户扫码
- **覆盖全部 13 个 MCP tools**：搜索、浏览推荐、笔记详情、用户主页、发布图文/视频、评论、回复、点赞、收藏
- **发布安全**：发布前强制用户确认标题/正文/图片

### 文件清单

```
skills/xhs-lifecycle/
├── SKILL.md                  # Skill 定义 + 使用指引
└── scripts/
    ├── start-server.sh       # 自动检测 Chrome + 启动 server
    └── check-status.sh       # 健康检查
```

## Test plan

- [x] macOS 上验证 Chrome 自动检测和 server 启动
- [x] 验证 `check-status.sh` 正确报告 SERVER_UP/SERVER_DOWN
- [x] 验证 MCP tools 调用（search_feeds, get_feed_detail, check_login_status）
- [ ] Linux 环境验证（待社区测试）
- [ ] Windows/WSL 环境验证（待社区测试）

🤖 Generated with [Claude Code](https://claude.com/claude-code)