### PR TITLE
feat: 支持获取原图 URL，通过浏览器上下文验证可访问性

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -856,12 +857,68 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 		return nil, fmt.Errorf("feed %s not found in noteDetailMap", feedID)
 	}
 
+	// 为每张图片填充原图 URL，并通过浏览器上下文验证可访问性
+	note := noteDetail.Note
+	for i := range note.ImageList {
+		candidate := toOriginalURL(note.ImageList[i].URLDefault)
+		if candidate != "" && candidate != note.ImageList[i].URLDefault {
+			if checkImageAccessible(page, candidate) {
+				note.ImageList[i].URLOriginal = candidate
+			} else {
+				logrus.Debugf("原图 URL 不可访问，跳过: %s", candidate)
+			}
+		}
+	}
+
 	return &FeedDetailResponse{
-		Note:     noteDetail.Note,
+		Note:     note,
 		Comments: noteDetail.Comments,
 	}, nil
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
 	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+}
+
+// toOriginalURL 去除小红书 CDN 图片 URL 中的压缩/裁剪参数，返回原图 URL。
+// CDN 有两种压缩格式：
+//  1. Query 参数：https://sns-img-hw.xhscdn.com/{hash}?imageView2/2/w/1080/format/jpg
+//  2. 路径感叹号后缀：https://ci.xiaohongshu.com/{hash}!nd_dft_wlteh_webp_3
+func toOriginalURL(rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	// 去除所有 query 参数（imageView2/... 等压缩指令）
+	parsed.RawQuery = ""
+
+	result := parsed.String()
+
+	// 去除路径中 "!" 后的 CDN 处理后缀
+	if idx := strings.Index(result, "!"); idx != -1 {
+		result = result[:idx]
+	}
+
+	return result
+}
+
+// checkImageAccessible 在浏览器上下文中用 fetch HEAD 验证图片 URL 是否可访问
+func checkImageAccessible(page *rod.Page, imageURL string) bool {
+	result := page.MustEval(`(url) => {
+		try {
+			const xhr = new XMLHttpRequest();
+			xhr.open('HEAD', url, false);
+			xhr.send();
+			return xhr.status >= 200 && xhr.status < 400;
+		} catch(e) {
+			return false;
+		}
+	}`, imageURL)
+
+	return result.Bool()
 }

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -107,11 +107,12 @@ type FeedDetail struct {
 
 // DetailImageInfo 表示详情页的图片信息
 type DetailImageInfo struct {
-	Width      int    `json:"width"`
-	Height     int    `json:"height"`
-	URLDefault string `json:"urlDefault"`
-	URLPre     string `json:"urlPre"`
-	LivePhoto  bool   `json:"livePhoto,omitempty"`
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+	URLDefault  string `json:"urlDefault"`
+	URLPre      string `json:"urlPre"`
+	URLOriginal string `json:"urlOriginal,omitempty"` // 去除 CDN 压缩参数后的原图 URL
+	LivePhoto   bool   `json:"livePhoto,omitempty"`
 }
 
 // CommentList 表示评论列表


### PR DESCRIPTION
- DetailImageInfo 新增 URLOriginal 字段
- toOriginalURL 去除 CDN 压缩参数（query string 和 ! 后缀）
- checkImageAccessible 在浏览器上下文中用 XHR HEAD 验证原图可访问性
- 验证失败时静默跳过，不影响现有行为