### PR TITLE
fix: 防止 cookie 损坏 + 浏览器崩了不影响服务

### DIFF
--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -38,9 +38,39 @@ func (c *localCookie) LoadCookies() ([]byte, error) {
 	return data, nil
 }
 
-// SaveCookies 保存 cookies 到文件中。
+// SaveCookies 原子写入 cookies 到文件中。
+// 先写临时文件再 rename，防止写入中途崩溃导致文件损坏。
 func (c *localCookie) SaveCookies(data []byte) error {
-	return os.WriteFile(c.path, data, 0644)
+	dir := filepath.Dir(c.path)
+	tmp, err := os.CreateTemp(dir, "cookies.tmp.*")
+	if err != nil {
+		return errors.Wrap(err, "创建临时文件失败")
+	}
+	tmpPath := tmp.Name()
+
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return errors.Wrap(err, "chmod 临时文件失败")
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return errors.Wrap(err, "写入临时文件失败")
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return errors.Wrap(err, "sync 临时文件失败")
+	}
+	tmp.Close()
+
+	if err := os.Rename(tmpPath, c.path); err != nil {
+		os.Remove(tmpPath)
+		return errors.Wrap(err, "rename 临时文件失败")
+	}
+	return nil
 }
 
 // DeleteCookies 删除 cookies 文件。

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/xpzouying/headless_browser v0.2.0 h1:EmuHXDVzx0tAevHJUdETs8iT/eK+QqrLiybvGd1xZDA=
-github.com/xpzouying/headless_browser v0.2.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
 github.com/xpzouying/headless_browser v0.3.0 h1:ila/Kmei1dvBbP71SXEQuWfLuvjCw5HMqsgOzK39xn0=
 github.com/xpzouying/headless_browser v0.3.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/service.go
+++ b/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -564,8 +565,20 @@ func saveCookies(page *rod.Page) error {
 	return cookieLoader.SaveCookies(data)
 }
 
-// withBrowserPage 执行需要浏览器页面的操作的通用函数
-func withBrowserPage(fn func(*rod.Page) error) error {
+// withBrowserPage 执行需要浏览器页面的操作的通用函数。
+// 每次创建新 browser + page，操作完释放。
+// 通过 recover 捕获 panic，防止浏览器崩溃导致服务整体挂掉。
+func withBrowserPage(fn func(*rod.Page) error) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("浏览器操作 panic: %v", r)
+			logrus.WithFields(logrus.Fields{
+				"panic": r,
+				"stack": string(debug.Stack()),
+			}).Error("withBrowserPage panic recovered")
+		}
+	}()
+
 	b := newBrowser()
 	defer b.Close()
 


### PR DESCRIPTION
## 改了什么

MCP 服务跑一段时间后经常挂，排查下来主要两个原因：

### 1. Cookie 文件写坏了

`SaveCookies` 直接用 `os.WriteFile`，进程要是中途崩了（比如 OOM、被 kill），cookies.json 就写了一半，下次启动读出来是坏的，登录态没了。

改成原子写入：先写临时文件 → sync 到磁盘 → rename 覆盖。中途崩了最多丢临时文件，原来的 cookies.json 不受影响。

### 2. 浏览器 panic 把服务带走了

go-rod 操作浏览器有时候会 panic（页面突然关了、元素找不到了），之前 `withBrowserPage` 没 recover，一个请求 panic 整个服务就退了。

加了 `defer recover`，浏览器出问题只影响当前这一次请求，返回错误就行，服务继续跑。

## 改动范围

| 文件 | 干了啥 |
|------|-------|
| `cookies/cookies.go` | `SaveCookies` 改成 temp + sync + rename |
| `service.go` | `withBrowserPage` 加 defer recover |

就这两个文件，没加新依赖，编译通过。