### PR TITLE
fix: Chrome 132+ headless mode compatibility

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,111 @@
+name: Sync Upstream
+
+# Runs daily at 08:00 UTC (16:00 CST) and on every push to main
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  push:
+    branches: [main]
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/xpzouying/xiaohongshu-mcp.git
+          git fetch upstream main
+
+      - name: Check for upstream changes
+        id: check
+        run: |
+          BEHIND=$(git rev-list --count HEAD..upstream/main)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          echo "Upstream is $BEHIND commits ahead"
+
+      - name: Attempt merge
+        if: steps.check.outputs.behind != '0'
+        id: merge
+        run: |
+          git merge upstream/main --no-edit 2>&1 | tee /tmp/merge-output.txt
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            git merge --abort
+          else
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push clean merge
+        if: steps.check.outputs.behind != '0' && steps.merge.outputs.conflict == 'false'
+        run: git push origin main
+
+      - name: Create PR for conflicts
+        if: steps.check.outputs.behind != '0' && steps.merge.outputs.conflict == 'true'
+        run: |
+          BRANCH="sync-upstream-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git merge upstream/main --no-edit || true
+
+          # Stage conflict markers so the PR shows what needs resolving
+          git add -A
+          git commit -m "chore: sync upstream (conflicts need manual resolution)" || true
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: sync upstream ($(date +%Y-%m-%d))" \
+            --body "$(cat <<'EOF'
+          ## Upstream Sync
+
+          Upstream has new commits that conflict with our fork modifications.
+
+          **Conflicts detected in:**
+          $(grep -l '<<<<<<<' $(git diff --name-only upstream/main) 2>/dev/null || echo "See merge output")
+
+          **Our modifications (likely conflict sources):**
+          - `browser/browser.go` — Chrome 132+ headless fix
+          - `Dockerfile` — Chrome auto-update disabled
+
+          **Action needed:** Resolve conflicts manually, ensuring our Chrome 132+ fixes are preserved.
+          EOF
+          )" \
+            --label "upstream-sync"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-test:
+    needs: sync
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build
+        run: |
+          go build -o /tmp/app .
+          echo "Build successful"
+
+      - name: Docker build test
+        run: |
+          docker build -t xiaohongshu-mcp:test .
+          echo "Docker build successful"

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,10 @@ RUN mkdir -p /app/images && \
 # 5. 设置默认 Chrome 路径（rod 会用）
 ENV ROD_BROWSER_BIN=/usr/bin/google-chrome
 
+# 6. Disable Chrome auto-updates (prevents Chrome version drift breaking go-rod)
+RUN rm -f /etc/cron.daily/google-chrome /etc/apt/sources.list.d/google-chrome.list && \
+    rm -f /etc/apt/apt.conf.d/*unattended-upgrades 2>/dev/null; true
+
 EXPOSE 18060
 
 CMD ["./app"]

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -1,13 +1,39 @@
 package browser
 
 import (
+	"encoding/json"
 	"net/url"
 	"os"
 
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/go-rod/stealth"
 	"github.com/sirupsen/logrus"
-	"github.com/xpzouying/headless_browser"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 )
+
+// defaultUserAgent matches the one in headless_browser package.
+const defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+// Browser wraps a go-rod browser with Chrome 132+ headless compatibility.
+// Replaces headless_browser.Browser to fix "Multiple targets are not
+// supported in headless mode" error in Chrome 132+.
+type Browser struct {
+	browser  *rod.Browser
+	launcher *launcher.Launcher
+}
+
+// Close closes the browser and cleans up resources.
+func (b *Browser) Close() {
+	b.browser.MustClose()
+	b.launcher.Cleanup()
+}
+
+// NewPage creates a new page with stealth mode enabled.
+func (b *Browser) NewPage() *rod.Page {
+	return stealth.MustPage(b.browser)
+}
 
 type browserConfig struct {
 	binPath string
@@ -35,35 +61,61 @@ func maskProxyCredentials(proxyURL string) string {
 	return u.String()
 }
 
-func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
+// NewBrowser creates a browser instance with Chrome 132+ headless compatibility.
+//
+// Chrome 132+ removed --headless=old. The new headless mode rejects
+// --no-startup-window (which go-rod's launcher.Headless(true) sets).
+// We configure go-rod's launcher directly, setting only --headless
+// without --no-startup-window.
+func NewBrowser(headless bool, options ...Option) *Browser {
 	cfg := &browserConfig{}
 	for _, opt := range options {
 		opt(cfg)
 	}
 
-	opts := []headless_browser.Option{
-		headless_browser.WithHeadless(headless),
-	}
-	if cfg.binPath != "" {
-		opts = append(opts, headless_browser.WithChromeBinPath(cfg.binPath))
+	l := launcher.New().
+		Set("no-sandbox").
+		Set("user-agent", defaultUserAgent)
+
+	// Set headless WITHOUT --no-startup-window (Chrome 132+ fix)
+	if headless {
+		l = l.Set("headless")
+		l = l.Delete("no-startup-window")
 	}
 
-	// Read proxy from environment variable
+	if cfg.binPath != "" {
+		l = l.Bin(cfg.binPath)
+	}
+
 	if proxy := os.Getenv("XHS_PROXY"); proxy != "" {
-		opts = append(opts, headless_browser.WithProxy(proxy))
+		l = l.Proxy(proxy)
 		logrus.Infof("Using proxy: %s", maskProxyCredentials(proxy))
 	}
 
-	// 加载 cookies
+	debugURL := l.MustLaunch()
+
+	b := rod.New().
+		ControlURL(debugURL).
+		MustConnect()
+
+	// Load cookies
 	cookiePath := cookies.GetCookiesFilePath()
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
 
 	if data, err := cookieLoader.LoadCookies(); err == nil {
-		opts = append(opts, headless_browser.WithCookies(string(data)))
-		logrus.Debugf("loaded cookies from filesuccessfully")
+		var cks []*proto.NetworkCookie
+		if err := json.Unmarshal(data, &cks); err != nil {
+			logrus.Warnf("failed to unmarshal cookies: %v", err)
+		} else {
+			b.MustSetCookies(cks...)
+			logrus.Debugf("loaded cookies from file successfully")
+		}
 	} else {
 		logrus.Warnf("failed to load cookies: %v", err)
 	}
 
-	return headless_browser.New(opts...)
+	return &Browser{
+		browser:  b,
+		launcher: l,
+	}
 }

--- a/service.go
+++ b/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
-	"github.com/xpzouying/headless_browser"
+	// headless_browser removed — using browser.Browser for Chrome 132+ compat
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
@@ -545,7 +545,7 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 	}, nil
 }
 
-func newBrowser() *headless_browser.Browser {
+func newBrowser() *browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(), browser.WithBinPath(configs.GetBinPath()))
 }
 


### PR DESCRIPTION
Chrome 132 removed --headless=old and Chrome's new headless mode rejects --no-startup-window ("Multiple targets are not supported in headless mode").

Changes:
- browser/browser.go: Replace headless_browser.Browser with our own Browser type that configures go-rod's launcher directly, setting --headless without --no-startup-window
- service.go: Use browser.Browser instead of headless_browser.Browser
- Dockerfile: Disable Chrome auto-updates to prevent future breakage

Also adds GitHub Actions workflow for daily upstream sync with automatic merge (clean) or conflict PR creation.