### PR TITLE
fix(publish): avoid 5min timeout when waiting for publish tab

### DIFF
--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -50,8 +50,11 @@ func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 	}
 	time.Sleep(2 * time.Second)
 
-	// 等待页面稳定
-	if err := pp.WaitDOMStable(time.Second, 0.1); err != nil {
+	// 等待页面稳定。给 WaitDOMStable 独立的短超时，防止它无限占用
+	// 外层 300s 预算 —— 新版发布页存在持续动画/埋点请求，
+	// 可能让 DOMStable 一直等不到稳定态。
+	stablePage := pp.Timeout(10 * time.Second)
+	if err := stablePage.WaitDOMStable(time.Second, 0.1); err != nil {
 		logrus.Warnf("等待 DOM 稳定出现问题: %v，继续尝试", err)
 	}
 	time.Sleep(1 * time.Second)
@@ -116,7 +119,21 @@ func clickEmptyPosition(page *rod.Page) {
 }
 
 func mustClickPublishTab(page *rod.Page, tabname string) error {
-	page.MustElement(`div.upload-content`).MustWaitVisible()
+	// 等待发布页头部的 TAB 容器出现即可。
+	//
+	// 历史上这里用的是 `div.upload-content` + `MustWaitVisible`：
+	// 1) 该选择器实际指向当前 active TAB 的上传区域，
+	//    默认 active 是 "上传视频"，UI 改版后可能延迟渲染/布局变动；
+	// 2) `MustElement` 在找不到时会 panic，被上层 context 的
+	//    `page.Timeout(300s)` 吃掉后表现为 "context deadline exceeded"，
+	//    让整个发布流程卡 5 分钟才失败。
+	//
+	// 更稳健的做法：用带短 timeout 的 Element 等 `div.creator-tab`
+	// 至少出现一个，再进入重试循环。
+	waitPage := page.Timeout(15 * time.Second)
+	if _, err := waitPage.Element(`div.creator-tab`); err != nil {
+		return errors.Wrap(err, "等待发布 TAB 容器加载失败")
+	}
 
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## Problem

`publish_content` (and any other entry point that goes through
`NewPublishImageAction`) hangs for a full 5 minutes and then fails with
`context deadline exceeded` originating in `mustClickPublishTab`:

    mustClickPublishTab(page, "上传图文")
      -> page.MustElement(`div.upload-content`)
      -> context deadline exceeded

The 5 minute number is not a coincidence: it matches the
`page.Timeout(300 * time.Second)` set at the top of
`NewPublishImageAction`.

## Root cause

`NewPublishImageAction` wraps the page in a single 300s timeout context
that is shared by every subsequent chained operation:

```go
pp := page.Timeout(300 * time.Second)
...
pp.WaitDOMStable(time.Second, 0.1) // only logs a warning on error
...
mustClickPublishTab(pp, "上传图文")
```

On the current creator UI, `https://creator.xiaohongshu.com/publish/publish`
fires a steady stream of animations / tracking requests, so
`WaitDOMStable` never sees a stable DOM and silently burns the entire
300s budget (its error is only logged as a warning, so execution
continues).

By the time we reach `mustClickPublishTab`, the parent context is
already deadline-exceeded. Its very first line is:

```go
page.MustElement(`div.upload-content`).MustWaitVisible()
```

`MustElement` panics on a dead context, and the panic propagates up as
the `context deadline exceeded` error users see.

I verified by dumping the live DOM in both headless and headful mode
with the project's own browser package: `div.creator-tab` matches 5
elements as expected, the real "上传图文" tab is fully clickable
(rect 369x81, hitTest returns its own SPAN), and the existing
`isElementVisible` check correctly filters the off-screen `-9999px`
duplicate. So the existing selector logic in `getTabElement` is fine;
the bug is purely in the wait/timeout plumbing surrounding it.

## Fix

Two minimal, defensive changes in `xiaohongshu/publish.go`:

1. Give `WaitDOMStable` its own 10s child timeout derived from `pp`,
   so it cannot starve the outer 300s publish budget no matter how
   noisy the creator UI gets.
2. Replace the panic-style
   `page.MustElement('div.upload-content').MustWaitVisible()` in
   `mustClickPublishTab` with a 15s scoped `Element('div.creator-tab')`
   call. `div.creator-tab` is the actual prerequisite for clicking a
   publish tab (the header tabs container), and is more robust to
   header/upload-area UI tweaks than the active-tab upload region.
   Errors are returned via `errors.Wrap` instead of panicking, so
   failures surface immediately with a useful message instead of after
   a 5 minute hang.

`getTabElement` and the rest of the click loop are intentionally left
untouched.

## Verification

- `go build .` clean
- Replaced the local `xiaohongshu-mcp` binary with the patched build
  and restarted the MCP server on `:18060`
- Successfully published a 9-image image-text note end-to-end via
  `mcp__xiaohongshu__publish_content`. No 5 minute hang, no
  `context deadline exceeded`.