### PR TITLE
fix: handle duplicate search filter tags when applying filters

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -165,6 +165,13 @@ type SearchAction struct {
 	page *rod.Page
 }
 
+const (
+	searchStateWaitTimeout      = 10 * time.Second
+	searchFeedsReadyWaitTimeout = 8 * time.Second
+	filterActivationWaitTimeout = 10 * time.Second
+	filterApplyDelay            = 1200 * time.Millisecond
+)
+
 func NewSearchAction(page *rod.Page) *SearchAction {
 	pp := page.Timeout(60 * time.Second)
 
@@ -177,6 +184,8 @@ func chooseFilterTag(tags []filterTagState, targetText string) (int, bool, error
 			return index, false, nil
 		}
 	}
+	// On the current search page DOM, duplicated tags are rendered for the same label
+	// and the interactive copy is typically the later `display:flex` node.
 	for index := len(tags) - 1; index >= 0; index-- {
 		tag := tags[index]
 		if tag.Text == targetText && tag.Display == "flex" {
@@ -192,18 +201,22 @@ func chooseFilterTag(tags []filterTagState, targetText string) (int, bool, error
 	return -1, false, fmt.Errorf("未找到筛选项: %s", targetText)
 }
 
-func (s *SearchAction) waitForSearchState(page *rod.Page) {
-	page.MustWait(`() => !!(
+func (s *SearchAction) waitForSearchState(page *rod.Page) error {
+	waitPage := page.Timeout(searchStateWaitTimeout)
+	defer waitPage.CancelTimeout()
+
+	return waitPage.Wait(rod.Eval(`() => !!(
 		window.__INITIAL_STATE__ &&
 		window.__INITIAL_STATE__.search &&
 		window.__INITIAL_STATE__.search.feeds
-	)`)
+	)`))
 }
 
 func (s *SearchAction) waitForSearchFeedsReady(page *rod.Page) {
-	waitPage := page.Timeout(8 * time.Second)
+	waitPage := page.Timeout(searchFeedsReadyWaitTimeout)
 	defer waitPage.CancelTimeout()
 
+	// Best effort: some valid searches may still render an empty feed list.
 	_ = waitPage.Wait(rod.Eval(`() => {
 		const feeds = window.__INITIAL_STATE__ &&
 			window.__INITIAL_STATE__.search &&
@@ -262,16 +275,23 @@ func (s *SearchAction) applyFilter(page *rod.Page, filter internalFilterOption) 
 		return fmt.Errorf("点击筛选项失败: %s", filter.Text)
 	}
 
-	page.Timeout(10 * time.Second).MustWait(fmt.Sprintf(`() => {
+	waitPage := page.Timeout(filterActivationWaitTimeout)
+	defer waitPage.CancelTimeout()
+
+	if err := waitPage.Wait(rod.Eval(fmt.Sprintf(`() => {
 		const groups = document.querySelectorAll('div.filter-panel div.filters');
 		const group = groups[%d];
 		if (!group) return false;
 		return Array.from(group.querySelectorAll('div.tags')).some(tag =>
 			(tag.textContent || '').trim() === %q && tag.classList.contains('active')
 		);
-	}`, filter.FiltersIndex-1, filter.Text))
+	}`, filter.FiltersIndex-1, filter.Text))); err != nil {
+		return fmt.Errorf("等待筛选项生效失败: %w", err)
+	}
 
-	time.Sleep(1200 * time.Millisecond)
+	// Give the page a short settle window after the active state flips so the
+	// subsequent feed read sees the refreshed search result data.
+	time.Sleep(filterApplyDelay)
 	return nil
 }
 
@@ -281,7 +301,9 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
 	page.MustWaitLoad()
-	s.waitForSearchState(page)
+	if err := s.waitForSearchState(page); err != nil {
+		return nil, fmt.Errorf("等待搜索结果状态初始化失败: %w", err)
+	}
 	s.waitForSearchFeedsReady(page)
 
 	// 如果有筛选条件，则应用筛选
@@ -317,7 +339,9 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 			}
 		}
 
-		s.waitForSearchState(page)
+		if err := s.waitForSearchState(page); err != nil {
+			return nil, fmt.Errorf("等待筛选后的搜索结果状态初始化失败: %w", err)
+		}
 		s.waitForSearchFeedsReady(page)
 	}
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -11,6 +11,12 @@ import (
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
+type filterTagState struct {
+	Text    string `json:"text"`
+	Active  bool   `json:"active"`
+	Display string `json:"display"`
+}
+
 type SearchResult struct {
 	Search struct {
 		Feeds FeedsValue `json:"feeds"`
@@ -165,14 +171,118 @@ func NewSearchAction(page *rod.Page) *SearchAction {
 	return &SearchAction{page: pp}
 }
 
+func chooseFilterTag(tags []filterTagState, targetText string) (int, bool, error) {
+	for index, tag := range tags {
+		if tag.Text == targetText && tag.Active {
+			return index, false, nil
+		}
+	}
+	for index := len(tags) - 1; index >= 0; index-- {
+		tag := tags[index]
+		if tag.Text == targetText && tag.Display == "flex" {
+			return index, true, nil
+		}
+	}
+	for index := len(tags) - 1; index >= 0; index-- {
+		tag := tags[index]
+		if tag.Text == targetText {
+			return index, true, nil
+		}
+	}
+	return -1, false, fmt.Errorf("未找到筛选项: %s", targetText)
+}
+
+func (s *SearchAction) waitForSearchState(page *rod.Page) {
+	page.MustWait(`() => !!(
+		window.__INITIAL_STATE__ &&
+		window.__INITIAL_STATE__.search &&
+		window.__INITIAL_STATE__.search.feeds
+	)`)
+}
+
+func (s *SearchAction) waitForSearchFeedsReady(page *rod.Page) {
+	waitPage := page.Timeout(8 * time.Second)
+	defer waitPage.CancelTimeout()
+
+	_ = waitPage.Wait(rod.Eval(`() => {
+		const feeds = window.__INITIAL_STATE__ &&
+			window.__INITIAL_STATE__.search &&
+			window.__INITIAL_STATE__.search.feeds;
+		if (!feeds) return false;
+		const feedsData = feeds.value !== undefined ? feeds.value : feeds._value;
+		return Array.isArray(feedsData) && feedsData.length > 0;
+	}`))
+}
+
+func (s *SearchAction) getFilterTags(page *rod.Page, filter internalFilterOption) ([]filterTagState, error) {
+	result := page.MustEval(fmt.Sprintf(`() => {
+		const groups = document.querySelectorAll('div.filter-panel div.filters');
+		const group = groups[%d];
+		if (!group) return "[]";
+		const tags = Array.from(group.querySelectorAll('div.tags')).map(tag => ({
+			text: (tag.textContent || '').trim(),
+			active: tag.classList.contains('active'),
+			display: getComputedStyle(tag).display
+		}));
+		return JSON.stringify(tags);
+	}`, filter.FiltersIndex-1)).String()
+
+	var tags []filterTagState
+	if err := json.Unmarshal([]byte(result), &tags); err != nil {
+		return nil, fmt.Errorf("解析筛选项失败: %w", err)
+	}
+	return tags, nil
+}
+
+func (s *SearchAction) applyFilter(page *rod.Page, filter internalFilterOption) error {
+	tags, err := s.getFilterTags(page, filter)
+	if err != nil {
+		return err
+	}
+
+	tagIndex, shouldClick, err := chooseFilterTag(tags, filter.Text)
+	if err != nil {
+		return err
+	}
+	if !shouldClick {
+		return nil
+	}
+
+	clicked := page.MustEval(fmt.Sprintf(`() => {
+		const groups = document.querySelectorAll('div.filter-panel div.filters');
+		const group = groups[%d];
+		if (!group) return false;
+		const tags = Array.from(group.querySelectorAll('div.tags'));
+		const tag = tags[%d];
+		if (!tag) return false;
+		tag.click();
+		return true;
+	}`, filter.FiltersIndex-1, tagIndex)).Bool()
+	if !clicked {
+		return fmt.Errorf("点击筛选项失败: %s", filter.Text)
+	}
+
+	page.Timeout(10 * time.Second).MustWait(fmt.Sprintf(`() => {
+		const groups = document.querySelectorAll('div.filter-panel div.filters');
+		const group = groups[%d];
+		if (!group) return false;
+		return Array.from(group.querySelectorAll('div.tags')).some(tag =>
+			(tag.textContent || '').trim() === %q && tag.classList.contains('active')
+		);
+	}`, filter.FiltersIndex-1, filter.Text))
+
+	time.Sleep(1200 * time.Millisecond)
+	return nil
+}
+
 func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...FilterOption) ([]Feed, error) {
 	page := s.page.Context(ctx)
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
-
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	page.MustWaitLoad()
+	s.waitForSearchState(page)
+	s.waitForSearchFeedsReady(page)
 
 	// 如果有筛选条件，则应用筛选
 	if len(filters) > 0 {
@@ -202,16 +312,13 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 		// 应用所有筛选条件
 		for _, filter := range allInternalFilters {
-			selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
-				filter.FiltersIndex, filter.TagsIndex)
-			option := page.MustElement(selector)
-			option.MustClick()
+			if err := s.applyFilter(page, filter); err != nil {
+				return nil, fmt.Errorf("应用筛选项失败: %w", err)
+			}
 		}
 
-		// 等待页面更新
-		page.MustWaitStable()
-		// 重新等待 __INITIAL_STATE__ 更新
-		page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+		s.waitForSearchState(page)
+		s.waitForSearchFeedsReady(page)
 	}
 
 	result := page.MustEval(`() => {

--- a/xiaohongshu/search_filter_test.go
+++ b/xiaohongshu/search_filter_test.go
@@ -59,3 +59,39 @@ func TestChooseFilterTagPrefersInteractiveDuplicateWhenTargetNotActive(t *testin
 		t.Fatalf("expected interactive duplicate index 2, got %d", index)
 	}
 }
+
+func TestChooseFilterTagReturnsErrorWhenTargetMissing(t *testing.T) {
+	tags := []filterTagState{
+		{Text: "不限", Active: true, Display: "flex"},
+	}
+
+	_, _, err := chooseFilterTag(tags, "一周内")
+	if err == nil {
+		t.Fatalf("expected error when target tag is missing")
+	}
+}
+
+func TestChooseFilterTagReturnsErrorForEmptyTags(t *testing.T) {
+	_, _, err := chooseFilterTag(nil, "一周内")
+	if err == nil {
+		t.Fatalf("expected error for empty tag list")
+	}
+}
+
+func TestChooseFilterTagFallsBackToLastMatchingTag(t *testing.T) {
+	tags := []filterTagState{
+		{Text: "一周内", Active: false, Display: "none"},
+		{Text: "一周内", Active: false, Display: "none"},
+	}
+
+	index, shouldClick, err := chooseFilterTag(tags, "一周内")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !shouldClick {
+		t.Fatalf("expected click for fallback target")
+	}
+	if index != 1 {
+		t.Fatalf("expected fallback index 1, got %d", index)
+	}
+}

--- a/xiaohongshu/search_filter_test.go
+++ b/xiaohongshu/search_filter_test.go
@@ -1,0 +1,61 @@
+package xiaohongshu
+
+import "testing"
+
+func TestChooseFilterTagSkipsAlreadyActiveDuplicate(t *testing.T) {
+	tags := []filterTagState{
+		{Text: "综合", Active: true},
+		{Text: "综合", Active: true},
+		{Text: "最新", Active: false},
+	}
+
+	index, shouldClick, err := chooseFilterTag(tags, "综合")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if shouldClick {
+		t.Fatalf("expected no click for already active tag")
+	}
+	if index != 0 {
+		t.Fatalf("expected active index 0, got %d", index)
+	}
+}
+
+func TestChooseFilterTagReturnsInactiveMatchWhenTargetNotActive(t *testing.T) {
+	tags := []filterTagState{
+		{Text: "不限", Active: true},
+		{Text: "视频", Active: false, Display: "block"},
+		{Text: "视频", Active: false, Display: "flex"},
+		{Text: "图文", Active: false},
+	}
+
+	index, shouldClick, err := chooseFilterTag(tags, "图文")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !shouldClick {
+		t.Fatalf("expected click for inactive target")
+	}
+	if index != 3 {
+		t.Fatalf("expected index 3, got %d", index)
+	}
+}
+
+func TestChooseFilterTagPrefersInteractiveDuplicateWhenTargetNotActive(t *testing.T) {
+	tags := []filterTagState{
+		{Text: "不限", Active: true, Display: "flex"},
+		{Text: "一周内", Active: false, Display: "block"},
+		{Text: "一周内", Active: false, Display: "flex"},
+	}
+
+	index, shouldClick, err := chooseFilterTag(tags, "一周内")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !shouldClick {
+		t.Fatalf("expected click for inactive target")
+	}
+	if index != 2 {
+		t.Fatalf("expected interactive duplicate index 2, got %d", index)
+	}
+}


### PR DESCRIPTION
## Summary
- handle duplicated filter tag nodes on the search result page instead of relying on the first matching node
- prefer the interactive duplicate tag and skip clicking when the target tag is already active
- add regression tests for duplicated active tags and duplicated interactive tags

## Root Cause
The search result filter panel now renders duplicated `div.tags` nodes for the same label. The previous implementation clicked the first matching node by fixed position, which can target a non-interactive duplicate. In that case the filter is not applied, and the search request eventually times out while waiting for the page state to change.

## Test Plan
- `go test ./xiaohongshu -run 'TestChooseFilterTag|TestFilterValidation' -count=1`
- build the server from this branch and run it against a logged-in Chrome session
- `GET /api/v1/login/status` returns `200`
- `POST /api/v1/feeds/search` with `keyword=一人公司` and `filters.publish_time=一周内` returns `200`
- `POST /api/v1/feeds/search` with `keyword=一人公司` and default filters (`综合 / 不限 / 一周内 / 不限 / 不限`) returns `200`
- MCP `tools/call -> search_feeds` with the same filters returns `200`
