### PR TITLE
fix: 搜索超时，MustWaitStable 换成等数据就绪

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -170,9 +170,11 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	page.MustWaitLoad()
 
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	// 直接等搜索数据就绪，不用 MustWaitStable
+	// 搜索结果页有持续的动画和轮询，MustWaitStable 会一直等到超时
+	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined && window.__INITIAL_STATE__.search !== undefined && window.__INITIAL_STATE__.search.feeds !== undefined`)
 
 	// 如果有筛选条件，则应用筛选
 	if len(filters) > 0 {


### PR DESCRIPTION
## 问题

搜索接口（`/api/v1/feeds/search`）调用后 60 秒超时 panic：

```
panic recovered: context canceled
xiaohongshu/search.go:198
```

搜索结果页有持续的动画和 XHR 轮询，`MustWaitStable()` 等 DOM 完全静止，但页面永远不会"稳定"，最终超时。

## 修复

- `MustWaitStable()` → `MustWaitLoad()`（只等基本页面加载完成）
- 等待条件从 `__INITIAL_STATE__ !== undefined` 细化为 `__INITIAL_STATE__.search.feeds !== undefined`（数据一到就返回）

## 测试

修复前：搜索 100% 超时 panic
修复后：搜索 5 秒内返回结果（2 核 2G 机器测试）