### PR TITLE
feat: get_feed_detail 支持 include_images 参数，返回 Base64 图片供 LLM 直接查看

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/h2non/filetype"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
@@ -442,7 +447,22 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		config.ScrollSpeed = raw
 	}
 
-	logrus.Infof("MCP: 获取Feed详情 - Feed ID: %s, loadAllComments=%v, config=%+v", feedID, loadAll, config)
+	// 解析 include_images 参数
+	includeImages := false
+	if raw, ok := args["include_images"]; ok {
+		switch v := raw.(type) {
+		case bool:
+			includeImages = v
+		case string:
+			if parsed, err := strconv.ParseBool(v); err == nil {
+				includeImages = parsed
+			}
+		case float64:
+			includeImages = v != 0
+		}
+	}
+
+	logrus.Infof("MCP: 获取Feed详情 - Feed ID: %s, includeImages=%v, loadAllComments=%v, config=%+v", feedID, includeImages, loadAll, config)
 
 	result, err := s.xiaohongshuService.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAll, config)
 	if err != nil {
@@ -467,12 +487,84 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		}
 	}
 
-	return &MCPToolResult{
-		Content: []MCPContent{{
-			Type: "text",
-			Text: string(jsonData),
-		}},
+	contents := []MCPContent{{
+		Type: "text",
+		Text: string(jsonData),
+	}}
+
+	// 当 include_images=true 时，下载预览图并以 Base64 编码返回
+	if includeImages {
+		if detailResp, ok := result.Data.(*xiaohongshu.FeedDetailResponse); ok {
+			for i, img := range detailResp.Note.ImageList {
+				imageURL := img.URLPre
+				if imageURL == "" {
+					imageURL = img.URLDefault
+				}
+				if imageURL == "" {
+					continue
+				}
+
+				imgData, mimeType, dlErr := downloadImageAsBase64(imageURL)
+				if dlErr != nil {
+					logrus.Warnf("下载图片 %d 失败: %v", i+1, dlErr)
+					contents = append(contents, MCPContent{
+						Type: "text",
+						Text: fmt.Sprintf("图片 %d 下载失败: %v", i+1, dlErr),
+					})
+					continue
+				}
+
+				contents = append(contents, MCPContent{
+					Type:     "image",
+					MimeType: mimeType,
+					Data:     imgData,
+				})
+			}
+		}
 	}
+
+	return &MCPToolResult{Content: contents}
+}
+
+// downloadImageAsBase64 下载图片并返回 Base64 编码字符串和 MIME 类型
+func downloadImageAsBase64(imageURL string) (string, string, error) {
+	req, err := http.NewRequest("GET", imageURL, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	// 设置请求头，防止防盗链拦截
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	if parsedURL, err := url.Parse(imageURL); err == nil {
+		req.Header.Set("Referer", fmt.Sprintf("%s://%s/", parsedURL.Scheme, parsedURL.Host))
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("下载失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("下载失败，状态码: %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("读取数据失败: %w", err)
+	}
+
+	// 检测图片格式
+	kind, err := filetype.Match(data)
+	if err != nil || !filetype.IsImage(data) {
+		return "", "", fmt.Errorf("非有效图片格式")
+	}
+
+	mimeType := kind.MIME.Value
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	return encoded, mimeType, nil
 }
 
 // handleUserProfile 获取用户主页

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -57,6 +57,7 @@ type FilterOption struct {
 type FeedDetailArgs struct {
 	FeedID           string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
 	XsecToken        string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	IncludeImages    bool   `json:"include_images,omitempty" jsonschema:"是否在返回结果中包含图片内容（Base64编码）。true返回图片供LLM直接查看，false仅返回图片URL（默认）。使用预览图以控制体积"`
 	LoadAllComments  bool   `json:"load_all_comments,omitempty" jsonschema:"是否加载全部评论。false仅返回前10条一级评论（默认），true滚动加载更多评论"`
 	Limit            int    `json:"limit,omitempty" jsonschema:"【仅当load_all_comments为true时生效】限制加载的一级评论数量。例如20表示最多加载20条，默认20"`
 	ClickMoreReplies bool   `json:"click_more_replies,omitempty" jsonschema:"【仅当load_all_comments为true时生效】是否展开二级回复。true展开子评论，false不展开（默认）"`
@@ -264,7 +265,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
-			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
+			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。设置include_images=true可让LLM直接查看图片内容（Base64编码预览图）。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Feed Detail",
 				ReadOnlyHint: true,
@@ -274,6 +275,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 			argsMap := map[string]interface{}{
 				"feed_id":           args.FeedID,
 				"xsec_token":        args.XsecToken,
+				"include_images":    args.IncludeImages,
 				"load_all_comments": args.LoadAllComments,
 			}
 


### PR DESCRIPTION
## 问题

大量小红书笔记的核心内容在图片中（教程、代码截图、长文排版等），`desc` 字段往往只有 hashtag 或简短描述。当前 `get_feed_detail` 返回图片的 URL（`ImageList[].URLDefault`），但 LLM 无法直接读取远程图片内容。

## 方案

给 `get_feed_detail` 新增 `include_images` 可选参数（默认 `false`），设为 `true` 时：

1. 下载每张预览图（`urlPre`，比原图体积小）
2. 检测图片格式（MIME type）
3. Base64 编码后作为 MCP `ImageContent` 返回

LLM 一次调用即可获取笔记的文字和图片内容。

## 实现细节

- **复用已有模式：** `get_login_qrcode` 已使用 `ImageContent` 返回 Base64 图片，本 PR 复用相同的 `convertToMCPResult` 路径
- **预览图优先：** 使用 `urlPre`（预览图）而非 `urlDefault`（原图）以控制 payload 体积，`urlPre` 为空时回退到 `urlDefault`
- **防盗链处理：** 设置 `Referer` 和 `User-Agent` 请求头，与 `pkg/downloader` 保持一致
- **容错：** 单张图片下载失败时返回文本提示，不影响其余图片和整体结果
- **完全向后兼容：** `include_images` 默认 `false`，不设置时行为与之前完全一致

## 改动文件

| 文件 | 改动 |
|------|------|
| `mcp_server.go` | `FeedDetailArgs` 新增 `IncludeImages` 字段；更新工具描述；传递参数到 handler |
| `mcp_handlers.go` | `handleGetFeedDetail` 增加图片下载+编码逻辑；新增 `downloadImageAsBase64` 辅助函数 |

## 使用示例

```json
{
  "feed_id": "xxx",
  "xsec_token": "yyy",
  "include_images": true
}
```

返回结果包含文字内容（TextContent）+ 图片内容（ImageContent × N）。

Closes #653