### PR TITLE
feat: 视频帖子详情接口新增视频下载地址

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ test_*.sh
 
 # Cookies files (contain sensitive login information)
 cookies.json
+# Compiled binaries (local builds)
+bin/*-video
+bin/*-local

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -856,10 +856,259 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 		return nil, fmt.Errorf("feed %s not found in noteDetailMap", feedID)
 	}
 
+	// 如果是视频帖子，补充视频下载 URL
+	if noteDetail.Note.Type == "video" {
+		if noteDetail.Note.Video == nil || noteDetail.Note.Video.URL == "" {
+			videoInfo := f.extractVideoURL(page, feedID)
+			if videoInfo != nil {
+				if noteDetail.Note.Video == nil {
+					noteDetail.Note.Video = videoInfo
+				} else {
+					// 保留已有的 stream 信息，补充 URL 和 Duration
+					if noteDetail.Note.Video.URL == "" {
+						noteDetail.Note.Video.URL = videoInfo.URL
+					}
+					if noteDetail.Note.Video.Duration == 0 {
+						noteDetail.Note.Video.Duration = videoInfo.Duration
+					}
+				}
+			}
+		}
+	}
+
 	return &FeedDetailResponse{
 		Note:     noteDetail.Note,
 		Comments: noteDetail.Comments,
 	}, nil
+}
+
+// extractVideoURL 从页面中提取视频的下载地址
+func (f *FeedDetailAction) extractVideoURL(page *rod.Page, feedID string) *FeedDetailVideo {
+	// 从 __INITIAL_STATE__ 中提取完整的视频信息
+	videoJSON := page.MustEval(`(feedID) => {
+		try {
+			if (!window.__INITIAL_STATE__ ||
+				!window.__INITIAL_STATE__.note ||
+				!window.__INITIAL_STATE__.note.noteDetailMap) {
+				return "";
+			}
+			const noteDetail = window.__INITIAL_STATE__.note.noteDetailMap[feedID];
+			if (!noteDetail || !noteDetail.note || !noteDetail.note.video) {
+				return "";
+			}
+			return JSON.stringify(noteDetail.note.video);
+		} catch(e) {
+			return "";
+		}
+	}`, feedID).String()
+
+	if videoJSON == "" {
+		// Fallback: 从 <video> 或 <source> 标签提取
+		videoSrc := page.MustEval(`() => {
+			const video = document.querySelector('video');
+			if (video && video.src) return video.src;
+			const source = document.querySelector('video source');
+			if (source && source.src) return source.src;
+			return "";
+		}`).String()
+
+		if videoSrc != "" {
+			logrus.Infof("从 <video> 标签提取到视频 URL: %s", videoSrc[:min(80, len(videoSrc))])
+			return &FeedDetailVideo{URL: videoSrc}
+		}
+		return nil
+	}
+
+	// 解析视频 JSON
+	var rawVideo struct {
+		Consumer struct {
+			OriginVideoKey string `json:"originVideoKey"`
+		} `json:"consumer"`
+		Media struct {
+			Stream map[string][]struct {
+				MasterURL  string   `json:"masterUrl"`
+				BackupURLs []string `json:"backupUrls"`
+				Width      int      `json:"width"`
+				Height     int      `json:"height"`
+				AvgBitrate int      `json:"avgBitrate"`
+			} `json:"stream"`
+		} `json:"media"`
+		Capa struct {
+			Duration int `json:"duration"`
+		} `json:"capa"`
+	}
+
+	if err := json.Unmarshal([]byte(videoJSON), &rawVideo); err != nil {
+		logrus.Warnf("解析视频 JSON 失败: %v", err)
+		return nil
+	}
+
+	logrus.Infof("视频原始数据: duration=%d, consumer.key=%s, stream codecs=%v",
+		rawVideo.Capa.Duration,
+		rawVideo.Consumer.OriginVideoKey,
+		func() []string {
+			keys := make([]string, 0)
+			for k, v := range rawVideo.Media.Stream {
+				keys = append(keys, fmt.Sprintf("%s(%d)", k, len(v)))
+			}
+			return keys
+		}())
+
+	// 如果 rawVideo 解析出的 stream 为空但 videoJSON 里有数据，直接从 JSON 提取 URL
+	if len(rawVideo.Media.Stream) == 0 || allStreamsEmpty(rawVideo.Media.Stream) {
+		logrus.Infof("rawVideo stream 为空，尝试从 JSON 直接提取 URL")
+		return extractVideoURLFromJSON(videoJSON)
+	}
+
+	result := &FeedDetailVideo{
+		Duration: rawVideo.Capa.Duration,
+		Media: &FeedDetailVideoMedia{
+			Stream: make(map[string][]VideoStream),
+		},
+	}
+
+	// 提取所有视频流，按 codec 分组
+	// 优先选择最高分辨率的 h264 作为主 URL（兼容性最好）
+	var bestURL string
+	var bestBitrate int
+
+	for _, codec := range []string{"h264", "h265", "av1", "h266"} {
+		streams, ok := rawVideo.Media.Stream[codec]
+		if !ok || len(streams) == 0 {
+			continue
+		}
+
+		for _, s := range streams {
+			vs := VideoStream{
+				MasterURL:  s.MasterURL,
+				BackupURLs: s.BackupURLs,
+				Width:      s.Width,
+				Height:     s.Height,
+				AvgBitrate: s.AvgBitrate,
+			}
+			result.Media.Stream[codec] = append(result.Media.Stream[codec], vs)
+
+			// 优先选 h264 最高码率，因为兼容性最好
+			if codec == "h264" && s.AvgBitrate > bestBitrate {
+				if s.MasterURL != "" {
+					bestURL = s.MasterURL
+					bestBitrate = s.AvgBitrate
+				} else if len(s.BackupURLs) > 0 {
+					bestURL = s.BackupURLs[0]
+					bestBitrate = s.AvgBitrate
+				}
+			}
+		}
+	}
+
+	// 如果没有 h264，用任何可用的
+	if bestURL == "" {
+		for _, codec := range []string{"h265", "av1", "h266"} {
+			streams := rawVideo.Media.Stream[codec]
+			for _, s := range streams {
+				if s.MasterURL != "" {
+					bestURL = s.MasterURL
+					break
+				}
+				if len(s.BackupURLs) > 0 {
+					bestURL = s.BackupURLs[0]
+					break
+				}
+			}
+			if bestURL != "" {
+				break
+			}
+		}
+	}
+
+	result.URL = bestURL
+
+	// Fallback: 使用 originVideoKey 构造 URL
+	if result.URL == "" && rawVideo.Consumer.OriginVideoKey != "" {
+		result.URL = "https://sns-video-bd.xhscdn.com/" + rawVideo.Consumer.OriginVideoKey
+	}
+
+	if result.URL != "" {
+		logrus.Infof("提取到视频 URL: %s (时长: %ds)", result.URL[:min(80, len(result.URL))], result.Duration)
+	} else {
+		logrus.Warnf("未能从 struct 解析中提取视频 URL，尝试 JSON 直接提取")
+		if fallback := extractVideoURLFromJSON(videoJSON); fallback != nil && fallback.URL != "" {
+			result.URL = fallback.URL
+			if result.Duration == 0 {
+				result.Duration = fallback.Duration
+			}
+		}
+	}
+
+	return result
+}
+
+// allStreamsEmpty 检查所有 stream 是否为空
+func allStreamsEmpty(streams map[string][]struct {
+	MasterURL  string   `json:"masterUrl"`
+	BackupURLs []string `json:"backupUrls"`
+	Width      int      `json:"width"`
+	Height     int      `json:"height"`
+	AvgBitrate int      `json:"avgBitrate"`
+}) bool {
+	for _, s := range streams {
+		if len(s) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// extractVideoURLFromJSON 直接从 JSON 字符串中提取视频 URL（fallback）
+func extractVideoURLFromJSON(videoJSON string) *FeedDetailVideo {
+	// 用 map[string]interface{} 解析完整 JSON
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(videoJSON), &raw); err != nil {
+		return nil
+	}
+
+	result := &FeedDetailVideo{}
+
+	// 提取 duration
+	if capa, ok := raw["capa"].(map[string]interface{}); ok {
+		if d, ok := capa["duration"].(float64); ok {
+			result.Duration = int(d)
+		}
+	}
+
+	// 从 media.stream 中提取 URL
+	if media, ok := raw["media"].(map[string]interface{}); ok {
+		if stream, ok := media["stream"].(map[string]interface{}); ok {
+			for _, codec := range []string{"h264", "h265", "av1"} {
+				if arr, ok := stream[codec].([]interface{}); ok {
+					for _, item := range arr {
+						if m, ok := item.(map[string]interface{}); ok {
+							if masterURL, ok := m["masterUrl"].(string); ok && masterURL != "" {
+								result.URL = masterURL
+								return result
+							}
+							if backups, ok := m["backupUrls"].([]interface{}); ok && len(backups) > 0 {
+								if bu, ok := backups[0].(string); ok && bu != "" {
+									result.URL = bu
+									return result
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: consumer.originVideoKey
+	if consumer, ok := raw["consumer"].(map[string]interface{}); ok {
+		if key, ok := consumer["originVideoKey"].(string); ok && key != "" {
+			result.URL = "https://sns-video-bd.xhscdn.com/" + key
+			return result
+		}
+	}
+
+	return result
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -882,186 +882,134 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 	}, nil
 }
 
+// rawVideoData 用于解析 __INITIAL_STATE__ 中的视频 JSON（复用 VideoStream 类型）
+type rawVideoData struct {
+	Consumer struct {
+		OriginVideoKey string `json:"originVideoKey"`
+	} `json:"consumer"`
+	Media struct {
+		Stream map[string][]VideoStream `json:"stream"`
+	} `json:"media"`
+	Capa struct {
+		Duration int `json:"duration"`
+	} `json:"capa"`
+}
+
 // extractVideoURL 从页面中提取视频的下载地址
 func (f *FeedDetailAction) extractVideoURL(page *rod.Page, feedID string) *FeedDetailVideo {
-	// 从 __INITIAL_STATE__ 中提取完整的视频信息
-	videoJSON := page.MustEval(`(feedID) => {
-		try {
-			if (!window.__INITIAL_STATE__ ||
-				!window.__INITIAL_STATE__.note ||
-				!window.__INITIAL_STATE__.note.noteDetailMap) {
-				return "";
-			}
-			const noteDetail = window.__INITIAL_STATE__.note.noteDetailMap[feedID];
-			if (!noteDetail || !noteDetail.note || !noteDetail.note.video) {
-				return "";
-			}
-			return JSON.stringify(noteDetail.note.video);
-		} catch(e) {
-			return "";
-		}
-	}`, feedID).String()
-
+	videoJSON := f.evalVideoJSON(page, feedID)
 	if videoJSON == "" {
-		// Fallback: 从 <video> 或 <source> 标签提取
-		videoSrc := page.MustEval(`() => {
-			const video = document.querySelector('video');
-			if (video && video.src) return video.src;
-			const source = document.querySelector('video source');
-			if (source && source.src) return source.src;
-			return "";
-		}`).String()
+		return f.evalVideoTagSrc(page)
+	}
+	return parseVideoJSON(videoJSON)
+}
 
-		if videoSrc != "" {
-			logrus.Infof("从 <video> 标签提取到视频 URL: %s", videoSrc[:min(80, len(videoSrc))])
-			return &FeedDetailVideo{URL: videoSrc}
-		}
+// evalVideoJSON 从 __INITIAL_STATE__ 中提取视频 JSON 字符串
+func (f *FeedDetailAction) evalVideoJSON(page *rod.Page, feedID string) string {
+	result, err := page.Eval(`(feedID) => {
+		try {
+			const map = window.__INITIAL_STATE__?.note?.noteDetailMap;
+			const video = map?.[feedID]?.note?.video;
+			return video ? JSON.stringify(video) : "";
+		} catch(e) { return ""; }
+	}`, feedID)
+	if err != nil {
+		logrus.Warnf("eval 视频 JSON 失败: %v", err)
+		return ""
+	}
+	return result.Value.String()
+}
+
+// evalVideoTagSrc 从 <video> 标签中提取视频 src（fallback）
+func (f *FeedDetailAction) evalVideoTagSrc(page *rod.Page) *FeedDetailVideo {
+	result, err := page.Eval(`() => {
+		const v = document.querySelector('video');
+		if (v && v.src) return v.src;
+		const s = document.querySelector('video source');
+		if (s && s.src) return s.src;
+		return "";
+	}`)
+	if err != nil || result.Value.String() == "" {
 		return nil
 	}
+	src := result.Value.String()
+	logrus.Infof("从 <video> 标签提取到视频 URL: %s", src[:min(80, len(src))])
+	return &FeedDetailVideo{URL: src}
+}
 
-	// 解析视频 JSON
-	var rawVideo struct {
-		Consumer struct {
-			OriginVideoKey string `json:"originVideoKey"`
-		} `json:"consumer"`
-		Media struct {
-			Stream map[string][]struct {
-				MasterURL  string   `json:"masterUrl"`
-				BackupURLs []string `json:"backupUrls"`
-				Width      int      `json:"width"`
-				Height     int      `json:"height"`
-				AvgBitrate int      `json:"avgBitrate"`
-			} `json:"stream"`
-		} `json:"media"`
-		Capa struct {
-			Duration int `json:"duration"`
-		} `json:"capa"`
-	}
-
-	if err := json.Unmarshal([]byte(videoJSON), &rawVideo); err != nil {
-		logrus.Warnf("解析视频 JSON 失败: %v", err)
-		return nil
-	}
-
-	logrus.Infof("视频原始数据: duration=%d, consumer.key=%s, stream codecs=%v",
-		rawVideo.Capa.Duration,
-		rawVideo.Consumer.OriginVideoKey,
-		func() []string {
-			keys := make([]string, 0)
-			for k, v := range rawVideo.Media.Stream {
-				keys = append(keys, fmt.Sprintf("%s(%d)", k, len(v)))
-			}
-			return keys
-		}())
-
-	// 如果 rawVideo 解析出的 stream 为空但 videoJSON 里有数据，直接从 JSON 提取 URL
-	if len(rawVideo.Media.Stream) == 0 || allStreamsEmpty(rawVideo.Media.Stream) {
-		logrus.Infof("rawVideo stream 为空，尝试从 JSON 直接提取 URL")
-		return extractVideoURLFromJSON(videoJSON)
+// parseVideoJSON 解析视频 JSON 并提取下载地址
+func parseVideoJSON(videoJSON string) *FeedDetailVideo {
+	var raw rawVideoData
+	if err := json.Unmarshal([]byte(videoJSON), &raw); err != nil {
+		logrus.Warnf("解析视频 JSON 失败: %v, 尝试 fallback", err)
+		return parseVideoURLFromRawJSON(videoJSON)
 	}
 
 	result := &FeedDetailVideo{
-		Duration: rawVideo.Capa.Duration,
+		Duration: raw.Capa.Duration,
 		Media: &FeedDetailVideoMedia{
 			Stream: make(map[string][]VideoStream),
 		},
 	}
 
-	// 提取所有视频流，按 codec 分组
-	// 优先选择最高分辨率的 h264 作为主 URL（兼容性最好）
+	// 收集所有流，同时选出最佳下载 URL
 	var bestURL string
 	var bestBitrate int
 
-	for _, codec := range []string{"h264", "h265", "av1", "h266"} {
-		streams, ok := rawVideo.Media.Stream[codec]
-		if !ok || len(streams) == 0 {
+	for _, codec := range videoCodecPriority {
+		streams := raw.Media.Stream[codec]
+		if len(streams) == 0 {
 			continue
 		}
+		result.Media.Stream[codec] = streams
 
 		for _, s := range streams {
-			vs := VideoStream{
-				MasterURL:  s.MasterURL,
-				BackupURLs: s.BackupURLs,
-				Width:      s.Width,
-				Height:     s.Height,
-				AvgBitrate: s.AvgBitrate,
+			url := pickStreamURL(s)
+			if url == "" {
+				continue
 			}
-			result.Media.Stream[codec] = append(result.Media.Stream[codec], vs)
-
-			// 优先选 h264 最高码率，因为兼容性最好
-			if codec == "h264" && s.AvgBitrate > bestBitrate {
-				if s.MasterURL != "" {
-					bestURL = s.MasterURL
-					bestBitrate = s.AvgBitrate
-				} else if len(s.BackupURLs) > 0 {
-					bestURL = s.BackupURLs[0]
-					bestBitrate = s.AvgBitrate
-				}
-			}
-		}
-	}
-
-	// 如果没有 h264，用任何可用的
-	if bestURL == "" {
-		for _, codec := range []string{"h265", "av1", "h266"} {
-			streams := rawVideo.Media.Stream[codec]
-			for _, s := range streams {
-				if s.MasterURL != "" {
-					bestURL = s.MasterURL
-					break
-				}
-				if len(s.BackupURLs) > 0 {
-					bestURL = s.BackupURLs[0]
-					break
-				}
-			}
-			if bestURL != "" {
-				break
+			// 优先选 h264 最高码率（兼容性最好），否则选任意最高码率
+			isPreferred := codec == "h264" || bestURL == ""
+			if isPreferred && s.AvgBitrate >= bestBitrate {
+				bestURL = url
+				bestBitrate = s.AvgBitrate
 			}
 		}
 	}
 
 	result.URL = bestURL
 
-	// Fallback: 使用 originVideoKey 构造 URL
-	if result.URL == "" && rawVideo.Consumer.OriginVideoKey != "" {
-		result.URL = "https://sns-video-bd.xhscdn.com/" + rawVideo.Consumer.OriginVideoKey
+	// Fallback: originVideoKey
+	if result.URL == "" && raw.Consumer.OriginVideoKey != "" {
+		result.URL = xhsVideoCDNBase + raw.Consumer.OriginVideoKey
+	}
+
+	// Fallback: 从原始 JSON 直接提取
+	if result.URL == "" {
+		if fb := parseVideoURLFromRawJSON(videoJSON); fb != nil && fb.URL != "" {
+			result.URL = fb.URL
+		}
 	}
 
 	if result.URL != "" {
 		logrus.Infof("提取到视频 URL: %s (时长: %ds)", result.URL[:min(80, len(result.URL))], result.Duration)
-	} else {
-		logrus.Warnf("未能从 struct 解析中提取视频 URL，尝试 JSON 直接提取")
-		if fallback := extractVideoURLFromJSON(videoJSON); fallback != nil && fallback.URL != "" {
-			result.URL = fallback.URL
-			if result.Duration == 0 {
-				result.Duration = fallback.Duration
-			}
-		}
 	}
-
 	return result
 }
 
-// allStreamsEmpty 检查所有 stream 是否为空
-func allStreamsEmpty(streams map[string][]struct {
-	MasterURL  string   `json:"masterUrl"`
-	BackupURLs []string `json:"backupUrls"`
-	Width      int      `json:"width"`
-	Height     int      `json:"height"`
-	AvgBitrate int      `json:"avgBitrate"`
-}) bool {
-	for _, s := range streams {
-		if len(s) > 0 {
-			return false
-		}
+// pickStreamURL 从单个 VideoStream 中选取可用的 URL
+func pickStreamURL(s VideoStream) string {
+	if s.MasterURL != "" {
+		return s.MasterURL
 	}
-	return true
+	if len(s.BackupURLs) > 0 {
+		return s.BackupURLs[0]
+	}
+	return ""
 }
 
-// extractVideoURLFromJSON 直接从 JSON 字符串中提取视频 URL（fallback）
-func extractVideoURLFromJSON(videoJSON string) *FeedDetailVideo {
-	// 用 map[string]interface{} 解析完整 JSON
+// parseVideoURLFromRawJSON 用 map[string]interface{} 从 JSON 直接提取视频 URL（struct 解析失败时的 fallback）
+func parseVideoURLFromRawJSON(videoJSON string) *FeedDetailVideo {
 	var raw map[string]interface{}
 	if err := json.Unmarshal([]byte(videoJSON), &raw); err != nil {
 		return nil
@@ -1077,24 +1025,26 @@ func extractVideoURLFromJSON(videoJSON string) *FeedDetailVideo {
 	}
 
 	// 从 media.stream 中提取 URL
-	if media, ok := raw["media"].(map[string]interface{}); ok {
-		if stream, ok := media["stream"].(map[string]interface{}); ok {
-			for _, codec := range []string{"h264", "h265", "av1"} {
-				if arr, ok := stream[codec].([]interface{}); ok {
-					for _, item := range arr {
-						if m, ok := item.(map[string]interface{}); ok {
-							if masterURL, ok := m["masterUrl"].(string); ok && masterURL != "" {
-								result.URL = masterURL
-								return result
-							}
-							if backups, ok := m["backupUrls"].([]interface{}); ok && len(backups) > 0 {
-								if bu, ok := backups[0].(string); ok && bu != "" {
-									result.URL = bu
-									return result
-								}
-							}
-						}
-					}
+	media, _ := raw["media"].(map[string]interface{})
+	stream, _ := media["stream"].(map[string]interface{})
+	for _, codec := range videoCodecPriority {
+		arr, ok := stream[codec].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range arr {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if u, ok := m["masterUrl"].(string); ok && u != "" {
+				result.URL = u
+				return result
+			}
+			if backups, ok := m["backupUrls"].([]interface{}); ok && len(backups) > 0 {
+				if u, ok := backups[0].(string); ok && u != "" {
+					result.URL = u
+					return result
 				}
 			}
 		}
@@ -1103,7 +1053,7 @@ func extractVideoURLFromJSON(videoJSON string) *FeedDetailVideo {
 	// Fallback: consumer.originVideoKey
 	if consumer, ok := raw["consumer"].(map[string]interface{}); ok {
 		if key, ok := consumer["originVideoKey"].(string); ok && key != "" {
-			result.URL = "https://sns-video-bd.xhscdn.com/" + key
+			result.URL = xhsVideoCDNBase + key
 			return result
 		}
 	}

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -125,8 +125,14 @@ type VideoStream struct {
 	BackupURLs []string `json:"backupUrls,omitempty"`
 	Width      int      `json:"width,omitempty"`
 	Height     int      `json:"height,omitempty"`
-	AvgBitrate int     `json:"avgBitrate,omitempty"`
+	AvgBitrate int      `json:"avgBitrate,omitempty"`
 }
+
+// 视频编码优先级（h264 兼容性最好）
+var videoCodecPriority = []string{"h264", "h265", "av1", "h266"}
+
+// 小红书视频 CDN 基础地址
+const xhsVideoCDNBase = "https://sns-video-bd.xhscdn.com/"
 
 // DetailImageInfo 表示详情页的图片信息
 type DetailImageInfo struct {

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -103,6 +103,29 @@ type FeedDetail struct {
 	User         User              `json:"user"`
 	InteractInfo InteractInfo      `json:"interactInfo"`
 	ImageList    []DetailImageInfo `json:"imageList"`
+	Video        *FeedDetailVideo  `json:"video,omitempty"`
+}
+
+// FeedDetailVideo 表示详情页的视频信息
+type FeedDetailVideo struct {
+	// URL 是可直接下载的视频地址（从 media.stream 中提取的最高质量 URL）
+	URL      string                `json:"url,omitempty"`
+	Duration int                   `json:"duration,omitempty"`
+	Media    *FeedDetailVideoMedia `json:"media,omitempty"`
+}
+
+// FeedDetailVideoMedia 表示视频媒体信息
+type FeedDetailVideoMedia struct {
+	Stream map[string][]VideoStream `json:"stream,omitempty"`
+}
+
+// VideoStream 表示单个视频流
+type VideoStream struct {
+	MasterURL  string   `json:"masterUrl,omitempty"`
+	BackupURLs []string `json:"backupUrls,omitempty"`
+	Width      int      `json:"width,omitempty"`
+	Height     int      `json:"height,omitempty"`
+	AvgBitrate int     `json:"avgBitrate,omitempty"`
 }
 
 // DetailImageInfo 表示详情页的图片信息

--- a/xiaohongshu/video_extract_test.go
+++ b/xiaohongshu/video_extract_test.go
@@ -1,0 +1,170 @@
+package xiaohongshu
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseVideoJSON_H264Stream(t *testing.T) {
+	input := `{
+		"capa": {"duration": 120},
+		"media": {
+			"stream": {
+				"h264": [{"masterUrl": "http://cdn.example.com/h264.mp4", "width": 720, "height": 1280, "avgBitrate": 2000000}],
+				"h265": [{"masterUrl": "http://cdn.example.com/h265.mp4", "width": 1080, "height": 1920, "avgBitrate": 3000000}]
+			}
+		}
+	}`
+
+	result := parseVideoJSON(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Duration != 120 {
+		t.Errorf("duration: got %d, want 120", result.Duration)
+	}
+	if result.URL != "http://cdn.example.com/h264.mp4" {
+		t.Errorf("url: got %s, want h264 URL (preferred codec)", result.URL)
+	}
+	if len(result.Media.Stream["h264"]) != 1 {
+		t.Errorf("h264 streams: got %d, want 1", len(result.Media.Stream["h264"]))
+	}
+	if len(result.Media.Stream["h265"]) != 1 {
+		t.Errorf("h265 streams: got %d, want 1", len(result.Media.Stream["h265"]))
+	}
+}
+
+func TestParseVideoJSON_OnlyH265(t *testing.T) {
+	input := `{
+		"capa": {"duration": 60},
+		"media": {
+			"stream": {
+				"h265": [{"masterUrl": "http://cdn.example.com/h265.mp4", "width": 1080, "height": 1920, "avgBitrate": 3000000}]
+			}
+		}
+	}`
+
+	result := parseVideoJSON(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.URL != "http://cdn.example.com/h265.mp4" {
+		t.Errorf("url: got %s, want h265 URL (fallback)", result.URL)
+	}
+}
+
+func TestParseVideoJSON_OriginVideoKey(t *testing.T) {
+	input := `{
+		"consumer": {"originVideoKey": "abc123/video.mp4"},
+		"capa": {"duration": 30},
+		"media": {"stream": {}}
+	}`
+
+	result := parseVideoJSON(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	expected := xhsVideoCDNBase + "abc123/video.mp4"
+	if result.URL != expected {
+		t.Errorf("url: got %s, want %s", result.URL, expected)
+	}
+}
+
+func TestParseVideoJSON_BackupURLFallback(t *testing.T) {
+	input := `{
+		"capa": {"duration": 10},
+		"media": {
+			"stream": {
+				"h264": [{"masterUrl": "", "backupUrls": ["http://backup.example.com/video.mp4"], "width": 720, "height": 1280}]
+			}
+		}
+	}`
+
+	result := parseVideoJSON(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.URL != "http://backup.example.com/video.mp4" {
+		t.Errorf("url: got %s, want backup URL", result.URL)
+	}
+}
+
+func TestParseVideoJSON_EmptyJSON(t *testing.T) {
+	result := parseVideoJSON("{}")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.URL != "" {
+		t.Errorf("url: got %s, want empty", result.URL)
+	}
+}
+
+func TestParseVideoJSON_InvalidJSON(t *testing.T) {
+	result := parseVideoJSON("not json")
+	// Should fallback to parseVideoURLFromRawJSON which also fails, return nil
+	if result != nil && result.URL != "" {
+		t.Errorf("expected nil or empty url for invalid json, got %s", result.URL)
+	}
+}
+
+func TestParseVideoURLFromRawJSON(t *testing.T) {
+	input := `{
+		"capa": {"duration": 45},
+		"media": {
+			"stream": {
+				"h264": [{"masterUrl": "http://cdn.example.com/raw.mp4"}]
+			}
+		}
+	}`
+
+	result := parseVideoURLFromRawJSON(input)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.URL != "http://cdn.example.com/raw.mp4" {
+		t.Errorf("url: got %s, want raw URL", result.URL)
+	}
+	if result.Duration != 45 {
+		t.Errorf("duration: got %d, want 45", result.Duration)
+	}
+}
+
+func TestPickStreamURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream VideoStream
+		want   string
+	}{
+		{"master url", VideoStream{MasterURL: "http://master.mp4"}, "http://master.mp4"},
+		{"backup url", VideoStream{BackupURLs: []string{"http://backup.mp4"}}, "http://backup.mp4"},
+		{"both", VideoStream{MasterURL: "http://master.mp4", BackupURLs: []string{"http://backup.mp4"}}, "http://master.mp4"},
+		{"empty", VideoStream{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickStreamURL(tt.stream)
+			if got != tt.want {
+				t.Errorf("pickStreamURL: got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVideoStreamJSON(t *testing.T) {
+	// Verify VideoStream can round-trip JSON correctly
+	input := `{"masterUrl":"http://example.com/v.mp4","backupUrls":["http://backup.com/v.mp4"],"width":1080,"height":1920,"avgBitrate":3000000}`
+	var vs VideoStream
+	if err := json.Unmarshal([]byte(input), &vs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if vs.MasterURL != "http://example.com/v.mp4" {
+		t.Errorf("MasterURL: got %s", vs.MasterURL)
+	}
+	if vs.Width != 1080 || vs.Height != 1920 {
+		t.Errorf("dimensions: got %dx%d", vs.Width, vs.Height)
+	}
+	if vs.AvgBitrate != 3000000 {
+		t.Errorf("bitrate: got %d", vs.AvgBitrate)
+	}
+}


### PR DESCRIPTION
## 改动说明

当前 `get_feed_detail` 接口对视频帖子不返回视频下载地址，`FeedDetail` struct 缺少 `Video` 字段，导致 `__INITIAL_STATE__` 中的视频流数据在 JSON 反序列化时被丢弃。

本 PR 补充了视频 URL 的提取逻辑，使视频帖子的详情接口能够返回可直接下载的视频地址。

## 具体改动

### `xiaohongshu/types.go`
- 新增 `FeedDetailVideo`、`FeedDetailVideoMedia`、`VideoStream` 类型
- `FeedDetail` struct 新增 `Video *FeedDetailVideo` 字段

### `xiaohongshu/feed_detail.go`
- 新增 `extractVideoURL()` 方法：从 `__INITIAL_STATE__` 的 `noteDetailMap[feedID].note.video` 中提取视频流信息
- 新增 `extractVideoURLFromJSON()` fallback：当 struct 解析失败时，用 `map[string]interface{}` 直接从 JSON 提取
- 新增 `<video>` 标签 fallback：从 DOM 中的 video/source 元素提取 src
- 选择最佳 URL 的优先级：h264（兼容性最好）> h265 > av1 > originVideoKey

## 返回示例

```json
{
  "video": {
    "url": "http://sns-video-hs.xhscdn.com/stream/.../xxx.mp4",
    "duration": 120,
    "media": {
      "stream": {
        "h264": [{"masterUrl": "...", "width": 720, "height": 1280, "avgBitrate": 2137631}],
        "h265": [
          {"masterUrl": "...", "width": 720, "height": 1280, "avgBitrate": 1510309},
          {"masterUrl": "...", "width": 1080, "height": 1920, "avgBitrate": 2977255},
          {"masterUrl": "...", "width": 2160, "height": 3840, "avgBitrate": 10256916}
        ]
      }
    }
  }
}
```

## 使用方式

视频 URL 可直接通过 curl 下载，需带 Referer 头：

```bash
curl -L -H "Referer: https://www.xiaohongshu.com/" -o video.mp4 "<video.url>"
```

## 测试验证

- ✅ 视频帖子返回完整视频流信息（h264/h265/av1 多分辨率）
- ✅ 顶层 `video.url` 返回最佳质量 h264 直链
- ✅ `video.duration` 返回视频时长（秒）
- ✅ 实际下载验证通过（720p ~ 4K）
- ✅ 图文帖子不受影响（`video` 字段为 null）
