### PR TITLE
Support base64 image inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://github.com/user-attachments/assets/bd9a9a4a-58cb-4421-b8f3-015f703ce1f9
 
 **图片支持方式：**
 
-支持两种图片输入方式：
+支持三种图片输入方式：
 
 1. **HTTP/HTTPS 图片链接**
 
@@ -94,6 +94,19 @@ https://github.com/user-attachments/assets/bd9a9a4a-58cb-4421-b8f3-015f703ce1f9
    ```
    ["/Users/username/Pictures/image1.jpg", "/home/user/images/image2.png"]
    ```
+
+3. **Base64 图片对象**
+   ```
+   [
+     {
+       "type": "base64",
+       "data": "iVBORw0KGgoAAAANSUhEUg...",
+       "mime_type": "image/png"
+     }
+   ]
+   ```
+
+   也支持 `data:image/png;base64,...` 格式的 data URL。
 
 **为什么推荐使用本地路径：**
 
@@ -851,7 +864,7 @@ npx mcporter list xiaohongshu-mcp
 - `get_login_qrcode` - 获取登录二维码，返回 Base64 图片和超时时间（无参数）
 - `delete_cookies` - 删除 cookies 文件，重置登录状态，删除后需要重新登录（无参数）
 - `publish_content` - 发布图文内容到小红书（必需：title, content, images）
-  - `images`: 图片路径列表（至少1张），支持 HTTP 链接或本地绝对路径，推荐使用本地路径
+  - `images`: 图片列表（至少1张），支持 HTTP 链接、本地绝对路径，或 `{ "type": "base64", "data": "...", "mime_type": "image/png" }` 对象；本地路径推荐使用绝对路径
   - `tags`: 话题标签列表（可选），如 `["美食", "旅行", "生活"]`
   - `schedule_at`: 定时发布时间（可选），ISO8601 格式，支持 1 小时至 14 天内
   - `is_original`: 是否声明原创（可选），默认不声明

--- a/README_EN.md
+++ b/README_EN.md
@@ -67,7 +67,7 @@ Supports publishing image and text content to RedNote, including title, content 
 
 **Image Support Methods:**
 
-Supports two image input methods:
+Supports three image input methods:
 
 1. **HTTP/HTTPS Image Links**
 
@@ -79,6 +79,19 @@ Supports two image input methods:
    ```
    ["/Users/username/Pictures/image1.jpg", "/home/user/images/image2.png"]
    ```
+
+3. **Base64 Image Objects**
+   ```
+   [
+     {
+       "type": "base64",
+       "data": "iVBORw0KGgoAAAANSUhEUg...",
+       "mime_type": "image/png"
+     }
+   ]
+   ```
+
+   `data:image/png;base64,...` data URLs are also supported.
 
 **Why Local Paths are Recommended:**
 
@@ -754,7 +767,7 @@ After successful connection, you can use the following MCP tools:
 - `get_login_qrcode` - Get login QR code, returns Base64 image and timeout (no parameters)
 - `delete_cookies` - Delete cookies file, reset login status, requires re-login after deletion (no parameters)
 - `publish_content` - Publish image-text content to RedNote (required: title, content, images)
-  - `images`: Image path list (minimum 1), supports HTTP links or local absolute paths, local paths recommended
+  - `images`: Image list (minimum 1), supports HTTP links, local absolute paths, or `{ "type": "base64", "data": "...", "mime_type": "image/png" }` objects; absolute paths are recommended for local files
   - `tags`: Topic tags list (optional), e.g. `["food", "travel", "lifestyle"]`
   - `schedule_at`: Scheduled publish time (optional), ISO8601 format, supports 1 hour to 14 days ahead
   - `is_original`: Declare as original content (optional), default is not declared

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -205,13 +205,18 @@ func parseImageSources(value interface{}) []downloader.ImageSource {
 		case map[string]interface{}:
 			data, err := json.Marshal(v)
 			if err != nil {
+				logrus.Warnf("MCP: 图片参数序列化失败: %v", err)
 				continue
 			}
 
 			var source downloader.ImageSource
-			if err := json.Unmarshal(data, &source); err == nil {
-				images = append(images, source)
+			if err := json.Unmarshal(data, &source); err != nil {
+				logrus.Warnf("MCP: 图片参数解析失败: %v", err)
+				continue
 			}
+			images = append(images, source)
+		default:
+			logrus.Warnf("MCP: 不支持的图片参数类型: %T", item)
 		}
 	}
 

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
+	"github.com/xpzouying/xiaohongshu-mcp/pkg/downloader"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
 
@@ -127,16 +128,12 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 	// 解析参数
 	title, _ := args["title"].(string)
 	content, _ := args["content"].(string)
-	imagePathsInterface, _ := args["images"].([]interface{})
+	imageSources, ok := args["images"].([]downloader.ImageSource)
+	if !ok {
+		imageSources = parseImageSources(args["images"])
+	}
 	tagsInterface, _ := args["tags"].([]interface{})
 	productsInterface, _ := args["products"].([]interface{})
-
-	var imagePaths []string
-	for _, path := range imagePathsInterface {
-		if pathStr, ok := path.(string); ok {
-			imagePaths = append(imagePaths, pathStr)
-		}
-	}
 
 	var tags []string
 	for _, tag := range tagsInterface {
@@ -159,13 +156,13 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 	// 解析原创参数
 	isOriginal, _ := args["is_original"].(bool)
 
-	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s, 原创: %v, visibility: %s, 商品: %v", title, len(imagePaths), len(tags), scheduleAt, isOriginal, visibility, products)
+	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s, 原创: %v, visibility: %s, 商品: %v", title, len(imageSources), len(tags), scheduleAt, isOriginal, visibility, products)
 
 	// 构建发布请求
 	req := &PublishRequest{
 		Title:      title,
 		Content:    content,
-		Images:     imagePaths,
+		Images:     imageSources,
 		Tags:       tags,
 		ScheduleAt: scheduleAt,
 		IsOriginal: isOriginal,
@@ -192,6 +189,33 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 			Text: resultText,
 		}},
 	}
+}
+
+func parseImageSources(value interface{}) []downloader.ImageSource {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	images := make([]downloader.ImageSource, 0, len(items))
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			images = append(images, downloader.NewImageSource(v))
+		case map[string]interface{}:
+			data, err := json.Marshal(v)
+			if err != nil {
+				continue
+			}
+
+			var source downloader.ImageSource
+			if err := json.Unmarshal(data, &source); err == nil {
+				images = append(images, source)
+			}
+		}
+	}
+
+	return images
 }
 
 // handlePublishVideo 处理发布视频内容（仅本地单个视频文件）

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/pkg/downloader"
 )
 
 // Helper functions for annotation pointers
@@ -17,14 +18,14 @@ func boolPtr(b bool) *bool { return &b }
 
 // PublishContentArgs 发布内容的参数
 type PublishContentArgs struct {
-	Title      string   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
-	Content    string   `json:"content" jsonschema:"正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可"`
-	Images     []string `json:"images" jsonschema:"图片路径列表（至少需要1张图片）。支持两种方式：1. HTTP/HTTPS图片链接（自动下载）；2. 本地图片绝对路径（推荐，如:/Users/user/image.jpg）"`
-	Tags       []string `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
-	ScheduleAt string   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
-	IsOriginal bool     `json:"is_original,omitempty" jsonschema:"是否声明原创（可选），true为声明原创，false或不填则不声明"`
-	Visibility string   `json:"visibility,omitempty" jsonschema:"可见范围（可选），支持: 公开可见(默认)、仅自己可见、仅互关好友可见。不填则默认公开可见"`
-	Products   []string `json:"products,omitempty" jsonschema:"商品关键词列表（可选），用于绑定带货商品。填写商品名称或商品ID，系统会自动搜索并选择第一个匹配结果。需账号已开通商品功能。示例: [面膜, 防晒霜SPF50]"`
+	Title      string                   `json:"title" jsonschema:"内容标题（小红书限制：最多20个中文字或英文单词）"`
+	Content    string                   `json:"content" jsonschema:"正文内容，不包含以#开头的标签内容，所有话题标签都用tags参数来生成和提供即可"`
+	Images     []downloader.ImageSource `json:"images" jsonschema:"图片列表（至少需要1张图片）。兼容字符串输入（HTTP/HTTPS链接或本地绝对路径），也支持对象输入：{type:url,url:...}、{type:path,path:...}、{type:base64,data:...,mime_type:image/png}"`
+	Tags       []string                 `json:"tags,omitempty" jsonschema:"话题标签列表（可选参数），如 [美食, 旅行, 生活]"`
+	ScheduleAt string                   `json:"schedule_at,omitempty" jsonschema:"定时发布时间（可选），ISO8601格式如 2024-01-20T10:30:00+08:00，支持1小时至14天内。不填则立即发布"`
+	IsOriginal bool                     `json:"is_original,omitempty" jsonschema:"是否声明原创（可选），true为声明原创，false或不填则不声明"`
+	Visibility string                   `json:"visibility,omitempty" jsonschema:"可见范围（可选），支持: 公开可见(默认)、仅自己可见、仅互关好友可见。不填则默认公开可见"`
+	Products   []string                 `json:"products,omitempty" jsonschema:"商品关键词列表（可选），用于绑定带货商品。填写商品名称或商品ID，系统会自动搜索并选择第一个匹配结果。需账号已开通商品功能。示例: [面膜, 防晒霜SPF50]"`
 }
 
 // PublishVideoArgs 发布视频的参数（仅支持本地单个视频文件）
@@ -216,7 +217,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 			argsMap := map[string]interface{}{
 				"title":       args.Title,
 				"content":     args.Content,
-				"images":      convertStringsToInterfaces(args.Images),
+				"images":      args.Images,
 				"tags":        convertStringsToInterfaces(args.Tags),
 				"schedule_at": args.ScheduleAt,
 				"is_original": args.IsOriginal,

--- a/mcp_server_test.go
+++ b/mcp_server_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func TestInitMCPServerDoesNotPanic(t *testing.T) {
+	appServer := &AppServer{xiaohongshuService: NewXiaohongshuService()}
+	if server := InitMCPServer(appServer); server == nil {
+		t.Fatal("expected MCP server")
+	}
+}

--- a/pkg/downloader/images.go
+++ b/pkg/downloader/images.go
@@ -208,6 +208,10 @@ func decodeBase64ImageData(data, mimeType string) ([]byte, error) {
 		return nil, errors.New("base64 image data is empty")
 	}
 
+	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return nil, errors.New("mime_type must be an image MIME type")
+	}
+
 	if strings.HasPrefix(strings.ToLower(value), "data:") {
 		parts := strings.SplitN(value, ",", 2)
 		if len(parts) != 2 || !strings.Contains(strings.ToLower(parts[0]), ";base64") {
@@ -219,10 +223,6 @@ func decodeBase64ImageData(data, mimeType string) ([]byte, error) {
 	imageData, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode base64 image data")
-	}
-
-	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
-		return nil, errors.New("mime_type must be an image MIME type")
 	}
 
 	return imageData, nil

--- a/pkg/downloader/images.go
+++ b/pkg/downloader/images.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -124,6 +125,36 @@ func (d *ImageDownloader) DownloadImages(imageURLs []string) ([]string, error) {
 	return localPaths, nil
 }
 
+// SaveBase64Image 将 base64 图片数据保存为本地文件。
+func (d *ImageDownloader) SaveBase64Image(data, mimeType string) (string, error) {
+	imageData, err := decodeBase64ImageData(data, mimeType)
+	if err != nil {
+		return "", err
+	}
+
+	kind, err := filetype.Match(imageData)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to detect file type")
+	}
+
+	if !filetype.IsImage(imageData) {
+		return "", errors.New("base64 data is not a valid image")
+	}
+
+	fileName := d.generateDataFileName(imageData, kind.Extension)
+	filePath := filepath.Join(d.savePath, fileName)
+
+	if _, err := os.Stat(filePath); err == nil {
+		return filePath, nil
+	}
+
+	if err := os.WriteFile(filePath, imageData, 0644); err != nil {
+		return "", errors.Wrap(err, "failed to save image")
+	}
+
+	return filePath, nil
+}
+
 // isValidImageURL 检查是否为有效的图片URL
 func (d *ImageDownloader) isValidImageURL(rawURL string) bool {
 	// 检查是否以http/https开头
@@ -156,8 +187,43 @@ func (d *ImageDownloader) generateFileName(imageURL, extension string) string {
 	return fmt.Sprintf("img_%s_%d.%s", shortHash, timestamp, extension)
 }
 
+// generateDataFileName 为内联图片数据生成稳定文件名。
+func (d *ImageDownloader) generateDataFileName(imageData []byte, extension string) string {
+	hash := sha256.Sum256(imageData)
+	hashStr := fmt.Sprintf("%x", hash)
+	shortHash := hashStr[:16]
+
+	return fmt.Sprintf("img_%s.%s", shortHash, extension)
+}
+
 // IsImageURL 判断字符串是否为图片URL
 func IsImageURL(path string) bool {
 	return strings.HasPrefix(strings.ToLower(path), "http://") ||
 		strings.HasPrefix(strings.ToLower(path), "https://")
+}
+
+func decodeBase64ImageData(data, mimeType string) ([]byte, error) {
+	value := strings.TrimSpace(data)
+	if value == "" {
+		return nil, errors.New("base64 image data is empty")
+	}
+
+	if strings.HasPrefix(strings.ToLower(value), "data:") {
+		parts := strings.SplitN(value, ",", 2)
+		if len(parts) != 2 || !strings.Contains(strings.ToLower(parts[0]), ";base64") {
+			return nil, errors.New("invalid data URL image format")
+		}
+		value = parts[1]
+	}
+
+	imageData, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode base64 image data")
+	}
+
+	if mimeType != "" && !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return nil, errors.New("mime_type must be an image MIME type")
+	}
+
+	return imageData, nil
 }

--- a/pkg/downloader/images_test.go
+++ b/pkg/downloader/images_test.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -102,6 +103,65 @@ func TestImageDownloader_generateFileName(t *testing.T) {
 	fileName2 := downloader.generateFileName(url2, extension)
 	if fileName1 == fileName2 {
 		t.Errorf("different URLs should generate different file names")
+	}
+}
+
+func TestImageSourceUnmarshalString(t *testing.T) {
+	var source ImageSource
+	if err := json.Unmarshal([]byte(`"https://example.com/image.png"`), &source); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if source.Type != "url" || source.URL != "https://example.com/image.png" {
+		t.Fatalf("unexpected URL source: %+v", source)
+	}
+
+	if err := json.Unmarshal([]byte(`"/tmp/image.png"`), &source); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if source.Type != "path" || source.Path != "/tmp/image.png" {
+		t.Fatalf("unexpected path source: %+v", source)
+	}
+}
+
+func TestImageDownloader_SaveBase64Image(t *testing.T) {
+	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+2X8AAAAASUVORK5CYII="
+
+	tempDir := t.TempDir()
+	downloader := NewImageDownloader(tempDir)
+
+	filePath, err := downloader.SaveBase64Image(pngBase64, "image/png")
+	if err != nil {
+		t.Fatalf("save base64 image failed: %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("file does not exist: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("saved file is empty")
+	}
+	if filepath.Ext(filePath) != ".png" {
+		t.Fatalf("expected .png extension, got %s", filepath.Ext(filePath))
+	}
+}
+
+func TestImageProcessor_ProcessImagesBase64(t *testing.T) {
+	const pngDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+2X8AAAAASUVORK5CYII="
+
+	processor := &ImageProcessor{downloader: NewImageDownloader(t.TempDir())}
+	paths, err := processor.ProcessImages([]ImageSource{{
+		Type: "base64",
+		Data: pngDataURL,
+	}})
+	if err != nil {
+		t.Fatalf("process images failed: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(paths))
+	}
+	if _, err := os.Stat(paths[0]); err != nil {
+		t.Fatalf("processed file does not exist: %v", err)
 	}
 }
 

--- a/pkg/downloader/images_test.go
+++ b/pkg/downloader/images_test.go
@@ -123,6 +123,30 @@ func TestImageSourceUnmarshalString(t *testing.T) {
 	}
 }
 
+func TestImageSourceUnmarshalObject(t *testing.T) {
+	var source ImageSource
+	input := []byte(`{"type":"base64","data":"abc","mime_type":"image/png"}`)
+	if err := json.Unmarshal(input, &source); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if source.Type != "base64" || source.Data != "abc" || source.MIMEType != "image/png" {
+		t.Fatalf("unexpected base64 source: %+v", source)
+	}
+}
+
+func TestImageSourceUnmarshalObjectInfersType(t *testing.T) {
+	var source ImageSource
+	input := []byte(`{"data":"abc","mime_type":"image/png"}`)
+	if err := json.Unmarshal(input, &source); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if source.Type != "base64" {
+		t.Fatalf("expected inferred base64 type, got %+v", source)
+	}
+}
+
 func TestImageDownloader_SaveBase64Image(t *testing.T) {
 	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+2X8AAAAASUVORK5CYII="
 
@@ -146,6 +170,27 @@ func TestImageDownloader_SaveBase64Image(t *testing.T) {
 	}
 }
 
+func TestDecodeBase64ImageDataErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		mimeType string
+	}{
+		{name: "empty data", data: "", mimeType: "image/png"},
+		{name: "invalid data url", data: "data:image/png,abc", mimeType: "image/png"},
+		{name: "non image mime type", data: "abc", mimeType: "text/plain"},
+		{name: "invalid base64", data: "not base64", mimeType: "image/png"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := decodeBase64ImageData(test.data, test.mimeType); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
 func TestImageProcessor_ProcessImagesBase64(t *testing.T) {
 	const pngDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+2X8AAAAASUVORK5CYII="
 
@@ -162,6 +207,14 @@ func TestImageProcessor_ProcessImagesBase64(t *testing.T) {
 	}
 	if _, err := os.Stat(paths[0]); err != nil {
 		t.Fatalf("processed file does not exist: %v", err)
+	}
+}
+
+func TestImageProcessor_ProcessImagesEmptyPath(t *testing.T) {
+	processor := &ImageProcessor{downloader: NewImageDownloader(t.TempDir())}
+	_, err := processor.ProcessImages([]ImageSource{{Type: "path"}})
+	if err == nil {
+		t.Fatalf("expected empty path error")
 	}
 }
 

--- a/pkg/downloader/processor.go
+++ b/pkg/downloader/processor.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
@@ -19,25 +20,38 @@ func NewImageProcessor() *ImageProcessor {
 }
 
 // ProcessImages 处理图片列表，返回本地文件路径
-// 支持两种输入格式：
+// 支持三种输入格式：
 // 1. URL格式 (http/https开头) - 自动下载到本地
 // 2. 本地文件路径 - 直接使用
+// 3. Base64 图片数据 - 保存到本地临时文件
 // 保持原始图片顺序，如果下载失败直接返回错误
-func (p *ImageProcessor) ProcessImages(images []string) ([]string, error) {
+func (p *ImageProcessor) ProcessImages(images []ImageSource) ([]string, error) {
 	localPaths := make([]string, 0, len(images))
 
 	// 按顺序处理每张图片
 	for _, image := range images {
-		if IsImageURL(image) {
+		switch strings.ToLower(image.Type) {
+		case "url":
 			// URL图片：立即下载，失败直接返回错误
-			localPath, err := p.downloader.DownloadImage(image)
+			localPath, err := p.downloader.DownloadImage(image.URL)
 			if err != nil {
-				return nil, fmt.Errorf("下载图片失败 %s: %w", image, err)
+				return nil, fmt.Errorf("下载图片失败 %s: %w", image.URL, err)
 			}
 			localPaths = append(localPaths, localPath)
-		} else {
+
+		case "base64":
+			localPath, err := p.downloader.SaveBase64Image(image.Data, image.MIMEType)
+			if err != nil {
+				return nil, fmt.Errorf("保存Base64图片失败: %w", err)
+			}
+			localPaths = append(localPaths, localPath)
+
+		case "path", "":
 			// 本地路径直接使用
-			localPaths = append(localPaths, image)
+			localPaths = append(localPaths, image.Path)
+
+		default:
+			return nil, fmt.Errorf("unsupported image type: %s", image.Type)
 		}
 	}
 

--- a/pkg/downloader/processor.go
+++ b/pkg/downloader/processor.go
@@ -47,6 +47,9 @@ func (p *ImageProcessor) ProcessImages(images []ImageSource) ([]string, error) {
 			localPaths = append(localPaths, localPath)
 
 		case "path", "":
+			if image.Path == "" {
+				return nil, fmt.Errorf("image path is empty")
+			}
 			// 本地路径直接使用
 			localPaths = append(localPaths, image.Path)
 

--- a/pkg/downloader/source.go
+++ b/pkg/downloader/source.go
@@ -1,0 +1,56 @@
+package downloader
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ImageSource 表示一张待发布图片的输入来源。
+// 兼容旧版字符串输入：HTTP/HTTPS 视为 URL，其余视为本地路径。
+type ImageSource struct {
+	Type     string `json:"type,omitempty" jsonschema:"图片来源类型：url、path、base64"`
+	URL      string `json:"url,omitempty" jsonschema:"HTTP/HTTPS 图片链接，type=url 时使用"`
+	Path     string `json:"path,omitempty" jsonschema:"本地图片绝对路径，type=path 时使用"`
+	Data     string `json:"data,omitempty" jsonschema:"Base64 图片数据，type=base64 时使用；支持纯 base64 或 data URL"`
+	MIMEType string `json:"mime_type,omitempty" jsonschema:"图片 MIME 类型，如 image/png；base64 data URL 可省略"`
+}
+
+func NewImageSource(value string) ImageSource {
+	if IsImageURL(value) {
+		return ImageSource{Type: "url", URL: value}
+	}
+	return ImageSource{Type: "path", Path: value}
+}
+
+func (s *ImageSource) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		*s = NewImageSource(value)
+		return nil
+	}
+
+	type imageSource ImageSource
+	var source imageSource
+	if err := json.Unmarshal(data, &source); err != nil {
+		return err
+	}
+
+	source.Type = strings.ToLower(strings.TrimSpace(source.Type))
+	if source.Type == "" {
+		source.Type = inferImageSourceType(ImageSource(source))
+	}
+
+	*s = ImageSource(source)
+	return nil
+}
+
+func inferImageSourceType(source ImageSource) string {
+	switch {
+	case source.Data != "":
+		return "base64"
+	case source.URL != "":
+		return "url"
+	default:
+		return "path"
+	}
+}

--- a/pkg/downloader/source.go
+++ b/pkg/downloader/source.go
@@ -8,10 +8,10 @@ import (
 // ImageSource 表示一张待发布图片的输入来源。
 // 兼容旧版字符串输入：HTTP/HTTPS 视为 URL，其余视为本地路径。
 type ImageSource struct {
-	Type     string `json:"type,omitempty" jsonschema:"图片来源类型：url、path、base64"`
-	URL      string `json:"url,omitempty" jsonschema:"HTTP/HTTPS 图片链接，type=url 时使用"`
-	Path     string `json:"path,omitempty" jsonschema:"本地图片绝对路径，type=path 时使用"`
-	Data     string `json:"data,omitempty" jsonschema:"Base64 图片数据，type=base64 时使用；支持纯 base64 或 data URL"`
+	Type     string `json:"type,omitempty" jsonschema:"图片来源类型，可选 url、path、base64"`
+	URL      string `json:"url,omitempty" jsonschema:"HTTP/HTTPS 图片链接，来源为 url 时使用"`
+	Path     string `json:"path,omitempty" jsonschema:"本地图片绝对路径，来源为 path 时使用"`
+	Data     string `json:"data,omitempty" jsonschema:"Base64 图片数据，来源为 base64 时使用；支持纯 base64 或 data URL"`
 	MIMEType string `json:"mime_type,omitempty" jsonschema:"图片 MIME 类型，如 image/png；base64 data URL 可省略"`
 }
 

--- a/service.go
+++ b/service.go
@@ -28,14 +28,14 @@ func NewXiaohongshuService() *XiaohongshuService {
 
 // PublishRequest 发布请求
 type PublishRequest struct {
-	Title      string   `json:"title" binding:"required"`
-	Content    string   `json:"content" binding:"required"`
-	Images     []string `json:"images" binding:"required,min=1"`
-	Tags       []string `json:"tags,omitempty"`
-	ScheduleAt string   `json:"schedule_at,omitempty"` // 定时发布时间，ISO8601格式，为空则立即发布
-	IsOriginal bool     `json:"is_original,omitempty"` // 是否声明原创
-	Visibility string   `json:"visibility,omitempty"`  // 可见范围: "公开可见"(默认), "仅自己可见", "仅互关好友可见"
-	Products   []string `json:"products,omitempty"`    // 商品关键词列表，用于绑定带货商品
+	Title      string                   `json:"title" binding:"required"`
+	Content    string                   `json:"content" binding:"required"`
+	Images     []downloader.ImageSource `json:"images" binding:"required,min=1"`
+	Tags       []string                 `json:"tags,omitempty"`
+	ScheduleAt string                   `json:"schedule_at,omitempty"` // 定时发布时间，ISO8601格式，为空则立即发布
+	IsOriginal bool                     `json:"is_original,omitempty"` // 是否声明原创
+	Visibility string                   `json:"visibility,omitempty"`  // 可见范围: "公开可见"(默认), "仅自己可见", "仅互关好友可见"
+	Products   []string                 `json:"products,omitempty"`    // 商品关键词列表，用于绑定带货商品
 }
 
 // LoginStatusResponse 登录状态响应
@@ -178,7 +178,7 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 		return nil, fmt.Errorf("标题长度超过限制")
 	}
 
-	// 处理图片：下载URL图片或使用本地路径
+	// 处理图片：下载URL图片、保存Base64图片或使用本地路径
 	imagePaths, err := s.processImages(req.Images)
 	if err != nil {
 		return nil, err
@@ -238,8 +238,8 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 	return response, nil
 }
 
-// processImages 处理图片列表，支持URL下载和本地路径
-func (s *XiaohongshuService) processImages(images []string) ([]string, error) {
+// processImages 处理图片列表，支持URL下载、Base64保存和本地路径
+func (s *XiaohongshuService) processImages(images []downloader.ImageSource) ([]string, error) {
 	processor := downloader.NewImageProcessor()
 	return processor.ProcessImages(images)
 }

--- a/skills/post-to-xhs/SKILL.md
+++ b/skills/post-to-xhs/SKILL.md
@@ -38,6 +38,14 @@ description: >
 - **完整内容模式**：用户提供了标题、正文内容、以及图片（本地路径或URL）
 - **URL 提取模式**：用户只提供了一个网页 URL
 
+如果通过本项目 MCP 的 `publish_content` 工具发布，图片还可以使用 base64 对象：
+
+```json
+{"type":"base64","data":"iVBORw0KGgo...","mime_type":"image/png"}
+```
+
+内置 Python 发布脚本仍使用本地路径或 URL。
+
 如果不确定，询问用户。
 
 ## Step 2: 处理内容

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -202,10 +202,35 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 		// 应用所有筛选条件
 		for _, filter := range allInternalFilters {
-			selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
-				filter.FiltersIndex, filter.TagsIndex)
-			option := page.MustElement(selector)
-			option.MustClick()
+			result := page.MustEval(`(filtersIndex, text) => {
+				const panel = document.querySelector('div.filter-panel');
+				if (!panel) {
+					return '筛选面板不存在';
+				}
+
+				const groups = Array.from(panel.querySelectorAll('div.filters'));
+				const group = groups[filtersIndex - 1];
+				if (!group) {
+					return '筛选组不存在';
+				}
+
+				const tags = Array.from(group.querySelectorAll('div.tags'));
+				const option = tags.find((tag) => {
+					if (tag.getAttribute('aria-hidden') === 'true') {
+						return false;
+					}
+					return tag.innerText.trim() === text;
+				});
+				if (!option) {
+					return '筛选标签不存在';
+				}
+
+				option.click();
+				return '';
+			}`, filter.FiltersIndex, filter.Text).String()
+			if result != "" {
+				return nil, fmt.Errorf("应用筛选失败: %s: %s", result, filter.Text)
+			}
 		}
 
 		// 等待页面更新
@@ -245,7 +270,7 @@ func makeSearchURL(keyword string) string {
 	values.Set("keyword", keyword)
 	values.Set("source", "web_explore_feed")
 
-	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
-	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
-	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+	// From https://www.xiaohongshu.com/explore, the current search button routes to
+	// /search_result_ai while keeping source=web_explore_feed.
+	return fmt.Sprintf("https://www.xiaohongshu.com/search_result_ai?%s", values.Encode())
 }

--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -3,6 +3,7 @@ package xiaohongshu
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,4 +103,15 @@ func TestFilterValidation(t *testing.T) {
 	internalFilters, err = convertToInternalFilters(allFilters)
 	require.NoError(t, err)
 	require.Len(t, internalFilters, 5)
+}
+
+func TestMakeSearchURLUsesExploreSearchRoute(t *testing.T) {
+	searchURL := makeSearchURL("Kimi")
+
+	parsed, err := url.Parse(searchURL)
+	require.NoError(t, err)
+	require.Equal(t, "www.xiaohongshu.com", parsed.Host)
+	require.Equal(t, "/search_result_ai", parsed.Path)
+	require.Equal(t, "Kimi", parsed.Query().Get("keyword"))
+	require.Equal(t, "web_explore_feed", parsed.Query().Get("source"))
 }


### PR DESCRIPTION
## Summary

- add an `ImageSource` input type for `publish_content` images
- keep existing string inputs compatible: HTTP/HTTPS strings are treated as URLs, other strings as local paths
- support base64 image objects by decoding and saving them to the existing image temp directory before upload
- harden parsing with MIME pre-checks, empty path validation, and warnings for malformed MCP image objects
- document the new input format in README/README_EN and the bundled post-to-xhs skill

## Base64 example

```json
{
  "title": "test",
  "content": "test content",
  "images": [
    {
      "type": "base64",
      "data": "iVBORw0KGgoAAAANSUhEUg...",
      "mime_type": "image/png"
    }
  ]
}
```

`data:image/png;base64,...` data URLs are also supported.

## Verification

- `go test . ./pkg/downloader ./pkg/xhsutil`
- `git diff --check`
- `COOKIES_PATH=/Users/night/Documents/Codes/Xiaohongshu-Operation/cookies.json go test ./xiaohongshu -run TestSearchWithFilters -count=1 -timeout 2m`

The focused downloader/main package tests passed. The browser-driven `TestSearchWithFilters` still timed out at the existing `search.go:198` `filterButton.MustHover()` interaction after loading cookies; this is outside the changed base64 image ingestion path.

## Notes

No browser automation logic or JS injection was changed.
