### PR TITLE
fix: adapt publish button lookup

### DIFF
--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -339,15 +339,171 @@ func submitPublish(page *rod.Page, title, content string, tags []string, schedul
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
-	submitButton, err := page.Element(".publish-page-publish-btn button.bg-red")
-	if err != nil {
-		return errors.Wrap(err, "查找发布按钮失败")
-	}
-	if err := submitButton.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return errors.Wrap(err, "点击发布按钮失败")
+	if err := clickPublishButton(page); err != nil {
+		return err
 	}
 
 	time.Sleep(3 * time.Second)
+	return nil
+}
+
+type publishButton struct {
+	elem     *rod.Element
+	isWidget bool
+}
+
+func clickPublishButton(page *rod.Page) error {
+	btn, err := waitForPublishButtonClickable(page, 15*time.Second)
+	if err != nil {
+		return err
+	}
+
+	if btn.isWidget {
+		return clickPublishWidget(page, btn.elem)
+	}
+
+	if err := btn.elem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return errors.Wrap(err, "点击发布按钮失败")
+	}
+	return nil
+}
+
+// waitForPublishButtonClickable 等待新版 xhs-publish-btn 或旧版 button.bg-red 可点击。
+func waitForPublishButtonClickable(page *rod.Page, maxWait time.Duration) (*publishButton, error) {
+	interval := 1 * time.Second
+	start := time.Now()
+	var lastDisabledReason string
+
+	slog.Info("开始等待发布按钮可点击")
+
+	for time.Since(start) < maxWait {
+		btn, disabledReason, err := findPublishButton(page)
+		if err != nil {
+			slog.Warn("查找发布按钮失败，继续等待", "error", err)
+			time.Sleep(interval)
+			continue
+		}
+		if btn != nil && disabledReason == "" {
+			return btn, nil
+		}
+		if disabledReason != "" {
+			lastDisabledReason = disabledReason
+		}
+		time.Sleep(interval)
+	}
+
+	if lastDisabledReason != "" {
+		return nil, errors.Errorf("等待发布按钮可点击超时: %s", lastDisabledReason)
+	}
+	return nil, errors.New("等待发布按钮可点击超时")
+}
+
+func findPublishButton(page *rod.Page) (*publishButton, string, error) {
+	widgets, err := page.Elements("xhs-publish-btn")
+	if err != nil {
+		return nil, "", errors.Wrap(err, "查找新版发布按钮失败")
+	}
+
+	for _, widget := range widgets {
+		if !isElementVisible(widget) {
+			continue
+		}
+
+		isPublish, err := widget.Attribute("is-publish")
+		if err != nil {
+			return nil, "", errors.Wrap(err, "读取新版发布按钮 is-publish 属性失败")
+		}
+		if isPublish != nil && *isPublish == "false" {
+			continue
+		}
+
+		submitDisabled, err := widget.Attribute("submit-disabled")
+		if err != nil {
+			return nil, "", errors.Wrap(err, "读取新版发布按钮 submit-disabled 属性失败")
+		}
+		if submitDisabled != nil && *submitDisabled == "true" {
+			return &publishButton{elem: widget, isWidget: true}, "新版发布按钮不可点击", nil
+		}
+
+		return &publishButton{elem: widget, isWidget: true}, "", nil
+	}
+
+	oldButtons, err := page.Elements(".publish-page-publish-btn button.bg-red")
+	if err != nil {
+		return nil, "", errors.Wrap(err, "查找旧版发布按钮失败")
+	}
+
+	for _, oldButton := range oldButtons {
+		if !isElementVisible(oldButton) {
+			continue
+		}
+
+		if disabled, err := oldButton.Attribute("disabled"); err != nil {
+			return nil, "", errors.Wrap(err, "读取旧版发布按钮 disabled 属性失败")
+		} else if disabled != nil {
+			return &publishButton{elem: oldButton}, "旧版发布按钮 disabled", nil
+		}
+
+		if ariaDisabled, err := oldButton.Attribute("aria-disabled"); err != nil {
+			return nil, "", errors.Wrap(err, "读取旧版发布按钮 aria-disabled 属性失败")
+		} else if ariaDisabled != nil && *ariaDisabled == "true" {
+			return &publishButton{elem: oldButton}, "旧版发布按钮 aria-disabled=true", nil
+		}
+
+		if cls, err := oldButton.Attribute("class"); err != nil {
+			return nil, "", errors.Wrap(err, "读取旧版发布按钮 class 属性失败")
+		} else if cls != nil && hasExactClass(*cls, "disabled") {
+			return &publishButton{elem: oldButton}, "旧版发布按钮包含 disabled class", nil
+		}
+
+		return &publishButton{elem: oldButton}, "", nil
+	}
+
+	return nil, "", nil
+}
+
+func clickPublishWidget(page *rod.Page, widget *rod.Element) error {
+	if err := widget.ScrollIntoView(); err != nil {
+		return errors.Wrap(err, "滚动新版发布按钮到可视区域失败")
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	shape, err := widget.Shape()
+	if err != nil {
+		return errors.Wrap(err, "获取新版发布按钮位置失败")
+	}
+	if len(shape.Quads) == 0 {
+		return errors.New("获取新版发布按钮位置失败: 无可点击区域")
+	}
+
+	quad := shape.Quads[0]
+	minX, maxX := quad[0], quad[0]
+	minY, maxY := quad[1], quad[1]
+	for i := 0; i < quad.Len(); i++ {
+		x := quad[i*2]
+		y := quad[i*2+1]
+		if x < minX {
+			minX = x
+		}
+		if x > maxX {
+			maxX = x
+		}
+		if y < minY {
+			minY = y
+		}
+		if y > maxY {
+			maxY = y
+		}
+	}
+
+	x := minX + (maxX-minX)*0.65
+	y := minY + (maxY-minY)/2
+	if err := page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {
+		return errors.Wrap(err, "移动到新版发布按钮失败")
+	}
+	if err := page.Mouse.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return errors.Wrap(err, "点击发布按钮失败")
+	}
 	return nil
 }
 

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
-	"github.com/go-rod/rod/lib/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -92,43 +90,12 @@ func uploadVideo(page *rod.Page, videoPath string) error {
 	fileInput.MustSetFiles(videoPath)
 
 	// 对于视频，等待发布按钮变为可点击即表示处理完成
-	btn, err := waitForPublishButtonClickable(pp)
+	btn, err := waitForPublishButtonClickable(pp, 10*time.Minute)
 	if err != nil {
 		return err
 	}
 	slog.Info("视频上传/处理完成，发布按钮可点击", "btn", btn)
 	return nil
-}
-
-// waitForPublishButtonClickable 等待发布按钮可点击
-func waitForPublishButtonClickable(page *rod.Page) (*rod.Element, error) {
-	maxWait := 10 * time.Minute
-	interval := 1 * time.Second
-	start := time.Now()
-	selector := ".publish-page-publish-btn button.bg-red"
-
-	slog.Info("开始等待发布按钮可点击(视频)")
-
-	for time.Since(start) < maxWait {
-		btn, err := page.Element(selector)
-		if err == nil && btn != nil {
-			// 可见性
-			vis, verr := btn.Visible()
-			if verr == nil && vis {
-				// 检查 disabled 属性
-				if disabled, _ := btn.Attribute("disabled"); disabled == nil {
-					// 再通过 class 名粗略判断不在禁用态
-					if cls, _ := btn.Attribute("class"); cls != nil && !strings.Contains(*cls, "disabled") {
-						return btn, nil
-					}
-					// 即使 class 包含 disabled，只要没有 disabled 属性，也尝试点击一次以确认
-					return btn, nil
-				}
-			}
-		}
-		time.Sleep(interval)
-	}
-	return nil, errors.New("等待发布按钮可点击超时")
 }
 
 // submitPublishVideo 填写标题、正文、标签并点击发布（等待按钮可点击后再提交）
@@ -178,15 +145,8 @@ func submitPublishVideo(page *rod.Page, title, content string, tags []string, sc
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
-	// 等待发布按钮可点击
-	btn, err := waitForPublishButtonClickable(page)
-	if err != nil {
+	if err := clickPublishButton(page); err != nil {
 		return err
-	}
-
-	// 点击发布
-	if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return errors.Wrap(err, "点击发布按钮失败")
 	}
 
 	time.Sleep(3 * time.Second)


### PR DESCRIPTION
## Summary
- prefer the new xhs-publish-btn publish control and keep the old button selector as fallback
- share publish button wait/click logic between image and video publishing
- click the new publish widget via Rod mouse coordinates after scrolling it into view

## Tests
- go test ./... -run '^$' -count=1
- go test ./xiaohongshu -run TestPublish -count=1 -timeout=30s