### PR TITLE
fix: search_feeds filter 按文本匹配，修 :nth-child 错位（closes #661 #657 #640）

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -200,12 +201,35 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 		// 等待筛选面板出现
 		page.MustWait(`() => document.querySelector('div.filter-panel') !== null`)
 
-		// 应用所有筛选条件
+		// .filters / .tags 的父节点里夹着 label，所以用 :nth-of-type 选 .filters、
+		// 按文本匹配 .tags，避免 :nth-child 数到 label 上导致错位。
 		for _, filter := range allInternalFilters {
-			selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
-				filter.FiltersIndex, filter.TagsIndex)
-			option := page.MustElement(selector)
-			option.MustClick()
+			filtersSelector := fmt.Sprintf(`div.filter-panel div.filters:nth-of-type(%d)`, filter.FiltersIndex)
+			filtersEl, err := page.Element(filtersSelector)
+			if err != nil {
+				return nil, fmt.Errorf("筛选组 %d (%s) 未找到: %w", filter.FiltersIndex, filter.Text, err)
+			}
+
+			tags, err := filtersEl.Elements("div.tags")
+			if err != nil {
+				return nil, fmt.Errorf("筛选组 %d tags 查找失败: %w", filter.FiltersIndex, err)
+			}
+
+			var matched *rod.Element
+			for _, t := range tags {
+				txt, terr := t.Text()
+				if terr != nil {
+					continue
+				}
+				if strings.TrimSpace(txt) == filter.Text {
+					matched = t
+					break
+				}
+			}
+			if matched == nil {
+				return nil, fmt.Errorf("筛选组 %d 中未找到文本 %q 的标签", filter.FiltersIndex, filter.Text)
+			}
+			matched.MustClick()
 		}
 
 		// 等待页面更新


### PR DESCRIPTION
## 问题

`search_feeds` 用 filter 的时候会点错按钮：

- @QINKAIZHOU 实测（#661）："最多评论" 点到 "最新"、"一周内" 点到 "一天内"
- @larval-zz / @ZhuYichuan / @ssz25（#657 #640）搜索直接 fail 或拿到错数据

## 根因

`xiaohongshu/search.go:205` 用的是：

```go
selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
    filter.FiltersIndex, filter.TagsIndex)
```

但小红书页面实际 DOM 是：

```html
<div class="filter-panel">
  <div class="sort-label">排序依据</div>   ← label 兄弟节点
  <div class="filters">...</div>           ← 真正的 filter 组 1
  <div class="filters">...</div>           ← filter 组 2
  ...
</div>

<div class="filters">
  <div class="filter-label">...</div>      ← label 又夹一层
  <div class="tags">综合</div>              ← tag 1
  <div class="tags">最新</div>              ← tag 2
  ...
</div>
```

`:nth-child(1)` 数到的是 label 不是 `.filters` / `.tags`，全局偏移 1 位（有时因为多个 label 偏移 2 位），就出现 "选最新点到综合" 这种错位。

而且每类 filter 前的 label 数量不一样，所以 @QINKAIZHOU 观察到的 "TagsIndex 1 和 2 都对应综合，TagsIndex 3 才对应最新" 在不同 filter 组里偏移量还不同——单纯 +1 补不回来。

## 修法

1. `.filters` 改用 `:nth-of-type(N)`——只数同类型兄弟，跳过 label
2. `.tags` 不用位置索引，直接按可见文本匹配

`internalFilterOption` 的 `Text` 字段本来就在 map 里记了每个 tag 的文本（"综合" / "最新" / "最多点赞"...），ground truth 现成的，位置索引本来就是多余的。DOM 以后再调顺序、加新 tag 也不会错位。

## Diff

只改 `xiaohongshu/search.go` 一处（+24, -4），`convertToInternalFilters` / `validateInternalFilterOption` 没动，向后兼容。

## 验证

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./xiaohongshu/ -run TestFilterValidation` ✓
- **没有跑真实浏览器/真实搜索测试**（本地没账号）。根因分析和选择器修改是 code inspection + CSS 规范推导，欢迎 reviewer 在有登录态的环境跑一下 `TestSearchWithFilters` 验证。

## 相关

Closes #661, #657, #640
同类问题之前的 search 超时修复 PR #650（还没 merge）也是我提的，不冲突。