### PR TITLE
feat: support configurable site domain for rednote.com

### DIFF
--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
@@ -15,9 +16,13 @@ import (
 func main() {
 	var (
 		binPath string // 浏览器二进制文件路径
+		domain  string // 站点域名
 	)
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
+	flag.StringVar(&domain, "domain", "", "站点域名 (默认: www.xiaohongshu.com, 海外用户可设为 www.rednote.com)")
 	flag.Parse()
+
+	configs.InitDomain(domain)
 
 	// 登录的时候，需要界面，所以不能无头模式
 	b := browser.NewBrowser(false, browser.WithBinPath(binPath))

--- a/configs/domain.go
+++ b/configs/domain.go
@@ -1,0 +1,46 @@
+package configs
+
+import "os"
+
+const (
+	// 默认域名
+	defaultDomain = "www.xiaohongshu.com"
+
+	// 创作者平台域名
+	defaultCreatorDomain = "creator.xiaohongshu.com"
+)
+
+var siteDomain = ""
+
+// InitDomain 初始化站点域名。
+// 支持通过环境变量 XHS_DOMAIN 或启动参数设置。
+// 例如: "www.rednote.com" (海外用户)
+func InitDomain(domain string) {
+	siteDomain = domain
+}
+
+// GetSiteDomain 获取站点域名。
+// 优先级: 启动参数 > 环境变量 > 默认值
+func GetSiteDomain() string {
+	if siteDomain != "" {
+		return siteDomain
+	}
+	if d := os.Getenv("XHS_DOMAIN"); d != "" {
+		return d
+	}
+	return defaultDomain
+}
+
+// GetCreatorDomain 获取创作者平台域名。
+func GetCreatorDomain() string {
+	domain := GetSiteDomain()
+	if domain == "www.rednote.com" {
+		return "creator.rednote.com"
+	}
+	return defaultCreatorDomain
+}
+
+// GetBaseURL 获取站点基础URL。
+func GetBaseURL() string {
+	return "https://" + GetSiteDomain()
+}

--- a/main.go
+++ b/main.go
@@ -13,10 +13,12 @@ func main() {
 		headless bool
 		binPath  string // 浏览器二进制文件路径
 		port     string
+		domain   string // 站点域名
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
+	flag.StringVar(&domain, "domain", "", "站点域名 (默认: www.xiaohongshu.com, 海外用户可设为 www.rednote.com)")
 	flag.Parse()
 
 	if len(binPath) == 0 {
@@ -25,6 +27,7 @@ func main() {
 
 	configs.InitHeadless(headless)
 	configs.SetBinPath(binPath)
+	configs.InitDomain(domain)
 
 	// 初始化服务
 	xiaohongshuService := NewXiaohongshuService()

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -863,5 +864,5 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+	return fmt.Sprintf("https://%s/explore/%s?xsec_token=%s&xsec_source=pc_feed", configs.GetSiteDomain(), feedID, xsecToken)
 }

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -17,7 +18,7 @@ type FeedsListAction struct {
 func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 	pp := page.Timeout(60 * time.Second)
 
-	pp.MustNavigate("https://www.xiaohongshu.com")
+	pp.MustNavigate(configs.GetBaseURL())
 	pp.MustWaitDOMStable()
 
 	return &FeedsListAction{page: pp}

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/pkg/errors"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type LoginAction struct {
@@ -18,7 +19,7 @@ func NewLogin(page *rod.Page) *LoginAction {
 
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	pp := a.page.Context(ctx)
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(configs.GetBaseURL() + "/explore").MustWaitLoad()
 
 	time.Sleep(1 * time.Second)
 
@@ -38,7 +39,7 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(configs.GetBaseURL() + "/explore").MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
@@ -60,7 +61,7 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(configs.GetBaseURL() + "/explore").MustWaitLoad()
 
 	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type NavigateAction struct {
@@ -17,7 +18,7 @@ func NewNavigate(page *rod.Page) *NavigateAction {
 func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 	page := n.page.Context(ctx)
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").
+	page.MustNavigate(configs.GetBaseURL() + "/explore").
 		MustWaitLoad().
 		MustElement(`div#app`)
 

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 // PublishImageContent 发布图文内容
@@ -32,16 +33,16 @@ type PublishAction struct {
 	page *rod.Page
 }
 
-const (
-	urlOfPublic = `https://creator.xiaohongshu.com/publish/publish?source=official`
-)
+func getPublishURL() string {
+	return "https://" + configs.GetCreatorDomain() + "/publish/publish?source=official"
+}
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 
 	pp := page.Timeout(300 * time.Second)
 
 	// 使用更稳健的导航和等待策略
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	if err := pp.Navigate(getPublishURL()); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -26,7 +26,7 @@ type PublishVideoContent struct {
 func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
 	pp := page.Timeout(300 * time.Second)
 
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	if err := pp.Navigate(getPublishURL()); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -247,5 +248,5 @@ func makeSearchURL(keyword string) string {
 
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
-	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+	return fmt.Sprintf("https://%s/search_result?%s", configs.GetSiteDomain(), values.Encode())
 }

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/configs"
 )
 
 type UserProfileAction struct {
@@ -101,7 +102,7 @@ func (u *UserProfileAction) extractUserProfileData(page *rod.Page) (*UserProfile
 }
 
 func makeUserProfileURL(userID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?xsec_token=%s&xsec_source=pc_note", userID, xsecToken)
+	return fmt.Sprintf("https://%s/user/profile/%s?xsec_token=%s&xsec_source=pc_note", configs.GetSiteDomain(), userID, xsecToken)
 }
 
 func (u *UserProfileAction) GetMyProfileViaSidebar(ctx context.Context) (*UserProfileResponse, error) {


### PR DESCRIPTION
## Problem

Users outside mainland China are served `rednote.com` instead of `xiaohongshu.com`. Since all navigation URLs were hardcoded to `www.xiaohongshu.com`, cookies set for `.rednote.com` domain were never sent by the browser — causing authentication failures for overseas users.

## Solution

Add a `-domain` flag and `XHS_DOMAIN` environment variable to configure the site domain. All hardcoded URLs now use `configs.GetSiteDomain()` / `configs.GetBaseURL()` / `configs.GetCreatorDomain()`.

### Usage

```bash
# Via flag (both MCP server and login binary)
./xiaohongshu-mcp-linux-amd64 -domain www.rednote.com
./xiaohongshu-login-linux-amd64 -domain www.rednote.com

# Via environment variable
XHS_DOMAIN=www.rednote.com ./xiaohongshu-mcp-linux-amd64
```

**Priority:** `-domain` flag > `XHS_DOMAIN` env var > default (`www.xiaohongshu.com`)

## Changes

- New: `configs/domain.go` — centralized domain configuration with `GetSiteDomain()`, `GetBaseURL()`, `GetCreatorDomain()`
- Modified: `main.go`, `cmd/login/main.go` — add `-domain` flag
- Modified: All navigation files — replace hardcoded URLs with `configs` calls

## Testing

Tested with `-domain www.rednote.com` on a US-based Linux server. Search, feed detail, and login status all work correctly with rednote.com cookies.