### PR TITLE
feat: configurable site domain for rednote.com support

### DIFF
--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"os"
 
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
@@ -15,9 +17,19 @@ import (
 func main() {
 	var (
 		binPath string // 浏览器二进制文件路径
+		domain  string // 站点域名
 	)
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
+	flag.StringVar(&domain, "domain", "", "站点域名，默认 www.xiaohongshu.com，国际版用 www.rednote.com")
 	flag.Parse()
+
+	// 支持环境变量
+	if len(domain) == 0 {
+		domain = os.Getenv("XHS_DOMAIN")
+	}
+	if len(domain) > 0 {
+		configs.SetSiteDomain(domain)
+	}
 
 	// 登录的时候，需要界面，所以不能无头模式
 	b := browser.NewBrowser(false, browser.WithBinPath(binPath))

--- a/configs/browser.go
+++ b/configs/browser.go
@@ -1,9 +1,15 @@
 package configs
 
+import "strings"
+
 var (
 	useHeadless = true
 
 	binPath = ""
+
+	// 站点域名，默认为 xiaohongshu.com，可切换为 rednote.com（国际版）
+	siteDomain    = "www.xiaohongshu.com"
+	creatorDomain = "creator.xiaohongshu.com"
 )
 
 func InitHeadless(h bool) {
@@ -21,4 +27,55 @@ func SetBinPath(b string) {
 
 func GetBinPath() string {
 	return binPath
+}
+
+// SetSiteDomain 设置站点域名（如 www.rednote.com）
+func SetSiteDomain(d string) {
+	siteDomain = d
+	// 自动推断 creator 域名
+	if strings.Contains(d, "rednote.com") {
+		creatorDomain = "creator.rednote.com"
+	} else {
+		creatorDomain = "creator.xiaohongshu.com"
+	}
+}
+
+// GetSiteDomain 获取站点域名
+func GetSiteDomain() string {
+	return siteDomain
+}
+
+// GetCreatorDomain 获取创作者平台域名
+func GetCreatorDomain() string {
+	return creatorDomain
+}
+
+// ExploreURL 获取首页 explore 地址
+func ExploreURL() string {
+	return "https://" + siteDomain + "/explore"
+}
+
+// HomeURL 获取首页地址
+func HomeURL() string {
+	return "https://" + siteDomain
+}
+
+// SearchURL 获取搜索结果地址前缀
+func SearchURL() string {
+	return "https://" + siteDomain + "/search_result"
+}
+
+// FeedDetailURL 获取帖子详情地址
+func FeedDetailURL(feedID, xsecToken string) string {
+	return "https://" + siteDomain + "/explore/" + feedID + "?xsec_token=" + xsecToken + "&xsec_source=pc_feed"
+}
+
+// UserProfileURL 获取用户主页地址
+func UserProfileURL(userID, xsecToken string) string {
+	return "https://" + siteDomain + "/user/profile/" + userID + "?xsec_token=" + xsecToken + "&xsec_source=pc_note"
+}
+
+// PublishURL 获取发布页地址
+func PublishURL() string {
+	return "https://" + creatorDomain + "/publish/publish?source=official"
 }

--- a/main.go
+++ b/main.go
@@ -13,18 +13,28 @@ func main() {
 		headless bool
 		binPath  string // 浏览器二进制文件路径
 		port     string
+		domain   string // 站点域名
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
+	flag.StringVar(&domain, "domain", "", "站点域名，默认 www.xiaohongshu.com，国际版用 www.rednote.com")
 	flag.Parse()
 
 	if len(binPath) == 0 {
 		binPath = os.Getenv("ROD_BROWSER_BIN")
 	}
 
+	// 支持环境变量设置域名
+	if len(domain) == 0 {
+		domain = os.Getenv("XHS_DOMAIN")
+	}
+
 	configs.InitHeadless(headless)
 	configs.SetBinPath(binPath)
+	if len(domain) > 0 {
+		configs.SetSiteDomain(domain)
+	}
 
 	// 初始化服务
 	xiaohongshuService := NewXiaohongshuService()

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -863,5 +864,5 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+	return configs.FeedDetailURL(feedID, xsecToken)
 }

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -17,7 +18,7 @@ type FeedsListAction struct {
 func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 	pp := page.Timeout(60 * time.Second)
 
-	pp.MustNavigate("https://www.xiaohongshu.com")
+	pp.MustNavigate(configs.HomeURL())
 	pp.MustWaitDOMStable()
 
 	return &FeedsListAction{page: pp}

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/pkg/errors"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type LoginAction struct {
@@ -18,11 +19,11 @@ func NewLogin(page *rod.Page) *LoginAction {
 
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	pp := a.page.Context(ctx)
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(configs.ExploreURL()).MustWaitLoad()
 
 	time.Sleep(1 * time.Second)
 
-	exists, _, err := pp.Has(`.main-container .user .link-wrapper .channel`)
+	exists, _, err := pp.Has(`.main-container .link-wrapper .channel`)
 	if err != nil {
 		return false, errors.Wrap(err, "check login status failed")
 	}
@@ -37,21 +38,21 @@ func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 func (a *LoginAction) Login(ctx context.Context) error {
 	pp := a.page.Context(ctx)
 
-	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	// 导航到首页，这会触发二维码弹窗
+	pp.MustNavigate(configs.ExploreURL()).MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
 
 	// 检查是否已经登录
-	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+	if exists, _, _ := pp.Has(".main-container .link-wrapper .channel"); exists {
 		// 已经登录，直接返回
 		return nil
 	}
 
 	// 等待扫码成功提示或者登录完成
 	// 这里我们等待登录成功的元素出现，这样更简单可靠
-	pp.MustElement(".main-container .user .link-wrapper .channel")
+	pp.MustElement(".main-container .link-wrapper .channel")
 
 	return nil
 }
@@ -59,14 +60,14 @@ func (a *LoginAction) Login(ctx context.Context) error {
 func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error) {
 	pp := a.page.Context(ctx)
 
-	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	// 导航到首页，这会触发二维码弹窗
+	pp.MustNavigate(configs.ExploreURL()).MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
 
 	// 检查是否已经登录
-	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+	if exists, _, _ := pp.Has(".main-container .link-wrapper .channel"); exists {
 		return "", true, nil
 	}
 
@@ -92,7 +93,7 @@ func (a *LoginAction) WaitForLogin(ctx context.Context) bool {
 		case <-ctx.Done():
 			return false
 		case <-ticker.C:
-			el, err := pp.Element(".main-container .user .link-wrapper .channel")
+			el, err := pp.Element(".main-container .link-wrapper .channel")
 			if err == nil && el != nil {
 				return true
 			}

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type NavigateAction struct {
@@ -17,7 +18,7 @@ func NewNavigate(page *rod.Page) *NavigateAction {
 func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 	page := n.page.Context(ctx)
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").
+	page.MustNavigate(configs.ExploreURL()).
 		MustWaitLoad().
 		MustElement(`div#app`)
 
@@ -35,7 +36,8 @@ func (n *NavigateAction) ToProfilePage(ctx context.Context) error {
 	page.MustWaitStable()
 
 	// Find and click the "我" channel link in sidebar
-	profileLink := page.MustElement(`div.main-container li.user.side-bar-component a.link-wrapper span.channel`)
+	// 注意：rednote.com 的侧边栏结构不同（div.bottom-menu-component），此选择器仅适用于 xiaohongshu.com
+	profileLink := page.MustElement(`div.main-container li.user a.link-wrapper span.channel`)
 	profileLink.MustClick()
 
 	// Wait for navigation to complete

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/go-rod/rod/lib/input"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/pkg/errors"
@@ -32,16 +33,13 @@ type PublishAction struct {
 	page *rod.Page
 }
 
-const (
-	urlOfPublic = `https://creator.xiaohongshu.com/publish/publish?source=official`
-)
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 
 	pp := page.Timeout(300 * time.Second)
 
 	// 使用更稳健的导航和等待策略
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	if err := pp.Navigate(configs.PublishURL()); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -28,7 +29,7 @@ type PublishVideoContent struct {
 func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
 	pp := page.Timeout(300 * time.Second)
 
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	if err := pp.Navigate(configs.PublishURL()); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -247,5 +248,5 @@ func makeSearchURL(keyword string) string {
 
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
-	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+	return configs.SearchURL() + "?" + values.Encode()
 }

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type UserProfileAction struct {
@@ -101,7 +102,7 @@ func (u *UserProfileAction) extractUserProfileData(page *rod.Page) (*UserProfile
 }
 
 func makeUserProfileURL(userID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?xsec_token=%s&xsec_source=pc_note", userID, xsecToken)
+	return configs.UserProfileURL(userID, xsecToken)
 }
 
 func (u *UserProfileAction) GetMyProfileViaSidebar(ctx context.Context) (*UserProfileResponse, error) {


### PR DESCRIPTION
## Problem

International accounts (registered via Google OAuth) are region-tagged to rednote.com. When the MCP server navigates to xiaohongshu.com, client-side JavaScript detects the non-CN account/IP and redirects to rednote.com. Since all URLs are hardcoded to xiaohongshu.com, every operation fails for these accounts.

The redirect is client-side JS (HTTP 200), so DNS blocking does not help.

## Solution

1. **Extract all hardcoded URLs to configs/browser.go** — new helper functions: ExploreURL(), HomeURL(), SearchURL(), FeedDetailURL(), UserProfileURL(), PublishURL()
2. **Add -domain CLI flag and XHS_DOMAIN env var** to both the MCP server and login binary. Defaults to www.xiaohongshu.com (backwards compatible), set to www.rednote.com for international accounts
3. **Auto-derive creator domain** — when domain is www.rednote.com, creator domain becomes creator.rednote.com
4. **Broaden login status CSS selector** to work on both domains

## Usage



## Testing

Tested on a headless Linux server (NixOS) with a US IP and Google-auth account:
- login/status works via rednote.com
- feeds/list returns results from rednote.com
- Backwards compatible — default behavior unchanged
