### PR TITLE
fix(routes): return JSON 404 for OAuth discovery probes

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -23,6 +23,34 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 	// 健康检查
 	router.GET("/health", healthHandler)
 
+	// OAuth discovery endpoints — return JSON 404 instead of plain text 404.
+	//
+	// Background: Claude Code's MCP HTTP client probes a number of OAuth
+	// .well-known endpoints (per the MCP authorization spec) on every
+	// reconnect. When these paths return Gin's default plain-text
+	// "404 page not found", the client tries to parse the body as JSON,
+	// fails, and ends up stuck in a "needs authentication" state with no
+	// OAuth metadata to act on. The MCP endpoint still works, but the
+	// auth state machine on the client side never recovers without a
+	// process restart.
+	//
+	// Returning a JSON 404 here lets the client cleanly conclude "no auth
+	// metadata, no auth required" and fall back to anonymous mode.
+	noAuthRequired := func(c *gin.Context) {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":             "not_found",
+			"error_description": "This MCP server does not require authentication",
+		})
+	}
+	router.GET("/.well-known/oauth-protected-resource", noAuthRequired)
+	router.GET("/.well-known/oauth-protected-resource/*path", noAuthRequired)
+	router.GET("/.well-known/oauth-authorization-server", noAuthRequired)
+	router.GET("/.well-known/oauth-authorization-server/*path", noAuthRequired)
+	router.GET("/.well-known/openid-configuration", noAuthRequired)
+	router.GET("/.well-known/openid-configuration/*path", noAuthRequired)
+	router.GET("/mcp/.well-known/*path", noAuthRequired)
+	router.POST("/register", noAuthRequired)
+
 	// MCP 端点 - 使用官方 SDK 的 Streamable HTTP Handler
 	mcpHandler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server {


### PR DESCRIPTION
## Problem

Claude Code's MCP HTTP client probes a number of OAuth `.well-known` endpoints (per the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization)) on every reconnect. When those paths return Gin's default plain-text `404 page not found`, the client tries to parse the body as a JSON OAuth error response, fails with a JSON parse error, and ends up stuck in a "needs authentication" state with no OAuth metadata to act on.

The MCP endpoint itself still works, but the auth state machine on the client side never recovers without a process restart. End-user symptoms: the MCP server repeatedly appears as "disconnected" or "needs auth" even though the actual `/mcp` POST is fine.

## Server log captured during one failure

```
GET /.well-known/oauth-protected-resource/mcp     -> 404
GET /.well-known/oauth-protected-resource         -> 404
GET /.well-known/oauth-authorization-server       -> 404
GET /.well-known/openid-configuration             -> 404
GET /.well-known/oauth-authorization-server/mcp   -> 404
GET /.well-known/openid-configuration/mcp         -> 404
GET /mcp/.well-known/openid-configuration         -> 400
POST /register                                    -> 404
POST /mcp                                         -> 200  (works!)
```

And the client-side error:

```
Failed to start OAuth flow for xiaohongshu: SDK auth failed: HTTP 404:
Invalid OAuth error response: SyntaxError: JSON Parse error: Unable to
parse JSON string. Raw body: 404 page not found.
```

## Fix

Register lightweight handlers for the well-known OAuth probe paths and \`POST /register\` that return a JSON 404 body with a clear \`error_description\`:

\`\`\`json
{
  "error": "not_found",
  "error_description": "This MCP server does not require authentication"
}
\`\`\`

The client now sees a parseable JSON response, concludes no OAuth metadata is available, and falls back to anonymous mode cleanly. No behavior change for any existing endpoint.

## Verification

- \`go build\` clean
- Curl probes return JSON with status 404 and the expected body
- Repeated reconnects from Claude Code no longer get stuck in the auth-required state

## Files

- \`routes.go\` (+28 lines)