### PR TITLE
fix: 回复评论滚动查找逻辑，防止评论区未加载完时误判已到达底部

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -97,8 +97,8 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 		return err
 	}
 
-	// 等待评论容器加载
-	time.Sleep(2 * time.Second)
+	// 等待评论容器加载（增加到5秒，应对慢速网络）
+	time.Sleep(5 * time.Second)
 
 	// 使用 Go 实现的查找逻辑
 	commentEl, err := findCommentElement(page, commentID, userID)
@@ -166,20 +166,40 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 
 	var lastCommentCount = 0
 	stagnantChecks := 0
+	hasScrolled := false // 标记是否已经开始滚动
 
 	logrus.Infof("开始循环查找，最大尝试次数: %d", maxAttempts)
+
+	// === 阶段1: 先等待评论加载（修复：评论区未加载完时不应检查是否到达底部）===
+	logrus.Info("等待评论加载...")
+	var currentCount int
+	for waitAttempt := 0; waitAttempt < 30; waitAttempt++ {
+		currentCount = getCommentCount(page)
+		if currentCount > 0 {
+			logrus.Infof("✓ 评论区已加载，当前有 %d 条评论", currentCount)
+			break
+		}
+		logrus.Infof("评论区尚未加载，继续等待... (%d/30)", waitAttempt+1)
+		time.Sleep(1 * time.Second)
+	}
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		logrus.Infof("=== 查找尝试 %d/%d ===", attempt+1, maxAttempts)
 
-		// === 1. 检查是否到达底部 ===
-		if checkEndContainer(page) {
-			logrus.Info("已到达评论底部，未找到目标评论")
-			break
-		}
+		// === 1. 获取当前评论数量 ===
+		// 注：currentCount 在上面的等待阶段已经获取过，这里重新获取以确保最新
+		currentCount = getCommentCount(page)
 
-		// === 2. 获取当前评论数量 ===
-		currentCount := getCommentCount(page)
+		// === 2. 只有在有评论且有滚动历史的情况下才检查是否到达底部 ===
+		// 修复：评论区还没加载完时，不应该因为看到底部容器就停止
+		if hasScrolled && currentCount > 0 {
+			if checkEndContainer(page) {
+				logrus.Info("已到达评论底部，未找到目标评论")
+				break
+			}
+		} else if !hasScrolled && checkEndContainer(page) {
+			logrus.Info("评论区可能还未加载，暂不判定为底部，继续等待...")
+		}
 		logrus.Infof("当前评论数: %d", currentCount)
 		
 		if currentCount != lastCommentCount {
@@ -216,6 +236,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 				logrus.Warnf("未找到评论元素: %v", err)
 			}
 			time.Sleep(300 * time.Millisecond)
+			hasScrolled = true
 		}
 
 		// === 5. 继续向下滚动 ===
@@ -224,6 +245,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		if err != nil {
 			logrus.Warnf("滚动失败: %v", err)
 		}
+		hasScrolled = true
 		time.Sleep(500 * time.Millisecond)
 
 		// === 6. 滚动后立即查找（边滚动边查找）===

--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -185,6 +185,11 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 			logrus.Infof("✓ 评论区已加载，当前有 %d 条评论", currentCount)
 			break
 		}
+		// P3修复：检测到无评论区域时提前退出，不等待30秒
+		if checkEndContainer(page) {
+			logrus.Info("预检测到评论底部区域（无评论），跳过等待")
+			break
+		}
 		if i == commentWaitTimeout-1 {
 			logrus.Warnf("等待 %d 秒后评论区仍为空，将继续尝试查找", commentWaitTimeout)
 		}
@@ -195,9 +200,10 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 	for attempt := 0; attempt < maxScrollAttempts; attempt++ {
 		currentCount = getCommentCount(page)
 
-		// 只有在有评论且有滚动历史的情况下才检查是否到达底部
-		// 修复：评论区还没加载完时（hasScrolled=false），即使看到底部容器也不判定为到达
-		if hasScrolled && currentCount > 0 {
+		// P1修复：底部检测必须基于评论增长信号，而不只是滚动历史
+		// 原因：hasScrolled 在第一次 scrollBy 后立即为 true，此时懒加载评论可能还未返回
+		//       如果底部容器是预渲染的，循环会在评论实际出现前就 break
+		if hasScrolled && currentCount > 0 && currentCount > lastCommentCount {
 			if checkEndContainer(page) {
 				logrus.Info("已到达评论底部，未找到目标评论")
 				break

--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -153,143 +153,116 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	return nil
 }
 
-// findCommentElement 查找指定评论元素（参考 feed_detail.go 的滚动逻辑）
+// findCommentElement 查找指定评论元素
+// 修复：评论区未加载完时不应检查是否到达底部，防止过早退出循环
 func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element, error) {
 	logrus.Infof("开始查找评论 - commentID: %s, userID: %s", commentID, userID)
 
-	const maxAttempts = 100
-	const scrollInterval = 800 * time.Millisecond
+	const (
+		maxScrollAttempts   = 100  // 最大滚动尝试次数
+		scrollInterval      = 800 * time.Millisecond
+		commentWaitTimeout  = 30   // 预等待评论区加载的最大秒数
+		stagnantThreshold   = 10   // 连续无增量次数阈值
+	)
 
 	// 先滚动到评论区
 	scrollToCommentsArea(page)
 	time.Sleep(1 * time.Second)
 
-	var lastCommentCount = 0
-	stagnantChecks := 0
-	hasScrolled := false // 标记是否已经开始滚动
+	var (
+		lastCommentCount  = 0
+		stagnantChecks    = 0
+		hasScrolled       = false // 标记是否已经开始滚动
+		currentCount      int
+	)
 
-	logrus.Infof("开始循环查找，最大尝试次数: %d", maxAttempts)
-
-	// === 阶段1: 先等待评论加载（修复：评论区未加载完时不应检查是否到达底部）===
-	logrus.Info("等待评论加载...")
-	var currentCount int
-	for waitAttempt := 0; waitAttempt < 30; waitAttempt++ {
+	// === 阶段1: 等待评论区加载完成 ===
+	// 修复问题：旧代码在评论区未加载时就检查底部容器，导致误判退出
+	logrus.Info("等待评论区加载...")
+	for i := 0; i < commentWaitTimeout; i++ {
 		currentCount = getCommentCount(page)
 		if currentCount > 0 {
 			logrus.Infof("✓ 评论区已加载，当前有 %d 条评论", currentCount)
 			break
 		}
-		logrus.Infof("评论区尚未加载，继续等待... (%d/30)", waitAttempt+1)
+		if i == commentWaitTimeout-1 {
+			logrus.Warnf("等待 %d 秒后评论区仍为空，将继续尝试查找", commentWaitTimeout)
+		}
 		time.Sleep(1 * time.Second)
 	}
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		logrus.Infof("=== 查找尝试 %d/%d ===", attempt+1, maxAttempts)
-
-		// === 1. 获取当前评论数量 ===
-		// 注：currentCount 在上面的等待阶段已经获取过，这里重新获取以确保最新
+	// === 阶段2: 滚动查找评论 ===
+	for attempt := 0; attempt < maxScrollAttempts; attempt++ {
 		currentCount = getCommentCount(page)
 
-		// === 2. 只有在有评论且有滚动历史的情况下才检查是否到达底部 ===
-		// 修复：评论区还没加载完时，不应该因为看到底部容器就停止
+		// 只有在有评论且有滚动历史的情况下才检查是否到达底部
+		// 修复：评论区还没加载完时（hasScrolled=false），即使看到底部容器也不判定为到达
 		if hasScrolled && currentCount > 0 {
 			if checkEndContainer(page) {
 				logrus.Info("已到达评论底部，未找到目标评论")
 				break
 			}
-		} else if !hasScrolled && checkEndContainer(page) {
-			logrus.Info("评论区可能还未加载，暂不判定为底部，继续等待...")
 		}
-		logrus.Infof("当前评论数: %d", currentCount)
-		
+
+		// 评论数增量检测
 		if currentCount != lastCommentCount {
-			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
+			logrus.Infof("评论数变化: %d -> %d", lastCommentCount, currentCount)
 			lastCommentCount = currentCount
 			stagnantChecks = 0
 		} else {
 			stagnantChecks++
 			if stagnantChecks%5 == 0 {
-				logrus.Infof("评论数停滞 %d 次", stagnantChecks)
+				logrus.Infof("评论数停滞检测: %d 次", stagnantChecks)
 			}
 		}
 
-		// === 3. 停滞检测 ===
-		if stagnantChecks >= 10 {
-			logrus.Info("评论数量停滞超过10次，可能已加载完所有评论")
+		// 停滞超过阈值，退出循环
+		if stagnantChecks >= stagnantThreshold {
+			logrus.Warnf("评论数停滞 %d 次，可能已加载完所有评论，停止查找", stagnantThreshold)
 			break
 		}
 
-		// === 4. 先滚动到最后一个评论（触发懒加载）===
+		// 滚动到最后一个可见评论，触发懒加载
 		if currentCount > 0 {
-			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-			
-			// 使用 Go 获取所有评论元素
-			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
-			if err == nil && len(elements) > 0 {
-				// 滚动到最后一个评论
-				lastComment := elements[len(elements)-1]
-				err := lastComment.ScrollIntoView()
-				if err != nil {
+			if elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment"); err == nil && len(elements) > 0 {
+				if err := elements[len(elements)-1].ScrollIntoView(); err != nil {
 					logrus.Warnf("滚动到最后一个评论失败: %v", err)
 				}
-			} else {
-				logrus.Warnf("未找到评论元素: %v", err)
 			}
 			time.Sleep(300 * time.Millisecond)
 			hasScrolled = true
 		}
 
-		// === 5. 继续向下滚动 ===
-		logrus.Infof("继续向下滚动...")
-		_, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`)
-		if err != nil {
-			logrus.Warnf("滚动失败: %v", err)
+		// 继续向下滚动页面
+		if _, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`); err != nil {
+			logrus.Warnf("页面滚动失败: %v", err)
 		}
 		hasScrolled = true
 		time.Sleep(500 * time.Millisecond)
 
-		// === 6. 滚动后立即查找（边滚动边查找）===
-		// 优先通过 commentID 查找（使用 Timeout 避免长时间等待）
+		// 查找评论元素：优先通过 commentID 精确查找
 		if commentID != "" {
 			selector := fmt.Sprintf("#comment-%s", commentID)
-			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-			
-			// 使用 Timeout 避免长时间等待
-			el, err := page.Timeout(2 * time.Second).Element(selector)
-			if err == nil && el != nil {
-				logrus.Infof("✓ 通过 commentID 找到评论: %s (尝试 %d 次)", commentID, attempt+1)
+			if el, err := page.Timeout(2 * time.Second).Element(selector); err == nil && el != nil {
+				logrus.Infof("✓ 通过 commentID 找到评论: %s", commentID)
 				return el, nil
 			}
-			logrus.Infof("未找到 commentID (2秒超时)")
 		}
 
-		// 通过 userID 查找
+		// 通过 userID 查找（需匹配评论元素）
 		if userID != "" {
-			logrus.Infof("尝试通过 userID 查找: %s", userID)
-			
-			// 使用 Timeout 避免长时间等待
-			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
-			if err == nil && len(elements) > 0 {
-				logrus.Infof("找到 %d 个评论元素", len(elements))
+			if elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment"); err == nil && len(elements) > 0 {
 				for i, el := range elements {
-					// 快速检查，不等待
-					userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID))
-					if err == nil && userEl != nil {
-						logrus.Infof("✓ 通过 userID 在第 %d 个元素中找到评论: %s (尝试 %d 次)", i+1, userID, attempt+1)
+					if userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID)); err == nil && userEl != nil {
+						logrus.Infof("✓ 通过 userID 在第 %d 个元素中找到评论: %s", i+1, userID)
 						return el, nil
 					}
 				}
-				logrus.Infof("在 %d 个元素中未找到匹配的 userID", len(elements))
-			} else {
-				logrus.Infof("获取评论元素失败或超时: %v", err)
 			}
 		}
-		
-		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
 
-		// === 7. 等待内容加载 ===
 		time.Sleep(scrollInterval)
 	}
 
-	return nil, fmt.Errorf("未找到评论 (commentID: %s, userID: %s), 尝试次数: %d", commentID, userID, maxAttempts)
+	return nil, fmt.Errorf("未找到评论 (commentID: %s, userID: %s)", commentID, userID)
 }


### PR DESCRIPTION
## Summary

修复 reply_comment_in_feed 无法找到评论的 bug，参考 https://github.com/xpzouying/xiaohongshu-mcp/issues/641

### 问题原因
_find_and_scroll_to_comment 开始滚动时评论区还未加载完成，看到底部容器就错误地退出了循环。

### 修复内容

1. **预等待评论区加载**：滚动前最多等待 30 秒让评论区加载完成
2. **hasScrolled 标志**：只有产生滚动历史（hasScrolled=true）且有评论（currentCount>0）时，才检查是否到达底部
3. **停滞检测机制**：评论数连续无增量达到阈值时退出

### 代码改进

- 使用 const block 统一管理魔法数字
- 简化嵌套逻辑，减少冗余日志
- 优化注释，提高可维护性

🤖 Generated with Claude Code