### PR TITLE
feat: 精简 MCP 工具响应，减少 context window 占用

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +27,158 @@ func parseVisibility(args map[string]interface{}) string {
 		return s
 	}
 	return ""
+}
+
+func buildSearchFeedsCompactResponse(result *FeedsListResponse) SearchFeedsCompactResponse {
+	if result == nil {
+		return SearchFeedsCompactResponse{
+			Feeds: []SearchFeedSummary{},
+		}
+	}
+
+	feeds := make([]SearchFeedSummary, 0, len(result.Feeds))
+	for _, feed := range result.Feeds {
+		feeds = append(feeds, SearchFeedSummary{
+			ID:        feed.ID,
+			XsecToken: feed.XsecToken,
+			Title:     feed.NoteCard.DisplayTitle,
+		})
+	}
+
+	return SearchFeedsCompactResponse{
+		Feeds: feeds,
+		Count: len(feeds),
+	}
+}
+
+func buildUserProfileCompactResponse(result *UserProfileResponse) UserProfileCompactResponse {
+	if result == nil {
+		return UserProfileCompactResponse{
+			Feeds:        []SearchFeedSummary{},
+			Interactions: []xiaohongshu.UserInteractions{},
+		}
+	}
+
+	feeds := make([]SearchFeedSummary, 0, len(result.Feeds))
+	for _, feed := range result.Feeds {
+		feeds = append(feeds, SearchFeedSummary{
+			ID:        feed.ID,
+			XsecToken: feed.XsecToken,
+			Title:     feed.NoteCard.DisplayTitle,
+		})
+	}
+
+	return UserProfileCompactResponse{
+		Nickname:     result.UserBasicInfo.Nickname,
+		RedId:        result.UserBasicInfo.RedId,
+		Desc:         result.UserBasicInfo.Desc,
+		Gender:       result.UserBasicInfo.Gender,
+		IpLocation:   result.UserBasicInfo.IpLocation,
+		Interactions: result.Interactions,
+		Feeds:        feeds,
+		FeedCount:    len(feeds),
+	}
+}
+
+func buildFeedDetailCompactResponse(result *FeedDetailResponse, loadAllComments, repliesExpanded bool) (FeedDetailCompactResponse, error) {
+	if result == nil {
+		return FeedDetailCompactResponse{
+			Comments:       []CommentCompact{},
+			CommentsSortBy: "like_count_desc",
+		}, nil
+	}
+
+	var detail *xiaohongshu.FeedDetailResponse
+	switch data := result.Data.(type) {
+	case *xiaohongshu.FeedDetailResponse:
+		detail = data
+	case xiaohongshu.FeedDetailResponse:
+		detail = &data
+	default:
+		return FeedDetailCompactResponse{}, fmt.Errorf("unexpected feed detail data type %T", result.Data)
+	}
+
+	comments := buildSortedCommentCompactList(detail.Comments.List)
+
+	return FeedDetailCompactResponse{
+		FeedID:          result.FeedID,
+		XsecToken:       detail.Note.XsecToken,
+		Title:           detail.Note.Title,
+		Desc:            detail.Note.Desc,
+		Author:          getPreferredNickname(detail.Note.User),
+		Type:            detail.Note.Type,
+		LikedCount:      detail.Note.InteractInfo.LikedCount,
+		CommentCount:    detail.Note.InteractInfo.CommentCount,
+		CollectedCount:  detail.Note.InteractInfo.CollectedCount,
+		SharedCount:     detail.Note.InteractInfo.SharedCount,
+		ImageCount:      len(detail.Note.ImageList),
+		Comments:        comments,
+		CommentsLoaded:  len(detail.Comments.List),
+		HasMoreComments: detail.Comments.HasMore,
+		CommentsSortBy:  "like_count_desc",
+		LoadAllComments: loadAllComments,
+		RepliesExpanded: repliesExpanded,
+	}, nil
+}
+
+func buildSortedCommentCompactList(comments []xiaohongshu.Comment) []CommentCompact {
+	if len(comments) == 0 {
+		return []CommentCompact{}
+	}
+
+	sortedComments := append([]xiaohongshu.Comment(nil), comments...)
+	sort.SliceStable(sortedComments, func(i, j int) bool {
+		return parseLikeCount(sortedComments[i].LikeCount) > parseLikeCount(sortedComments[j].LikeCount)
+	})
+
+	result := make([]CommentCompact, 0, len(sortedComments))
+	for _, comment := range sortedComments {
+		result = append(result, CommentCompact{
+			ID:              comment.ID,
+			User:            getPreferredNickname(comment.UserInfo),
+			Content:         comment.Content,
+			LikeCount:       comment.LikeCount,
+			SubCommentCount: comment.SubCommentCount,
+			ShowTags:        comment.ShowTags,
+			Replies:         buildSortedCommentCompactList(comment.SubComments),
+		})
+	}
+
+	return result
+}
+
+func getPreferredNickname(user xiaohongshu.User) string {
+	if user.Nickname != "" {
+		return user.Nickname
+	}
+	return user.NickName
+}
+
+func parseLikeCount(raw string) float64 {
+	value := strings.TrimSpace(strings.ReplaceAll(raw, ",", ""))
+	if value == "" {
+		return 0
+	}
+
+	multiplier := 1.0
+	switch {
+	case strings.HasSuffix(value, "万"):
+		multiplier = 10000
+		value = strings.TrimSuffix(value, "万")
+	case strings.HasSuffix(strings.ToLower(value), "w"):
+		multiplier = 10000
+		value = value[:len(value)-1]
+	case strings.HasSuffix(value, "千"):
+		multiplier = 1000
+		value = strings.TrimSuffix(value, "千")
+	}
+
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0
+	}
+
+	return math.Round(parsed*multiplier*100) / 100
 }
 
 // handleCheckLoginStatus 处理检查登录状态
@@ -281,8 +435,10 @@ func (s *AppServer) handleListFeeds(ctx context.Context) *MCPToolResult {
 		}
 	}
 
+	compactResult := buildSearchFeedsCompactResponse(result)
+
 	// 格式化输出，转换为JSON字符串
-	jsonData, err := json.MarshalIndent(result, "", "  ")
+	jsonData, err := json.Marshal(compactResult)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{
@@ -337,8 +493,9 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
-	jsonData, err := json.MarshalIndent(result, "", "  ")
+	compactResult := buildSearchFeedsCompactResponse(result)
+
+	jsonData, err := json.Marshal(compactResult)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{
@@ -455,8 +612,19 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		}
 	}
 
+	compactResult, err := buildFeedDetailCompactResponse(result, loadAll, config.ClickMoreReplies)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("获取Feed详情成功，但精简失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
 	// 格式化输出，转换为JSON字符串
-	jsonData, err := json.MarshalIndent(result, "", "  ")
+	jsonData, err := json.Marshal(compactResult)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{
@@ -515,8 +683,9 @@ func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) 
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
-	jsonData, err := json.MarshalIndent(result, "", "  ")
+	compactResult := buildUserProfileCompactResponse(result)
+
+	jsonData, err := json.Marshal(compactResult)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{

--- a/mcp_handlers_test.go
+++ b/mcp_handlers_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
+)
+
+func TestBuildSearchFeedsCompactResponse(t *testing.T) {
+	result := &FeedsListResponse{
+		Feeds: []xiaohongshu.Feed{
+			{
+				ID:        "feed-1",
+				XsecToken: "token-1",
+				ModelType: "note",
+				Index:     0,
+				NoteCard: xiaohongshu.NoteCard{
+					DisplayTitle: "标题一",
+					User: xiaohongshu.User{
+						UserID:   "user-1",
+						Nickname: "作者一",
+					},
+				},
+			},
+			{
+				ID:        "feed-2",
+				XsecToken: "token-2",
+				ModelType: "note",
+				Index:     1,
+				NoteCard: xiaohongshu.NoteCard{
+					DisplayTitle: "标题二",
+				},
+			},
+		},
+		Count: 2,
+	}
+
+	compact := buildSearchFeedsCompactResponse(result)
+
+	require.Equal(t, 2, compact.Count)
+	require.Len(t, compact.Feeds, 2)
+	require.Equal(t, SearchFeedSummary{
+		ID:        "feed-1",
+		XsecToken: "token-1",
+		Title:     "标题一",
+	}, compact.Feeds[0])
+	require.Equal(t, SearchFeedSummary{
+		ID:        "feed-2",
+		XsecToken: "token-2",
+		Title:     "标题二",
+	}, compact.Feeds[1])
+}
+
+func TestBuildSearchFeedsCompactResponseNil(t *testing.T) {
+	compact := buildSearchFeedsCompactResponse(nil)
+
+	require.Equal(t, 0, compact.Count)
+	require.Empty(t, compact.Feeds)
+}
+
+func TestBuildFeedDetailCompactResponse(t *testing.T) {
+	result := &FeedDetailResponse{
+		FeedID: "feed-1",
+		Data: &xiaohongshu.FeedDetailResponse{
+			Note: xiaohongshu.FeedDetail{
+				NoteID:    "feed-1",
+				XsecToken: "token-1",
+				Title:     "标题",
+				Desc:      "正文",
+				Type:      "normal",
+				User: xiaohongshu.User{
+					Nickname: "作者",
+				},
+				InteractInfo: xiaohongshu.InteractInfo{
+					LikedCount:     "1.2万",
+					CommentCount:   "20",
+					CollectedCount: "300",
+					SharedCount:    "66",
+				},
+				ImageList: []xiaohongshu.DetailImageInfo{
+					{URLDefault: "https://example.com/1.jpg"},
+					{URLDefault: "https://example.com/2.jpg"},
+				},
+			},
+			Comments: xiaohongshu.CommentList{
+				List: []xiaohongshu.Comment{
+					{
+						ID:      "comment-1",
+						Content: "普通评论",
+						UserInfo: xiaohongshu.User{
+							Nickname: "用户1",
+						},
+						LikeCount:       "12",
+						SubCommentCount: "1",
+						SubComments: []xiaohongshu.Comment{
+							{
+								ID:      "reply-1",
+								Content: "回复 1",
+								UserInfo: xiaohongshu.User{
+									Nickname: "回复用户1",
+								},
+								LikeCount: "1",
+							},
+							{
+								ID:      "reply-2",
+								Content: "回复 2",
+								UserInfo: xiaohongshu.User{
+									Nickname: "回复用户2",
+								},
+								LikeCount: "20",
+							},
+						},
+					},
+					{
+						ID:      "comment-2",
+						Content: "热评",
+						UserInfo: xiaohongshu.User{
+							Nickname: "用户2",
+						},
+						LikeCount: "1.5万",
+						ShowTags:  []string{"热评"},
+					},
+					{
+						ID:      "comment-3",
+						Content: "次热评",
+						UserInfo: xiaohongshu.User{
+							Nickname: "用户3",
+						},
+						LikeCount: "300",
+					},
+				},
+				HasMore: true,
+			},
+		},
+	}
+
+	compact, err := buildFeedDetailCompactResponse(result, true, true)
+
+	require.NoError(t, err)
+	require.Equal(t, "feed-1", compact.FeedID)
+	require.Equal(t, "token-1", compact.XsecToken)
+	require.Equal(t, "标题", compact.Title)
+	require.Equal(t, "正文", compact.Desc)
+	require.Equal(t, "作者", compact.Author)
+	require.Equal(t, 2, compact.ImageCount)
+	require.Equal(t, 3, compact.CommentsLoaded)
+	require.True(t, compact.HasMoreComments)
+	require.Equal(t, "like_count_desc", compact.CommentsSortBy)
+	require.True(t, compact.LoadAllComments)
+	require.True(t, compact.RepliesExpanded)
+	require.Len(t, compact.Comments, 3)
+	require.Equal(t, "comment-2", compact.Comments[0].ID)
+	require.Equal(t, "comment-3", compact.Comments[1].ID)
+	require.Equal(t, "comment-1", compact.Comments[2].ID)
+	require.Len(t, compact.Comments[2].Replies, 2)
+	require.Equal(t, "reply-2", compact.Comments[2].Replies[0].ID)
+	require.Equal(t, "reply-1", compact.Comments[2].Replies[1].ID)
+}
+
+func TestBuildUserProfileCompactResponse(t *testing.T) {
+	result := &UserProfileResponse{
+		UserBasicInfo: xiaohongshu.UserBasicInfo{
+			Nickname:   "测试用户",
+			RedId:      "red123",
+			Desc:       "这是简介",
+			Gender:     1,
+			IpLocation: "上海",
+		},
+		Interactions: []xiaohongshu.UserInteractions{
+			{Type: "fans", Name: "粉丝", Count: "1000"},
+		},
+		Feeds: []xiaohongshu.Feed{
+			{
+				ID:        "feed-1",
+				XsecToken: "token-1",
+				NoteCard: xiaohongshu.NoteCard{
+					DisplayTitle: "笔记标题",
+					Cover: xiaohongshu.Cover{
+						URL:    "https://example.com/cover.jpg",
+						Width:  640,
+						Height: 480,
+					},
+				},
+			},
+		},
+	}
+
+	compact := buildUserProfileCompactResponse(result)
+
+	require.Equal(t, "测试用户", compact.Nickname)
+	require.Equal(t, "red123", compact.RedId)
+	require.Equal(t, "这是简介", compact.Desc)
+	require.Equal(t, 1, compact.Gender)
+	require.Equal(t, "上海", compact.IpLocation)
+	require.Len(t, compact.Interactions, 1)
+	require.Equal(t, 1, compact.FeedCount)
+	require.Len(t, compact.Feeds, 1)
+	require.Equal(t, "feed-1", compact.Feeds[0].ID)
+	require.Equal(t, "笔记标题", compact.Feeds[0].Title)
+}
+
+func TestBuildUserProfileCompactResponseNil(t *testing.T) {
+	compact := buildUserProfileCompactResponse(nil)
+
+	require.Empty(t, compact.Nickname)
+	require.Empty(t, compact.Feeds)
+	require.Empty(t, compact.Interactions)
+	require.Equal(t, 0, compact.FeedCount)
+}
+
+func TestParseLikeCount(t *testing.T) {
+	require.Equal(t, 0.0, parseLikeCount(""))
+	require.Equal(t, 12.0, parseLikeCount("12"))
+	require.Equal(t, 12000.0, parseLikeCount("1.2万"))
+	require.Equal(t, 23000.0, parseLikeCount("2.3w"))
+	require.Equal(t, 3000.0, parseLikeCount("3千"))
+}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -264,7 +264,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
-			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
+			Description: "获取小红书笔记详情，返回精简版笔记内容与按点赞排序的评论。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Feed Detail",
 				ReadOnlyHint: true,

--- a/types.go
+++ b/types.go
@@ -59,6 +59,63 @@ type SearchFeedsRequest struct {
 	Filters xiaohongshu.FilterOption `json:"filters,omitempty"`
 }
 
+// SearchFeedSummary MCP 搜索结果精简项
+type SearchFeedSummary struct {
+	ID        string `json:"id"`
+	XsecToken string `json:"xsecToken"`
+	Title     string `json:"title"`
+}
+
+// SearchFeedsCompactResponse MCP 搜索结果精简响应
+type SearchFeedsCompactResponse struct {
+	Feeds []SearchFeedSummary `json:"feeds"`
+	Count int                 `json:"count"`
+}
+
+// FeedDetailCompactResponse MCP 详情精简响应
+type FeedDetailCompactResponse struct {
+	FeedID          string           `json:"feed_id"`
+	XsecToken       string           `json:"xsecToken"`
+	Title           string           `json:"title"`
+	Desc            string           `json:"desc"`
+	Author          string           `json:"author"`
+	Type            string           `json:"type,omitempty"`
+	LikedCount      string           `json:"liked_count,omitempty"`
+	CommentCount    string           `json:"comment_count,omitempty"`
+	CollectedCount  string           `json:"collected_count,omitempty"`
+	SharedCount     string           `json:"shared_count,omitempty"`
+	ImageCount      int              `json:"image_count"`
+	Comments        []CommentCompact `json:"comments"`
+	CommentsLoaded  int              `json:"comments_loaded"`
+	HasMoreComments bool             `json:"has_more_comments"`
+	CommentsSortBy  string           `json:"comments_sort_by"`
+	LoadAllComments bool             `json:"load_all_comments"`
+	RepliesExpanded bool             `json:"replies_expanded"`
+}
+
+// CommentCompact MCP 评论精简项
+type CommentCompact struct {
+	ID              string           `json:"id"`
+	User            string           `json:"user"`
+	Content         string           `json:"content"`
+	LikeCount       string           `json:"like_count"`
+	SubCommentCount string           `json:"sub_comment_count,omitempty"`
+	ShowTags        []string         `json:"show_tags,omitempty"`
+	Replies         []CommentCompact `json:"replies,omitempty"`
+}
+
+// UserProfileCompactResponse MCP 用户主页精简响应
+type UserProfileCompactResponse struct {
+	Nickname     string                         `json:"nickname"`
+	RedId        string                         `json:"red_id,omitempty"`
+	Desc         string                         `json:"desc,omitempty"`
+	Gender       int                            `json:"gender,omitempty"`
+	IpLocation   string                         `json:"ip_location,omitempty"`
+	Interactions []xiaohongshu.UserInteractions `json:"interactions"`
+	Feeds        []SearchFeedSummary            `json:"feeds"`
+	FeedCount    int                            `json:"feed_count"`
+}
+
 // FeedDetailResponse Feed详情响应
 type FeedDetailResponse struct {
 	FeedID string `json:"feed_id"`


### PR DESCRIPTION
## Summary

- `list_feeds` / `search_feeds` 精简为只返回 `id`、`xsecToken`、`title`，去掉 Cover、Video、User 等大字段
- `get_feed_detail` 去掉图片 URL 等冗余字段，评论按点赞数排序，只保留关键信息
- `user_profile` feeds 列表同样精简，去掉 Cover/Video 等嵌套对象
- 所有 MCP 响应使用 `json.Marshal` 替代 `json.MarshalIndent`，减少空白字符
- 新增 `UserProfileCompactResponse` 精简结构体
- 新增完整的单元测试覆盖所有精简逻辑

## 动机

作为 MCP server，返回过多数据会导致 LLM 的 context window 过快填满，同时降低响应速度。大部分字段（封面图 URL、图片尺寸、视频能力信息等）对 LLM 决策没有帮助。

## Test plan

- [x] `TestBuildSearchFeedsCompactResponse` 通过
- [x] `TestBuildFeedDetailCompactResponse` 通过
- [x] `TestBuildUserProfileCompactResponse` 通过
- [x] `TestParseLikeCount` 通过
- [x] `go build ./...` 编译通过