### PR TITLE
fix: 恢复 TestSearchWithFilters 的 t.Skip，修复 go test 崩溃

### DIFF
--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -37,7 +37,7 @@ func TestSearch(t *testing.T) {
 
 func TestSearchWithFilters(t *testing.T) {
 
-	//t.Skip("SKIP: 测试筛选功能")
+	t.Skip("SKIP: 测试筛选功能")
 
 	b := browser.NewBrowser(false)
 	defer b.Close()


### PR DESCRIPTION
## 问题

`TestSearchWithFilters` 中的 `t.Skip` 在 PR #260 中被注释掉，导致运行 `go test ./...` 时自动启动浏览器并 panic：

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/go-rod/rod.(*Element).MustHover(...)
```

与 #550 修复的问题相同：需要真实浏览器环境的测试应加 `t.Skip`。

## 修复

恢复 `t.Skip("SKIP: 测试筛选功能")`，一行变更。

## 测试

```
=== RUN   TestSearchWithFilters
    search_test.go:40: SKIP: 测试筛选功能
--- SKIP: TestSearchWithFilters (0.00s)
PASS
```

`go test ./...` 不再因此 panic。