### PR TITLE
feat: 添加 XHS_BASE_URL 环境变量支持海外域名覆写

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -181,7 +181,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// === 2. 获取当前评论数量 ===
 		currentCount := getCommentCount(page)
 		logrus.Infof("当前评论数: %d", currentCount)
-		
+
 		if currentCount != lastCommentCount {
 			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
 			lastCommentCount = currentCount
@@ -202,7 +202,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// === 4. 先滚动到最后一个评论（触发懒加载）===
 		if currentCount > 0 {
 			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-			
+
 			// 使用 Go 获取所有评论元素
 			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
 			if err == nil && len(elements) > 0 {
@@ -231,7 +231,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		if commentID != "" {
 			selector := fmt.Sprintf("#comment-%s", commentID)
 			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-			
+
 			// 使用 Timeout 避免长时间等待
 			el, err := page.Timeout(2 * time.Second).Element(selector)
 			if err == nil && el != nil {
@@ -244,7 +244,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 		// 通过 userID 查找
 		if userID != "" {
 			logrus.Infof("尝试通过 userID 查找: %s", userID)
-			
+
 			// 使用 Timeout 避免长时间等待
 			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
 			if err == nil && len(elements) > 0 {
@@ -262,7 +262,7 @@ func findCommentElement(page *rod.Page, commentID, userID string) (*rod.Element,
 				logrus.Infof("获取评论元素失败或超时: %v", err)
 			}
 		}
-		
+
 		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
 
 		// === 7. 等待内容加载 ===

--- a/xiaohongshu/config.go
+++ b/xiaohongshu/config.go
@@ -1,0 +1,13 @@
+package xiaohongshu
+
+import (
+	"os"
+	"strings"
+)
+
+func getBaseURL() string {
+	if url := os.Getenv("XHS_BASE_URL"); url != "" {
+		return strings.TrimRight(url, "/")
+	}
+	return "https://www.xiaohongshu.com"
+}

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -863,5 +863,5 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+	return fmt.Sprintf("%s/explore/%s?xsec_token=%s&xsec_source=pc_feed", getBaseURL(), feedID, xsecToken)
 }

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -17,7 +17,7 @@ type FeedsListAction struct {
 func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 	pp := page.Timeout(60 * time.Second)
 
-	pp.MustNavigate("https://www.xiaohongshu.com")
+	pp.MustNavigate(getBaseURL())
 	pp.MustWaitDOMStable()
 
 	return &FeedsListAction{page: pp}

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -18,7 +18,7 @@ func NewLogin(page *rod.Page) *LoginAction {
 
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	pp := a.page.Context(ctx)
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(getBaseURL() + "/explore").MustWaitLoad()
 
 	time.Sleep(1 * time.Second)
 
@@ -38,7 +38,7 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(getBaseURL() + "/explore").MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
@@ -51,7 +51,9 @@ func (a *LoginAction) Login(ctx context.Context) error {
 
 	// 等待扫码成功提示或者登录完成
 	// 这里我们等待登录成功的元素出现，这样更简单可靠
-	pp.MustElement(".main-container .user .link-wrapper .channel")
+	if ok := a.WaitForLogin(ctx); !ok {
+		return errors.New("login wait failed")
+	}
 
 	return nil
 }
@@ -60,7 +62,7 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(getBaseURL() + "/explore").MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -17,7 +17,7 @@ func NewNavigate(page *rod.Page) *NavigateAction {
 func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 	page := n.page.Context(ctx)
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").
+	page.MustNavigate(getBaseURL() + "/explore").
 		MustWaitLoad().
 		MustElement(`div#app`)
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -245,7 +245,7 @@ func makeSearchURL(keyword string) string {
 	values.Set("keyword", keyword)
 	values.Set("source", "web_explore_feed")
 
-	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
-	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
-	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+	//https://www.rednote.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
+	//https://www.rednote.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
+	return fmt.Sprintf("%s/search_result?%s", getBaseURL(), values.Encode())
 }

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -101,7 +101,7 @@ func (u *UserProfileAction) extractUserProfileData(page *rod.Page) (*UserProfile
 }
 
 func makeUserProfileURL(userID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?xsec_token=%s&xsec_source=pc_note", userID, xsecToken)
+	return fmt.Sprintf("%s/user/profile/%s?xsec_token=%s&xsec_source=pc_note", getBaseURL(), userID, xsecToken)
 }
 
 func (u *UserProfileAction) GetMyProfileViaSidebar(ctx context.Context) (*UserProfileResponse, error) {


### PR DESCRIPTION
## 基本改动 | Basic Changes
添加了 `XHS_BASE_URL` 环境变量，允许在海外的用户覆写默认的 `www.xiaohongshu.com` 为 `www.rednote.com` 等域名，以解决海外访问时的自动重定向导致的 cookie / 导航问题。行为表现与 `XHS_PROXY` 相似。

## 提交 Checklist | PR Checklist
- [x] 代码已在本地运行并验证通过
- [x] 一个 PR 仅包含一个功能/修复
- [x] 附上演示截图或录屏（账号信息已打码） *注：仅为后端环境变量变更，无前端 UI 改动，故无截图*
- [x] 没有大量 JS 注入，使用 go-rod API 操作元素
- [x] 代码已格式化，注释清晰