### PR TITLE
[codex] 修复图文发布时过早关闭浏览器

### DIFF
--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -33,6 +33,12 @@ type PublishAction struct {
 
 const (
 	urlOfPublic = `https://creator.xiaohongshu.com/publish/publish?source=official`
+
+	publishSuccessText             = "发布成功"
+	publishImageUploadingText      = "图片还未上传成功"
+	publishImageUploadingAltText   = "图片还未上传完成"
+	publishImageUploadingRetryWait = 5 * time.Second
+	publishSuccessTimeout          = 5 * time.Minute
 )
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
@@ -338,6 +344,22 @@ func submitPublish(page *rod.Page, title, content string, tags []string, schedul
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
+	if err := clickPublishButton(page); err != nil {
+		return err
+	}
+
+	return waitForPublishSuccess(page)
+}
+
+type publishState int
+
+const (
+	publishStateUnknown publishState = iota
+	publishStateSuccess
+	publishStateImageUploading
+)
+
+func clickPublishButton(page *rod.Page) error {
 	submitButton, err := page.Element(".publish-page-publish-btn button.bg-red")
 	if err != nil {
 		return errors.Wrap(err, "查找发布按钮失败")
@@ -346,8 +368,75 @@ func submitPublish(page *rod.Page, title, content string, tags []string, schedul
 		return errors.Wrap(err, "点击发布按钮失败")
 	}
 
-	time.Sleep(3 * time.Second)
+	slog.Info("已点击发布按钮，等待页面反馈")
 	return nil
+}
+
+func waitForPublishSuccess(page *rod.Page) error {
+	deadline := time.Now().Add(publishSuccessTimeout)
+	nextRetryAt := time.Now().Add(publishImageUploadingRetryWait)
+	sawImageUploadingHint := false
+	retryCount := 0
+
+	for time.Now().Before(deadline) {
+		state, err := getPublishState(page)
+		if err != nil {
+			slog.Warn("读取发布状态失败，继续等待", "error", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		switch state {
+		case publishStateSuccess:
+			slog.Info("检测到发布成功文案")
+			return nil
+		case publishStateImageUploading:
+			if !sawImageUploadingHint {
+				slog.Warn("检测到图片仍在上传，等待后重试发布")
+			}
+			sawImageUploadingHint = true
+		}
+
+		if sawImageUploadingHint && time.Now().After(nextRetryAt) {
+			retryCount++
+			if err := clickPublishButton(page); err != nil {
+				slog.Warn("重试点击发布按钮失败，继续等待", "retry", retryCount, "error", err)
+			} else {
+				slog.Info("已重试点击发布按钮", "retry", retryCount)
+			}
+			nextRetryAt = time.Now().Add(publishImageUploadingRetryWait)
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	return errors.Errorf("等待页面出现“%s”超时", publishSuccessText)
+}
+
+func getPublishState(page *rod.Page) (publishState, error) {
+	body, err := page.Element("body")
+	if err != nil {
+		return publishStateUnknown, errors.Wrap(err, "查找页面 body 失败")
+	}
+
+	text, err := body.Text()
+	if err != nil {
+		return publishStateUnknown, errors.Wrap(err, "读取页面文本失败")
+	}
+
+	return detectPublishState(text), nil
+}
+
+func detectPublishState(pageText string) publishState {
+	switch {
+	case strings.Contains(pageText, publishSuccessText):
+		return publishStateSuccess
+	case strings.Contains(pageText, publishImageUploadingText),
+		strings.Contains(pageText, publishImageUploadingAltText):
+		return publishStateImageUploading
+	default:
+		return publishStateUnknown
+	}
 }
 
 // waitAndClickTitleInput 在填写正文后等待 1 秒并回点标题输入框，增强后续交互稳定性

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -39,6 +39,7 @@ const (
 	publishImageUploadingAltText   = "图片还未上传完成"
 	publishImageUploadingRetryWait = 5 * time.Second
 	publishSuccessTimeout          = 5 * time.Minute
+	publishStateErrorLimit         = 30
 )
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
@@ -377,14 +378,20 @@ func waitForPublishSuccess(page *rod.Page) error {
 	nextRetryAt := time.Now().Add(publishImageUploadingRetryWait)
 	sawImageUploadingHint := false
 	retryCount := 0
+	consecutiveErrors := 0
 
 	for time.Now().Before(deadline) {
 		state, err := getPublishState(page)
 		if err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= publishStateErrorLimit {
+				return errors.Errorf("连续 %d 次读取页面状态失败，浏览器页面可能已异常: %v", consecutiveErrors, err)
+			}
 			slog.Warn("读取发布状态失败，继续等待", "error", err)
 			time.Sleep(time.Second)
 			continue
 		}
+		consecutiveErrors = 0
 
 		switch state {
 		case publishStateSuccess:
@@ -398,11 +405,15 @@ func waitForPublishSuccess(page *rod.Page) error {
 		}
 
 		if sawImageUploadingHint && time.Now().After(nextRetryAt) {
-			retryCount++
-			if err := clickPublishButton(page); err != nil {
-				slog.Warn("重试点击发布按钮失败，继续等待", "retry", retryCount, "error", err)
+			if state == publishStateImageUploading {
+				retryCount++
+				if err := clickPublishButton(page); err != nil {
+					slog.Warn("重试点击发布按钮失败，继续等待", "retry", retryCount, "error", err)
+				} else {
+					slog.Info("已重试点击发布按钮", "retry", retryCount)
+				}
 			} else {
-				slog.Info("已重试点击发布按钮", "retry", retryCount)
+				slog.Info("当前已不处于图片上传中，跳过重试点击", "state", state)
 			}
 			nextRetryAt = time.Now().Add(publishImageUploadingRetryWait)
 		}

--- a/xiaohongshu/publish_state_test.go
+++ b/xiaohongshu/publish_state_test.go
@@ -1,0 +1,40 @@
+package xiaohongshu
+
+import "testing"
+
+func TestDetectPublishState(t *testing.T) {
+	tests := []struct {
+		name     string
+		pageText string
+		want     publishState
+	}{
+		{
+			name:     "发布成功",
+			pageText: "你的笔记已提交，发布成功，稍后可在主页查看",
+			want:     publishStateSuccess,
+		},
+		{
+			name:     "图片仍在上传",
+			pageText: "封面处理中，图片还未上传成功，请稍后再试",
+			want:     publishStateImageUploading,
+		},
+		{
+			name:     "图片仍在上传-备用文案",
+			pageText: "当前图片还未上传完成，请稍后重新发布",
+			want:     publishStateImageUploading,
+		},
+		{
+			name:     "未知状态",
+			pageText: "正在保存草稿",
+			want:     publishStateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectPublishState(tt.pageText); got != tt.want {
+				t.Fatalf("detectPublishState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/xiaohongshu/publish_state_test.go
+++ b/xiaohongshu/publish_state_test.go
@@ -28,6 +28,16 @@ func TestDetectPublishState(t *testing.T) {
 			pageText: "正在保存草稿",
 			want:     publishStateUnknown,
 		},
+		{
+			name:     "空字符串",
+			pageText: "",
+			want:     publishStateUnknown,
+		},
+		{
+			name:     "成功优先于上传中",
+			pageText: "图片还未上传成功，但系统稍后提示发布成功",
+			want:     publishStateSuccess,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 变更说明

修复图文发布流程里点击“发布”后过早返回的问题。此前流程在封面图、标题、正文填写完成后，点击发布按钮仅等待约 3 秒就返回，`service` 层随即执行 `defer` 关闭浏览器。当页面此时提示“图片还未上传成功”时，浏览器被提前关闭，导致实际发布失败。

本次修改将图文发布的收口条件改为页面状态驱动：

- 首次点击发布后，持续轮询页面文本状态。
- 只有页面明确出现“发布成功”文案时，才认为发布完成并返回。
- 如果页面出现“图片还未上传成功”或“图片还未上传完成”，则保留浏览器会话，等待一段时间后重试点击发布。
- 超时后返回明确错误，避免假成功。

另外补充了一个纯逻辑单测，覆盖发布状态识别逻辑，便于后续在不依赖浏览器环境的情况下验证这段收口判断。

## 影响

- 图文发布流程在图片上传较慢时会更稳，不会因为过早关闭浏览器而中断。
- 成功返回的语义更准确，只有真正看到页面成功状态才结束流程。

## 验证

- `gofmt -w xiaohongshu/publish.go xiaohongshu/publish_state_test.go`
- `go test ./xiaohongshu -run TestDetectPublishState -count=1`
- `go test ./pkg/... -count=1`

## 备注

当前仓库里仍有一条与本次改动无关的浏览器集成测试在全量 `go test ./...` 时会失败，因此本次只执行了与改动直接相关的校验。