### PR TITLE
feat: get_feed_detail 支持 include_images 参数返回 Base64 图片

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -442,9 +442,30 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		config.ScrollSpeed = raw
 	}
 
-	logrus.Infof("MCP: 获取Feed详情 - Feed ID: %s, loadAllComments=%v, config=%+v", feedID, loadAll, config)
+	// 解析 include_images 参数
+	includeImages := false
+	if raw, ok := args["include_images"]; ok {
+		switch v := raw.(type) {
+		case bool:
+			includeImages = v
+		case string:
+			if parsed, err := strconv.ParseBool(v); err == nil {
+				includeImages = parsed
+			}
+		case float64:
+			includeImages = v != 0
+		}
+	}
 
-	result, err := s.xiaohongshuService.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAll, config)
+	logrus.Infof("MCP: 获取Feed详情 - Feed ID: %s, includeImages=%v, loadAllComments=%v, config=%+v", feedID, includeImages, loadAll, config)
+
+	var result *FeedDetailResponse
+	var err error
+	if includeImages {
+		result, err = s.xiaohongshuService.GetFeedDetailWithImages(ctx, feedID, xsecToken, loadAll, config)
+	} else {
+		result, err = s.xiaohongshuService.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAll, config)
+	}
 	if err != nil {
 		return &MCPToolResult{
 			Content: []MCPContent{{
@@ -454,6 +475,10 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 			IsError: true,
 		}
 	}
+
+	// 提取图片数据后从结果中移除，避免 base64 数据出现在 JSON 文本中
+	images := result.Images
+	result.Images = nil
 
 	// 格式化输出，转换为JSON字符串
 	jsonData, err := json.MarshalIndent(result, "", "  ")
@@ -467,12 +492,21 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		}
 	}
 
-	return &MCPToolResult{
-		Content: []MCPContent{{
-			Type: "text",
-			Text: string(jsonData),
-		}},
+	contents := []MCPContent{{
+		Type: "text",
+		Text: string(jsonData),
+	}}
+
+	// 将下载的图片作为 ImageContent 返回，LLM 可直接查看
+	for _, img := range images {
+		contents = append(contents, MCPContent{
+			Type:     "image",
+			MimeType: img.MimeType,
+			Data:     img.Data,
+		})
 	}
+
+	return &MCPToolResult{Content: contents}
 }
 
 // handleUserProfile 获取用户主页

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -57,6 +57,7 @@ type FilterOption struct {
 type FeedDetailArgs struct {
 	FeedID           string `json:"feed_id" jsonschema:"小红书笔记ID，从Feed列表获取"`
 	XsecToken        string `json:"xsec_token" jsonschema:"访问令牌，从Feed列表的xsecToken字段获取"`
+	IncludeImages    bool   `json:"include_images,omitempty" jsonschema:"是否在返回结果中包含图片内容（Base64编码）。true返回图片供LLM直接查看，false仅返回图片URL（默认）。使用预览图以控制体积"`
 	LoadAllComments  bool   `json:"load_all_comments,omitempty" jsonschema:"是否加载全部评论。false仅返回前10条一级评论（默认），true滚动加载更多评论"`
 	Limit            int    `json:"limit,omitempty" jsonschema:"【仅当load_all_comments为true时生效】限制加载的一级评论数量。例如20表示最多加载20条，默认20"`
 	ClickMoreReplies bool   `json:"click_more_replies,omitempty" jsonschema:"【仅当load_all_comments为true时生效】是否展开二级回复。true展开子评论，false不展开（默认）"`
@@ -264,7 +265,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
-			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
+			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。设置include_images=true可让LLM直接查看图片内容（Base64编码预览图）。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Feed Detail",
 				ReadOnlyHint: true,
@@ -274,6 +275,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 			argsMap := map[string]interface{}{
 				"feed_id":           args.FeedID,
 				"xsec_token":        args.XsecToken,
+				"include_images":    args.IncludeImages,
 				"load_all_comments": args.LoadAllComments,
 			}
 

--- a/service.go
+++ b/service.go
@@ -441,9 +441,10 @@ func (s *XiaohongshuService) GetFeedDetailWithImages(ctx context.Context, feedID
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	for i, img := range detailResp.Note.ImageList {
-		imageURL := img.URLDefault
+		// 优先使用预览图（体积小），回退到原图
+		imageURL := img.URLPre
 		if imageURL == "" {
-			imageURL = img.URLPre
+			imageURL = img.URLDefault
 		}
 		if imageURL == "" {
 			continue

--- a/service.go
+++ b/service.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -419,6 +423,81 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 	}
 
 	return response, nil
+}
+
+// GetFeedDetailWithImages 获取Feed详情并下载图片（Base64 编码）
+// 图片通过 HTTPS 直接下载，CDN 的 http:// URL 会自动转为 https://
+func (s *XiaohongshuService) GetFeedDetailWithImages(ctx context.Context, feedID, xsecToken string, loadAllComments bool, config xiaohongshu.CommentLoadConfig) (*FeedDetailResponse, error) {
+	response, err := s.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAllComments, config)
+	if err != nil {
+		return nil, err
+	}
+
+	detailResp, ok := response.Data.(*xiaohongshu.FeedDetailResponse)
+	if !ok || len(detailResp.Note.ImageList) == 0 {
+		return response, nil
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for i, img := range detailResp.Note.ImageList {
+		imageURL := img.URLDefault
+		if imageURL == "" {
+			imageURL = img.URLPre
+		}
+		if imageURL == "" {
+			continue
+		}
+		// CDN URL 使用 http://，但 CDN 支持且需要 https:// 才能正常访问
+		imageURL = strings.Replace(imageURL, "http://", "https://", 1)
+
+		imgData, mimeType, dlErr := downloadImageAsBase64(client, imageURL)
+		if dlErr != nil {
+			logrus.Warnf("下载图片 %d 失败: %v", i+1, dlErr)
+			continue
+		}
+
+		response.Images = append(response.Images, ImageData{
+			Data:     imgData,
+			MimeType: mimeType,
+		})
+	}
+
+	return response, nil
+}
+
+// downloadImageAsBase64 下载图片并返回 Base64 编码字符串和 MIME 类型
+func downloadImageAsBase64(client *http.Client, imageURL string) (string, string, error) {
+	req, err := http.NewRequest("GET", imageURL, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("创建请求失败: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	req.Header.Set("Referer", "https://www.xiaohongshu.com/")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("下载失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("读取失败: %w", err)
+	}
+
+	// 从 Content-Type 获取 MIME 类型，回退到检测
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" || mimeType == "application/octet-stream" {
+		mimeType = "image/webp"
+	}
+
+	return base64.StdEncoding.EncodeToString(data), mimeType, nil
 }
 
 // UserProfile 获取用户信息

--- a/types.go
+++ b/types.go
@@ -61,8 +61,15 @@ type SearchFeedsRequest struct {
 
 // FeedDetailResponse Feed详情响应
 type FeedDetailResponse struct {
-	FeedID string `json:"feed_id"`
-	Data   any    `json:"data"`
+	FeedID string      `json:"feed_id"`
+	Data   any         `json:"data"`
+	Images []ImageData `json:"images,omitempty"`
+}
+
+// ImageData 表示下载的图片数据（Base64 编码）
+type ImageData struct {
+	Data     string `json:"data"`     // Base64 编码的图片内容
+	MimeType string `json:"mimeType"` // MIME 类型，如 image/webp
 }
 
 // PostCommentRequest 发表评论请求


### PR DESCRIPTION
## 概述

Closes #653

为 `get_feed_detail` 工具新增 `include_images` 布尔参数。开启后，自动下载笔记图片并以 MCP `ImageContent`（Base64）格式返回，LLM 可直接"看到"图片内容。

## 主要改动

- **新参数 `include_images`**（默认 `false`）：向后兼容，不影响现有调用
- **图片下载**：优先使用 `URLPre`（预览图，体积小），回退到 `URLDefault`（原图）
- **CDN 适配**：小红书 CDN 实际要求 HTTPS，代码自动将 `http://` 转为 `https://`（e2e 测试中发现）
- **复用已有模式**：`get_login_qrcode` 已使用相同的 `ImageContent` 返回方式，本 PR 保持一致

## 改动文件

| 文件 | 说明 |
|------|------|
| `mcp_server.go` | 注册 `include_images` 参数 |
| `mcp_handlers.go` | 解析参数，调用图片下载，组装 `ImageContent` 响应 |
| `service.go` | 新增 `GetFeedDetailWithImages` 方法（下载 + Base64 编码） |
| `types.go` | `ImageInfo` 增加 `URLPre` 字段 |

## 使用示例

```json
{
  "tool": "get_feed_detail",
  "arguments": {
    "feed_id": "682b2d51000000000d03b965",
    "include_images": true
  }
}
```

返回结果包含：
1. 原有的 JSON 文本（笔记标题、正文、评论等）
2. 多个 `ImageContent` block（每张图片的 Base64 数据，MIME 类型自动检测）

## 测试

- `go build ./...` ✅
- `go test ./...` ✅（`pkg/downloader`、`pkg/xhsutil` 通过）
- e2e 手动验证通过（需要登录态，CI 中跳过）