### PR TITLE
feat: add scroll-based pagination to search_feeds

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,58 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: '0 1 * * 1' # 每周一 UTC 01:00 (北京时间 09:00)
+  workflow_dispatch: # 支持手动触发
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/xpzouying/xiaohongshu-mcp.git
+          git fetch upstream
+
+      - name: Merge upstream/main
+        id: merge
+        run: |
+          if git merge upstream/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            git merge --abort
+          fi
+
+      - name: Push (no conflict)
+        if: steps.merge.outputs.conflict == 'false'
+        run: git push origin main
+
+      - name: Create conflict PR
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: sync/upstream-${{ github.run_id }}
+        run: |
+          git checkout -b "$BRANCH_NAME"
+          git merge upstream/main --no-commit || true
+          git add -A
+          git commit -m "chore: sync upstream (conflicts need manual resolution)"
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --title "chore: sync upstream (conflicts)" \
+            --body "Upstream sync 发现合并冲突，需要手动解决。"

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -161,7 +161,7 @@ func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 	}
 
 	// 搜索 Feeds
-	result, err := s.xiaohongshuService.SearchFeeds(c.Request.Context(), keyword, filters)
+	result, err := s.xiaohongshuService.SearchFeeds(c.Request.Context(), keyword, 0, filters)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "SEARCH_FEEDS_FAILED",
 			"搜索Feeds失败", err.Error())

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -326,7 +326,13 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 		Location:    args.Filters.Location,
 	}
 
-	result, err := s.xiaohongshuService.SearchFeeds(ctx, args.Keyword, filter)
+	// limit 上限 200，默认 0 表示不翻页
+	limit := args.Limit
+	if limit > 200 {
+		limit = 200
+	}
+
+	result, err := s.xiaohongshuService.SearchFeeds(ctx, args.Keyword, limit, filter)
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -42,6 +42,7 @@ type PublishVideoArgs struct {
 type SearchFeedsArgs struct {
 	Keyword string       `json:"keyword" jsonschema:"搜索关键词"`
 	Filters FilterOption `json:"filters,omitempty" jsonschema:"筛选选项"`
+	Limit   int          `json:"limit,omitempty" jsonschema:"返回结果数量上限（默认20，最大200）。设置后会滚动加载更多结果"`
 }
 
 // FilterOption 筛选选项结构体

--- a/service.go
+++ b/service.go
@@ -369,7 +369,7 @@ func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse,
 	return response, nil
 }
 
-func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, filters ...xiaohongshu.FilterOption) (*FeedsListResponse, error) {
+func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, limit int, filters ...xiaohongshu.FilterOption) (*FeedsListResponse, error) {
 	b := newBrowser()
 	defer b.Close()
 
@@ -378,7 +378,7 @@ func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, fi
 
 	action := xiaohongshu.NewSearchAction(page)
 
-	feeds, err := action.Search(ctx, keyword, filters...)
+	feeds, err := action.Search(ctx, keyword, limit, filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -165,7 +165,7 @@ func NewSearchAction(page *rod.Page) *SearchAction {
 	return &SearchAction{page: pp}
 }
 
-func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...FilterOption) ([]Feed, error) {
+func (s *SearchAction) Search(ctx context.Context, keyword string, limit int, filters ...FilterOption) ([]Feed, error) {
 	page := s.page.Context(ctx)
 
 	searchURL := makeSearchURL(keyword)
@@ -214,18 +214,7 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 		page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
 	}
 
-	result := page.MustEval(`() => {
-		if (window.__INITIAL_STATE__ &&
-		    window.__INITIAL_STATE__.search &&
-		    window.__INITIAL_STATE__.search.feeds) {
-			const feeds = window.__INITIAL_STATE__.search.feeds;
-			const feedsData = feeds.value !== undefined ? feeds.value : feeds._value;
-			if (feedsData) {
-				return JSON.stringify(feedsData);
-			}
-		}
-		return "";
-	}`).String()
+	result := page.MustEval(readFeedsJS).String()
 
 	if result == "" {
 		return nil, errors.ErrNoFeeds
@@ -234,6 +223,11 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	var feeds []Feed
 	if err := json.Unmarshal([]byte(result), &feeds); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal feeds: %w", err)
+	}
+
+	// 翻页加载更多结果
+	if limit > 0 && len(feeds) < limit {
+		feeds = scrollAndCollectFeeds(page, feeds, limit)
 	}
 
 	return feeds, nil

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -225,8 +225,11 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, limit int, fi
 		return nil, fmt.Errorf("failed to unmarshal feeds: %w", err)
 	}
 
-	// 翻页加载更多结果
-	if limit > 0 && len(feeds) < limit {
+	// 根据 limit 截断或翻页加载更多结果
+	if limit > 0 {
+		if len(feeds) >= limit {
+			return feeds[:limit], nil
+		}
 		feeds = scrollAndCollectFeeds(page, feeds, limit)
 	}
 

--- a/xiaohongshu/search_pagination.go
+++ b/xiaohongshu/search_pagination.go
@@ -10,6 +10,9 @@ import (
 
 // scrollAndCollectFeeds 滚动页面加载更多搜索结果，按 Feed.ID 去重
 func scrollAndCollectFeeds(page *rod.Page, initialFeeds []Feed, limit int) []Feed {
+	// 确保翻页有超时保护，防止单次 WaitStable/Eval 无限等待
+	page = page.Timeout(60 * time.Second)
+
 	seen := make(map[string]bool, len(initialFeeds))
 	var allFeeds []Feed
 	for _, f := range initialFeeds {

--- a/xiaohongshu/search_pagination.go
+++ b/xiaohongshu/search_pagination.go
@@ -1,0 +1,96 @@
+package xiaohongshu
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// scrollAndCollectFeeds 滚动页面加载更多搜索结果，按 Feed.ID 去重
+func scrollAndCollectFeeds(page *rod.Page, initialFeeds []Feed, limit int) []Feed {
+	seen := make(map[string]bool, len(initialFeeds))
+	var allFeeds []Feed
+	for _, f := range initialFeeds {
+		if !seen[f.ID] {
+			seen[f.ID] = true
+			allFeeds = append(allFeeds, f)
+		}
+	}
+
+	if len(allFeeds) >= limit {
+		return allFeeds[:limit]
+	}
+
+	const maxStale = 3
+	staleCount := 0
+
+	for staleCount < maxStale && len(allFeeds) < limit {
+		// 使用 go-rod 滚动触发懒加载
+		if err := page.Mouse.Scroll(0, 800, 3); err != nil {
+			logrus.Warnf("翻页滚动失败: %v", err)
+			break
+		}
+		time.Sleep(1 * time.Second)
+
+		// 等待页面稳定
+		_ = page.WaitStable(500 * time.Millisecond)
+
+		// 重读 __INITIAL_STATE__ 中的 feeds
+		obj, err := page.Eval(readFeedsJS)
+		if err != nil {
+			logrus.Warnf("翻页读取 feeds 失败（可能超时）: %v", err)
+			break
+		}
+
+		raw := obj.Value.String()
+		if raw == "" {
+			staleCount++
+			continue
+		}
+
+		var feeds []Feed
+		if err := json.Unmarshal([]byte(raw), &feeds); err != nil {
+			logrus.Warnf("翻页解析 feeds 失败: %v", err)
+			staleCount++
+			continue
+		}
+
+		newCount := 0
+		for _, f := range feeds {
+			if !seen[f.ID] {
+				seen[f.ID] = true
+				allFeeds = append(allFeeds, f)
+				newCount++
+			}
+		}
+
+		if newCount == 0 {
+			staleCount++
+		} else {
+			staleCount = 0
+		}
+
+		logrus.Infof("翻页: 本次新增 %d 条, 总计 %d/%d", newCount, len(allFeeds), limit)
+	}
+
+	if len(allFeeds) > limit {
+		return allFeeds[:limit]
+	}
+	return allFeeds
+}
+
+// readFeedsJS 读取 __INITIAL_STATE__ 中 feeds 数据的 JS 脚本
+const readFeedsJS = `() => {
+	if (window.__INITIAL_STATE__ &&
+	    window.__INITIAL_STATE__.search &&
+	    window.__INITIAL_STATE__.search.feeds) {
+		const feeds = window.__INITIAL_STATE__.search.feeds;
+		const feedsData = feeds.value !== undefined ? feeds.value : feeds._value;
+		if (feedsData) {
+			return JSON.stringify(feedsData);
+		}
+	}
+	return "";
+}`

--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -23,7 +23,7 @@ func TestSearch(t *testing.T) {
 
 	action := NewSearchAction(page)
 
-	feeds, err := action.Search(context.Background(), "Kimi")
+	feeds, err := action.Search(context.Background(), "Kimi", 0)
 	require.NoError(t, err)
 	require.NotEmpty(t, feeds, "feeds should not be empty")
 
@@ -55,7 +55,7 @@ func TestSearchWithFilters(t *testing.T) {
 		PublishTime: "一天内",
 	}
 
-	feeds, err := action.Search(context.Background(), "dn432", filter)
+	feeds, err := action.Search(context.Background(), "dn432", 0, filter)
 	require.NoError(t, err)
 	require.NotEmpty(t, feeds, "feeds should not be empty")
 


### PR DESCRIPTION
## Summary

- Add `limit` parameter to `search_feeds` MCP tool (optional, default 20, max 200)
- Scroll-based pagination: scroll down → re-read `__INITIAL_STATE__` → deduplicate by `Feed.ID` → stop when limit reached or 3 consecutive stale scrolls
- All pagination logic isolated in new file `xiaohongshu/search_pagination.go` to minimize upstream merge conflicts
- Add GitHub Actions workflow for weekly upstream auto-sync (with conflict PR fallback)
- Existing files changed only 1-5 lines each for parameter threading

## Design: Fork-Friendly Minimal Invasion

| File | Change | Lines |
|------|--------|-------|
| `search_pagination.go` | **NEW** — all pagination logic | +90 |
| `search.go` | Add `limit` param + call pagination | +3/-13 |
| `mcp_server.go` | `SearchFeedsArgs.Limit` field | +1 |
| `mcp_handlers.go` | Parse & cap limit at 200 | +5 |
| `service.go` | Thread `limit` through | +2/-2 |
| `handlers_api.go` | Pass `limit=0` (backward compat) | +1/-1 |
| `sync-upstream.yml` | **NEW** — weekly upstream sync | +50 |

## Test plan

- [ ] `go build` passes
- [ ] `go vet` passes  
- [ ] Manual test: `search_feeds` with `limit=50` returns >30 results
- [ ] Manual test: `search_feeds` without `limit` returns ~20 results (backward compat)
- [ ] Existing `TestFilterValidation` passes

Upstream issue: https://github.com/xpzouying/xiaohongshu-mcp/issues/616

🤖 Generated with [Claude Code](https://claude.com/claude-code)