### PR TITLE
fix: prevent indefinite hang in publish_with_video on stale titleElem

### DIFF
--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -151,9 +151,19 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string, sc
 	if err := contentElem.Input(content); err != nil {
 		return errors.Wrap(err, "输入正文失败")
 	}
-	if err := waitAndClickTitleInput(titleElem); err != nil {
-		return err
-	}
+	// Best-effort: on the video publish page, titleElem becomes stale after
+	// video processing reflows the DOM, causing the inner Click to block
+	// indefinitely (vanilla v8 hangs here until ctx cancellation, manifesting
+	// as the "假成功 / context deadline exceeded" symptom in #583, #672). The
+	// "click back to title" step exists in publish.go to retrigger Vue state
+	// for the image flow; for the video flow it is empirically unnecessary
+	// because the publish button is already enabled after video upload. Wrap
+	// in a short page-level timeout so we continue gracefully if the click
+	// can't complete within a reasonable window.
+	_ = rod.Try(func() {
+		freshTitle := page.Timeout(2 * time.Second).MustElement("div.d-input input")
+		freshTitle.MustClick()
+	})
 	if err := inputTags(contentElem, tags); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

`publish_with_video` hangs indefinitely on Linux/Docker after the video finishes uploading and never returns to the caller. This PR fixes the root cause.

## Root cause

`submitPublishVideo` (xiaohongshu/publish_video.go) calls `waitAndClickTitleInput(titleElem)` after typing the content. On the video publish page, **`titleElem` becomes stale once xhs finishes processing the uploaded video and reflows the DOM**, so the inner `Click()` blocks indefinitely (until the caller's request context is cancelled).

This manifests as a cluster of related symptoms reported in:
- #583 — \`Publish fails on WSL2/Linux: context canceled after 60s timeout\`
- #672 / #670 / #645 — \`publish_content / publish_video returns 200 but the note never appears on timeline (假成功)\`

The current code:
\`\`\`go
if err := waitAndClickTitleInput(titleElem); err != nil {
    return err
}
\`\`\`
calls Click on a stale element reference and waits forever for a CDP mouse event response that will never come.

## Fix

Empirically, the publish button is already enabled after the video upload completes (logged as \`视频上传/处理完成，发布按钮可点击\`), so the \"click back to title\" step (originally added in publish.go to retrigger Vue state for the image flow) is not strictly needed for the video flow.

The patch wraps the click in \`rod.Try\` with a short page-level timeout, **re-resolving the title element each time** so we don't reuse the stale handle, and continues gracefully if the click cannot complete:

\`\`\`go
_ = rod.Try(func() {
    freshTitle := page.Timeout(2 * time.Second).MustElement(\"div.d-input input\")
    freshTitle.MustClick()
})
\`\`\`

## Reproduction

1. Deploy vanilla v8 \`xpzouying/xiaohongshu-mcp\` on any Linux Docker host
2. Login successfully (cookies present)
3. Call \`publish_with_video\` with a small valid mp4
4. Observe server log stops at \`视频上传/处理完成，发布按钮可点击\` and never progresses
5. After ctx cancel, no error logged but no note appears on timeline

## Verification

Patched build deployed to a Tencent Cloud amd64 VM. \`publish_with_video\` returned 200 in 28s and the note appeared on the user's timeline (deleted after verification).

Server log progression after fix:
\`\`\`
开始等待发布按钮可点击(视频)
视频上传/处理完成，发布按钮可点击
[video-pub] enter submitPublishVideo
[video-pub] step1-3: title/content found and filled
[video-pub] step4: title click (best-effort with 2s timeout)
[video-pub] step5: input tags
可见范围使用默认：公开可见
开始等待发布按钮可点击(视频)  ← second wait, just before click publish
[28s total] 200 OK returned, video appeared on timeline
\`\`\`

## Notes for reviewer

- An alternative is to skip the click entirely (commented in code as such). I went with best-effort + short timeout since it preserves the original intent on platforms where the click does succeed quickly.
- A similar issue may exist in publish.go for image flow under certain conditions (\#583 mentions WSL2 image publish hangs too); not addressed here since not reproduced.

## Test plan

- [x] \`go vet ./xiaohongshu/...\` passes
- [x] \`go build ./...\` passes
- [x] End-to-end: publish_with_video returns 200 + note appears on timeline (国内 IP + amd64 + real Chrome)
- [ ] Reviewer to verify on their environment