### PR TITLE
Make list tools safe to consume from MCP clients

### DIFF
--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -742,3 +742,94 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 		}},
 	}
 }
+
+// handleGetCollectList 处理获取收藏夹列表
+func (s *AppServer) handleGetCollectList(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取收藏夹列表")
+
+	cursor, _ := args["cursor"].(string)
+	num := 30
+	if n, ok := args["num"].(float64); ok && n > 0 {
+		num = int(n)
+	}
+
+	result, err := s.xiaohongshuService.GetCollectList(ctx, cursor, num)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取收藏夹列表失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("获取收藏夹列表成功，但序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(jsonData)}},
+	}
+}
+
+// handleGetLikedList 处理获取点赞笔记列表
+func (s *AppServer) handleGetLikedList(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取点赞笔记列表")
+
+	num := 30
+	if n, ok := args["num"].(float64); ok && n > 0 {
+		num = int(n)
+	}
+
+	result, err := s.xiaohongshuService.GetLikedList(ctx, num)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取点赞笔记列表失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("获取点赞笔记列表成功，但序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(jsonData)}},
+	}
+}
+
+// handleGetPublishedList 处理获取已发布笔记列表
+func (s *AppServer) handleGetPublishedList(ctx context.Context, args map[string]interface{}) *MCPToolResult {
+	logrus.Info("MCP: 获取已发布笔记列表")
+
+	num := 30
+	if n, ok := args["num"].(float64); ok && n > 0 {
+		num = int(n)
+	}
+
+	result, err := s.xiaohongshuService.GetPublishedList(ctx, num)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取已发布笔记列表失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: fmt.Sprintf("序列化失败: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(jsonData)}},
+	}
+}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -100,6 +100,17 @@ type FavoriteFeedArgs struct {
 	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
+
+// CollectListArgs 获取收藏夹列表参数
+type CollectListArgs struct {
+	Cursor string `json:"cursor,omitempty" jsonschema:"分页游标，首次请求留空，翻页时传入上次响应的cursor值"`
+	Num    int    `json:"num,omitempty" jsonschema:"每页数量，默认30"`
+}
+// LikedListArgs 获取点赞笔记列表参数
+type LikedListArgs struct {
+	Num int `json:"num,omitempty" jsonschema:"每页数量，默认30"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -443,7 +454,63 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	// 工具 14: 获取收藏夹列表
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_collect_list",
+			Description: "获取当前登录用户的收藏笔记列表，返回收藏的笔记ID、标题、封面等信息",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Collect List",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_collect_list", func(ctx context.Context, req *mcp.CallToolRequest, args CollectListArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"cursor": args.Cursor,
+				"num":    args.Num,
+			}
+			result := appServer.handleGetCollectList(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 15: 获取点赞笔记列表
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_liked_list",
+			Description: "获取当前登录用户点赞的笔记列表，返回点赞笔记的ID、标题等信息",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Liked List",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_liked_list", func(ctx context.Context, req *mcp.CallToolRequest, args LikedListArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{
+				"num": float64(args.Num),
+			}
+			result := appServer.handleGetLikedList(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 16: 获取已发布笔记列表
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_published_list",
+			Description: "获取当前登录用户自己发布的笔记列表",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Published List",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_published_list", func(ctx context.Context, req *mcp.CallToolRequest, args LikedListArgs) (*mcp.CallToolResult, any, error) {
+			argsMap := map[string]interface{}{"num": float64(args.Num)}
+			result := appServer.handleGetPublishedList(ctx, argsMap)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 16)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/service.go
+++ b/service.go
@@ -598,3 +598,95 @@ func (s *XiaohongshuService) GetMyProfile(ctx context.Context) (*UserProfileResp
 
 	return response, nil
 }
+
+// CollectListRequest 收藏夹请求
+type CollectListRequest struct {
+	Cursor string `json:"cursor,omitempty"`
+	Num    int    `json:"num,omitempty"`
+}
+
+// CollectListResponse 收藏夹响应
+type CollectListResponse struct {
+	Feeds   []xiaohongshu.Feed `json:"feeds"`
+	Count   int                `json:"count"`
+	Cursor  string             `json:"cursor,omitempty"`
+	HasMore bool               `json:"has_more"`
+}
+
+// GetCollectList 获取当前登录用户的收藏笔记列表
+func (s *XiaohongshuService) GetCollectList(ctx context.Context, cursor string, num int) (*CollectListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewCollectListAction(page)
+	result, err := action.GetCollectList(ctx, cursor, num)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CollectListResponse{
+		Feeds:   result.Feeds,
+		Count:   result.Count,
+		Cursor:  result.Cursor,
+		HasMore: result.HasMore,
+	}, nil
+}
+
+// LikedListResponse 点赞笔记响应
+type LikedListResponse struct {
+	Feeds   []xiaohongshu.Feed `json:"feeds"`
+	Count   int                `json:"count"`
+	HasMore bool               `json:"has_more"`
+}
+
+// GetLikedList 获取当前登录用户点赞的笔记列表
+func (s *XiaohongshuService) GetLikedList(ctx context.Context, num int) (*LikedListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewLikedListAction(page)
+	result, err := action.GetLikedList(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LikedListResponse{
+		Feeds:   result.Feeds,
+		Count:   result.Count,
+		HasMore: result.HasMore,
+	}, nil
+}
+
+// PublishedListResponse 已发布笔记响应
+type PublishedListResponse struct {
+	Feeds   []xiaohongshu.Feed `json:"feeds"`
+	Count   int                `json:"count"`
+	HasMore bool               `json:"has_more"`
+}
+
+// GetPublishedList 获取当前登录用户已发布的笔记列表
+func (s *XiaohongshuService) GetPublishedList(ctx context.Context, num int) (*PublishedListResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewPublishedListAction(page)
+	result, err := action.GetPublishedList(ctx, num)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublishedListResponse{
+		Feeds:   result.Feeds,
+		Count:   result.Count,
+		HasMore: result.HasMore,
+	}, nil
+}

--- a/xiaohongshu/collect_list.go
+++ b/xiaohongshu/collect_list.go
@@ -122,7 +122,7 @@ func (a *CollectListAction) extractFromDOM(page *rod.Page, offset, num int) (*Co
 
 	result := page.MustEval(script).String()
 	if result == "" || result == "null" {
-		return &CollectListResponse{Feeds: []Feed{}, Count: 0}, nil
+		return &CollectListResponse{Feeds: []Feed{}, Count: 0, HasMore: false}, nil
 	}
 
 	var payload collectListDOMResult
@@ -131,7 +131,7 @@ func (a *CollectListAction) extractFromDOM(page *rod.Page, offset, num int) (*Co
 	}
 
 	// 转换为 Feed 格式
-	var feeds []Feed
+	feeds := make([]Feed, 0, len(payload.Items))
 	for _, n := range payload.Items {
 		if n.Link == "" {
 			continue

--- a/xiaohongshu/collect_list.go
+++ b/xiaohongshu/collect_list.go
@@ -1,0 +1,164 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// CollectListResponse 收藏夹响应
+type CollectListResponse struct {
+	Feeds   []Feed `json:"feeds"`
+	Count   int    `json:"count"`
+	Cursor  string `json:"cursor,omitempty"`
+	HasMore bool   `json:"has_more"`
+}
+
+// CollectListAction 负责获取用户收藏列表
+type CollectListAction struct {
+	page *rod.Page
+}
+
+func NewCollectListAction(page *rod.Page) *CollectListAction {
+	pp := page.Timeout(90 * time.Second)
+	return &CollectListAction{page: pp}
+}
+
+// GetCollectList 获取当前登录用户的收藏笔记列表
+// 实现方式：导航到用户主页 -> 点击收藏 tab -> 从 DOM 和 __INITIAL_STATE__ 读取数据
+func (a *CollectListAction) GetCollectList(ctx context.Context, cursor string, num int) (*CollectListResponse, error) {
+	page := a.page.Context(ctx)
+
+	if num <= 0 {
+		num = 30
+	}
+
+	offset, err := parseListCursor(cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	// 1. 导航到 explore 页面，触发登录态
+	logrus.Info("CollectList: navigating to profile page")
+	page.MustNavigate("https://www.xiaohongshu.com/explore")
+	page.MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+
+	// 2. 获取当前登录用户 ID
+	userID, err := getMyUserID(page)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user ID: %w", err)
+	}
+	logrus.Infof("CollectList: got user ID: %s", userID)
+
+	// 3. 直接导航到收藏 tab URL
+	profileURL := fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?tab=fav", userID)
+	page.MustNavigate(profileURL)
+	page.MustWaitDOMStable()
+	time.Sleep(4 * time.Second)
+
+	loadEnoughNoteItems(page, offset+num)
+
+	// 5. 从 DOM 抓取笔记列表
+	return a.extractFromDOM(page, offset, num)
+}
+
+// clickCollectTab 点击收藏 tab
+func (a *CollectListAction) clickCollectTab(page *rod.Page) error {
+	result := page.MustEval(`() => {
+		const tabs = Array.from(document.querySelectorAll(".reds-tab-item"));
+		const collectTab = tabs.find(t => t.textContent.trim() === "收藏");
+		if (collectTab) {
+			collectTab.click();
+			return true;
+		}
+		return false;
+	}`).Bool()
+
+	if !result {
+		return fmt.Errorf("collect tab not found")
+	}
+	logrus.Info("CollectList: clicked collect tab")
+	return nil
+}
+
+// collectNote DOM 中的笔记节点结构
+type collectNote struct {
+	Title string `json:"title"`
+	Link  string `json:"link"`
+	Img   string `json:"img"`
+}
+
+type collectListDOMResult struct {
+	Total int           `json:"total"`
+	Items []collectNote `json:"items"`
+}
+
+// extractFromDOM 从 DOM 中提取收藏笔记列表
+func (a *CollectListAction) extractFromDOM(page *rod.Page, offset, num int) (*CollectListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const items = Array.from(document.querySelectorAll(".note-item"));
+		const offset = %d;
+		const limit = %d;
+		const selected = items.slice(offset, offset + limit).map(e => {
+			const a = e.querySelector("a");
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			const img = e.querySelector("img");
+			return {
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a ? a.href : "",
+				img: img ? img.src : ""
+			};
+		});
+		return JSON.stringify({
+			total: items.length,
+			items: selected
+		});
+	}`, offset, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" {
+		return &CollectListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var payload collectListDOMResult
+	if err := json.Unmarshal([]byte(result), &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse DOM notes: %w", err)
+	}
+
+	// 转换为 Feed 格式
+	var feeds []Feed
+	for _, n := range payload.Items {
+		if n.Link == "" {
+			continue
+		}
+		// 从链接提取 feed ID
+		feedID := extractFeedID(n.Link)
+		feed := Feed{
+			ID: feedID,
+			NoteCard: NoteCard{
+				DisplayTitle: n.Title,
+			},
+		}
+		feeds = append(feeds, feed)
+	}
+
+	nextOffset := offset + len(payload.Items)
+	hasMore := payload.Total > nextOffset
+	nextCursor := ""
+	if hasMore {
+		nextCursor = fmt.Sprintf("%d", nextOffset)
+	}
+
+	logrus.Infof("CollectList: extracted %d notes from DOM", len(feeds))
+	return &CollectListResponse{
+		Feeds:   feeds,
+		Count:   len(feeds),
+		Cursor:  nextCursor,
+		HasMore: hasMore,
+	}, nil
+}

--- a/xiaohongshu/liked_list.go
+++ b/xiaohongshu/liked_list.go
@@ -1,0 +1,304 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// LikedListResponse 点赞笔记响应
+type LikedListResponse struct {
+	Feeds   []Feed `json:"feeds"`
+	Count   int    `json:"count"`
+	HasMore bool   `json:"has_more"`
+}
+
+// LikedListAction 负责获取用户点赞列表
+type LikedListAction struct {
+	page *rod.Page
+}
+
+func NewLikedListAction(page *rod.Page) *LikedListAction {
+	pp := page.Timeout(90 * time.Second)
+	return &LikedListAction{page: pp}
+}
+
+// GetLikedList 获取当前登录用户点赞的笔记列表
+func (a *LikedListAction) GetLikedList(ctx context.Context, num int) (*LikedListResponse, error) {
+	page := a.page.Context(ctx)
+
+	if num <= 0 {
+		num = 30
+	}
+
+	logrus.Info("LikedList: navigating to explore")
+	page.MustNavigate("https://www.xiaohongshu.com/explore")
+	page.MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+
+	// 获取当前登录用户 ID
+	userID, err := getMyUserID(page)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user ID: %w", err)
+	}
+	logrus.Infof("LikedList: got user ID: %s", userID)
+
+	// 导航到用户主页，等 SPA 完全初始化
+	profileURL := fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s", userID)
+	page.MustNavigate(profileURL)
+	page.MustWaitDOMStable()
+	time.Sleep(5 * time.Second)
+
+	// 点击点赞 tab
+	page.MustEval(`() => {
+		const t = Array.from(document.querySelectorAll(".reds-tab-item")).find(t => t.textContent.trim() === "点赞");
+		if (t) t.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}));
+	}`)
+	logrus.Info("LikedList: clicked 点赞 tab")
+	time.Sleep(4 * time.Second)
+
+	// 滚动加载更多内容
+	page.MustEval(`() => window.scrollTo(0, document.body.scrollHeight)`)
+	time.Sleep(2 * time.Second)
+	page.MustEval(`() => window.scrollTo(0, document.body.scrollHeight)`)
+	time.Sleep(2 * time.Second)
+
+	return a.extractAllDeduped(page, num)
+}
+
+type likedNote struct {
+	Title string `json:"title"`
+	Link  string `json:"link"`
+	Img   string `json:"img"`
+}
+
+// extractNewItems 提取点赞 tab 新出现的内容
+// 策略：去除所有重复链接后取新出现的条目
+func (a *LikedListAction) extractNewItems(page *rod.Page, noteLinksJSON string, num int) (*LikedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const noteLinks = %s;
+		const noteSet = new Set(noteLinks);
+		const seenLinks = new Set();
+		const items = Array.from(document.querySelectorAll(".note-item"));
+		const newItems = [];
+		for (const e of items) {
+			const a = e.querySelector("a");
+			if (!a || seenLinks.has(a.href)) continue;
+			seenLinks.add(a.href);
+			if (!noteSet.has(a.href)) {
+				const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+				newItems.push({
+					title: titleEl ? titleEl.textContent.trim() : "",
+					link: a.href
+				});
+			}
+			if (newItems.length >= %d) break;
+		}
+		return JSON.stringify(newItems);
+	}`, noteLinksJSON, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		logrus.Warn("LikedList: no new items found, falling back")
+		return &LikedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []likedNote
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse liked notes: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feeds = append(feeds, Feed{ID: extractFeedID(n.Link), NoteCard: NoteCard{DisplayTitle: n.Title}})
+	}
+
+	logrus.Infof("LikedList: extracted %d liked notes (deduped)", len(feeds))
+	return &LikedListResponse{Feeds: feeds, Count: len(feeds), HasMore: len(feeds) == num}, nil
+}
+
+// extractLikedOnly 从点赞 tab 中提取非发布笔记的内容
+
+// extractAllDeduped 获取点赞 tab 中所有去重的笔记
+func (a *LikedListAction) extractAllDeduped(page *rod.Page, num int) (*LikedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const seen = new Set();
+		const result = [];
+		for (const e of document.querySelectorAll(".note-item")) {
+			const a = e.querySelector("a");
+			if (!a || seen.has(a.href)) continue;
+			seen.add(a.href);
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			result.push({
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a.href
+			});
+			if (result.length >= %d) break;
+		}
+		return JSON.stringify(result);
+	}`, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		return &LikedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []likedNote
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feeds = append(feeds, Feed{ID: extractFeedID(n.Link), NoteCard: NoteCard{DisplayTitle: n.Title}})
+	}
+
+	logrus.Infof("LikedList: extracted %d liked notes (all deduped)", len(feeds))
+	return &LikedListResponse{Feeds: feeds, Count: len(feeds), HasMore: len(feeds) == num}, nil
+}
+
+func (a *LikedListAction) extractLikedOnly(page *rod.Page, publishedLinksJSON string, num int) (*LikedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const published = new Set(%s);
+		const seen = new Set();
+		const result = [];
+		for (const e of document.querySelectorAll(".note-item")) {
+			const a = e.querySelector("a");
+			if (!a || seen.has(a.href)) continue;
+			seen.add(a.href);
+			if (published.has(a.href)) continue;
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			result.push({
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a.href
+			});
+			if (result.length >= %d) break;
+		}
+		return JSON.stringify(result);
+	}`, publishedLinksJSON, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		logrus.Warn("LikedList: no liked items found")
+		return &LikedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []likedNote
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feeds = append(feeds, Feed{ID: extractFeedID(n.Link), NoteCard: NoteCard{DisplayTitle: n.Title}})
+	}
+
+	logrus.Infof("LikedList: extracted %d liked notes", len(feeds))
+	return &LikedListResponse{Feeds: feeds, Count: len(feeds), HasMore: len(feeds) == num}, nil
+}
+
+func (a *LikedListAction) extractFromDOMOffset(page *rod.Page, offset int, num int) (*LikedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const items = Array.from(document.querySelectorAll(".note-item"));
+		const total = items.length;
+		let start = %d;
+		const limit = %d;
+		// 如果 offset 超出范围，从末尾往前取 limit 条
+		if (start >= total) start = Math.max(0, total - limit);
+		return JSON.stringify(items.slice(start, start + limit).map(e => {
+			const a = e.querySelector("a");
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			const img = e.querySelector("img");
+			return {
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a ? a.href : "",
+				img: img ? img.src : ""
+			};
+		}));
+	}`, offset, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		return &LikedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []likedNote
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse DOM notes: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feedID := extractFeedID(n.Link)
+		feed := Feed{ID: feedID, NoteCard: NoteCard{DisplayTitle: n.Title}}
+		feeds = append(feeds, feed)
+	}
+
+	logrus.Infof("LikedList: extracted %d notes from DOM (offset %d)", len(feeds), offset)
+	return &LikedListResponse{Feeds: feeds, Count: len(feeds), HasMore: len(feeds) == num}, nil
+}
+
+func (a *LikedListAction) extractFromDOM(page *rod.Page, num int) (*LikedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const items = Array.from(document.querySelectorAll(".note-item"));
+		const limit = %d;
+		return JSON.stringify(items.slice(0, limit).map(e => {
+			const a = e.querySelector("a");
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			const img = e.querySelector("img");
+			return {
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a ? a.href : "",
+				img: img ? img.src : ""
+			};
+		}));
+	}`, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		return &LikedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []likedNote
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse DOM notes: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feedID := extractFeedID(n.Link)
+		feed := Feed{
+			ID: feedID,
+			NoteCard: NoteCard{
+				DisplayTitle: n.Title,
+			},
+		}
+		feeds = append(feeds, feed)
+	}
+
+	logrus.Infof("LikedList: extracted %d notes from DOM", len(feeds))
+	return &LikedListResponse{
+		Feeds:   feeds,
+		Count:   len(feeds),
+		HasMore: len(feeds) == num,
+	}, nil
+}

--- a/xiaohongshu/list_helpers.go
+++ b/xiaohongshu/list_helpers.go
@@ -1,0 +1,105 @@
+package xiaohongshu
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+func getMyUserID(page *rod.Page) (string, error) {
+	result := page.MustEval(`() => {
+		const profileLinks = Array.from(document.querySelectorAll("a[href*='user/profile']"));
+		if (profileLinks.length > 0) {
+			const match = profileLinks[0].href.match(/user\/profile\/([^/?#]+)/);
+			if (match) return match[1];
+		}
+
+		try {
+			const state = window.__INITIAL_STATE__;
+			const uid = state?.user?.userInfo?.value?.userId ||
+				state?.user?.userInfo?._value?.userId;
+			if (uid) return uid;
+		} catch (e) {}
+
+		return "";
+	}`).String()
+
+	if result == "" {
+		return "", fmt.Errorf("could not get user ID from page")
+	}
+
+	return result, nil
+}
+
+func parseListCursor(cursor string) (int, error) {
+	if cursor == "" {
+		return 0, nil
+	}
+
+	offset, err := strconv.Atoi(cursor)
+	if err != nil || offset < 0 {
+		return 0, fmt.Errorf("invalid cursor: %q", cursor)
+	}
+
+	return offset, nil
+}
+
+func loadEnoughNoteItems(page *rod.Page, target int) {
+	if target <= 0 {
+		return
+	}
+
+	lastCount := -1
+	stableRounds := 0
+
+	for i := 0; i < 8; i++ {
+		count := page.MustEval(`() => document.querySelectorAll(".note-item").length`).Int()
+		if count >= target {
+			return
+		}
+
+		if count == lastCount {
+			stableRounds++
+			if stableRounds >= 2 {
+				return
+			}
+		} else {
+			stableRounds = 0
+		}
+		lastCount = count
+
+		page.MustEval(`() => window.scrollTo(0, document.body.scrollHeight)`)
+		time.Sleep(1500 * time.Millisecond)
+	}
+}
+
+// extractFeedID 从小红书笔记 URL 中提取 feed ID
+func extractFeedID(link string) string {
+	if link == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(link)
+	if err == nil && parsed.Path != "" {
+		id := strings.Trim(path.Base(parsed.Path), "/")
+		if id != "" && id != "." {
+			return id
+		}
+	}
+
+	cleaned := link
+	if idx := strings.IndexAny(cleaned, "?#"); idx >= 0 {
+		cleaned = cleaned[:idx]
+	}
+	cleaned = strings.TrimRight(cleaned, "/")
+	if cleaned == "" {
+		return ""
+	}
+
+	return path.Base(cleaned)
+}

--- a/xiaohongshu/list_helpers_test.go
+++ b/xiaohongshu/list_helpers_test.go
@@ -1,0 +1,76 @@
+package xiaohongshu
+
+import "testing"
+
+func TestParseListCursor(t *testing.T) {
+	tests := []struct {
+		name    string
+		cursor  string
+		want    int
+		wantErr bool
+	}{
+		{name: "empty cursor", cursor: "", want: 0},
+		{name: "zero cursor", cursor: "0", want: 0},
+		{name: "positive cursor", cursor: "30", want: 30},
+		{name: "negative cursor", cursor: "-1", wantErr: true},
+		{name: "invalid cursor", cursor: "abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseListCursor(tt.cursor)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseListCursor(%q) expected error", tt.cursor)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseListCursor(%q) unexpected error: %v", tt.cursor, err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("parseListCursor(%q) = %d, want %d", tt.cursor, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFeedID(t *testing.T) {
+	tests := []struct {
+		name string
+		link string
+		want string
+	}{
+		{
+			name: "plain explore url",
+			link: "https://www.xiaohongshu.com/explore/69c6852a000000001a02cd0a",
+			want: "69c6852a000000001a02cd0a",
+		},
+		{
+			name: "url with query",
+			link: "https://www.xiaohongshu.com/explore/69c90e93000000001d019c15?xsec_token=abc&xsec_source=pc_feed",
+			want: "69c90e93000000001d019c15",
+		},
+		{
+			name: "url with fragment",
+			link: "https://www.xiaohongshu.com/explore/69c90e93000000001d019c15#comments",
+			want: "69c90e93000000001d019c15",
+		},
+		{
+			name: "bare id",
+			link: "69c90e93000000001d019c15",
+			want: "69c90e93000000001d019c15",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractFeedID(tt.link)
+			if got != tt.want {
+				t.Fatalf("extractFeedID(%q) = %q, want %q", tt.link, got, tt.want)
+			}
+		})
+	}
+}

--- a/xiaohongshu/published_list.go
+++ b/xiaohongshu/published_list.go
@@ -1,0 +1,95 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// PublishedListResponse 已发布笔记响应
+type PublishedListResponse struct {
+	Feeds   []Feed `json:"feeds"`
+	Count   int    `json:"count"`
+	HasMore bool   `json:"has_more"`
+}
+
+// PublishedListAction 负责获取用户已发布笔记列表
+type PublishedListAction struct {
+	page *rod.Page
+}
+
+func NewPublishedListAction(page *rod.Page) *PublishedListAction {
+	pp := page.Timeout(90 * time.Second)
+	return &PublishedListAction{page: pp}
+}
+
+// GetPublishedList 获取当前登录用户自己发布的笔记列表
+// URL: ?tab=note&subTab=note
+func (a *PublishedListAction) GetPublishedList(ctx context.Context, num int) (*PublishedListResponse, error) {
+	page := a.page.Context(ctx)
+
+	if num <= 0 {
+		num = 30
+	}
+
+	logrus.Info("PublishedList: navigating to explore")
+	page.MustNavigate("https://www.xiaohongshu.com/explore")
+	page.MustWaitDOMStable()
+	time.Sleep(2 * time.Second)
+
+	userID, err := getMyUserID(page)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user ID: %w", err)
+	}
+	logrus.Infof("PublishedList: got user ID: %s", userID)
+
+	// 直接导航到发布内容 tab URL
+	profileURL := fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?tab=note&subTab=note", userID)
+	page.MustNavigate(profileURL)
+	page.MustWaitDOMStable()
+	time.Sleep(4 * time.Second)
+
+	return a.extractFromDOM(page, num)
+}
+
+func (a *PublishedListAction) extractFromDOM(page *rod.Page, num int) (*PublishedListResponse, error) {
+	script := fmt.Sprintf(`() => {
+		const items = Array.from(document.querySelectorAll(".note-item"));
+		return JSON.stringify(items.slice(0, %d).map(e => {
+			const a = e.querySelector("a");
+			const titleEl = e.querySelector("footer span, [class*=title], .title, a span");
+			return {
+				title: titleEl ? titleEl.textContent.trim() : "",
+				link: a ? a.href : ""
+			};
+		}));
+	}`, num)
+
+	result := page.MustEval(script).String()
+	if result == "" || result == "null" || result == "[]" {
+		return &PublishedListResponse{Feeds: []Feed{}, Count: 0}, nil
+	}
+
+	var notes []struct {
+		Title string `json:"title"`
+		Link  string `json:"link"`
+	}
+	if err := json.Unmarshal([]byte(result), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse: %w", err)
+	}
+
+	var feeds []Feed
+	for _, n := range notes {
+		if n.Link == "" {
+			continue
+		}
+		feeds = append(feeds, Feed{ID: extractFeedID(n.Link), NoteCard: NoteCard{DisplayTitle: n.Title}})
+	}
+
+	logrus.Infof("PublishedList: extracted %d notes", len(feeds))
+	return &PublishedListResponse{Feeds: feeds, Count: len(feeds), HasMore: len(feeds) == num}, nil
+}


### PR DESCRIPTION
## Summary
- add collect/liked/published list MCP tools to source control
- make `get_collect_list` cursor pagination actually work via offset-style DOM paging
- centralize profile/feed parsing helpers and add regression tests for cursor/feed-id parsing

## Verification
- `GOPROXY=https://goproxy.cn,direct go test ./xiaohongshu -run 'Test(ParseListCursor|ExtractFeedID|FilterValidation)$'`\n- `GOPROXY=https://goproxy.cn,direct go test ./... -run '^$'`\n- `GOPROXY=https://goproxy.cn,direct go build ./...`\n\n## Notes\n- local backup artifacts (`go.mod.bak`, `xiaohongshu-mcp-darwin-arm64-new`) were intentionally left uncommitted\n- live non-empty collect/liked/published account flows still need daemon rebuild + manual verification