### PR TITLE
feat: support CloakBrowser as optional browser binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,22 @@ go run .
 go run . -headless=false
 ```
 
+**使用 CloakBrowser（可选）**：
+
+如果已经安装 CloakBrowser，可以通过 `CLOAKBROWSER_BINARY_PATH` 显式指定浏览器二进制路径：
+
+```bash
+CLOAKBROWSER_BINARY_PATH=/path/to/cloakbrowser/chrome go run .
+```
+
+也可以继续使用已有的 `-bin` 参数指定浏览器路径：
+
+```bash
+go run . -bin /path/to/cloakbrowser/chrome
+```
+
+只有显式指定 CloakBrowser 路径时才会启用 CloakBrowser 模式。启用后，程序不会覆盖浏览器自身的 User-Agent，也不会启用 `go-rod/stealth` 注入，以避免额外脚本注入与浏览器自身环境产生冲突。普通 Chrome/Chromium 启动方式保持原有行为。
+
 **配置代理（可选）**：
 
 如果需要通过代理访问，可以设置 `XHS_PROXY` 环境变量：

--- a/README_EN.md
+++ b/README_EN.md
@@ -462,6 +462,22 @@ go run .
 go run . -headless=false
 ```
 
+**Using CloakBrowser (Optional):**
+
+If CloakBrowser is installed, you can explicitly specify its browser binary with `CLOAKBROWSER_BINARY_PATH`:
+
+```bash
+CLOAKBROWSER_BINARY_PATH=/path/to/cloakbrowser/chrome go run .
+```
+
+You can also continue to use the existing `-bin` flag:
+
+```bash
+go run . -bin /path/to/cloakbrowser/chrome
+```
+
+CloakBrowser mode is enabled only when the CloakBrowser binary path is explicitly provided. In that mode, the service will not override the browser's own User-Agent and will not enable `go-rod/stealth` injection, avoiding conflicts with CloakBrowser's own runtime environment. Regular Chrome/Chromium launches keep the existing behavior.
+
 ## 1.4. Verify MCP
 
 ```bash

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -18,8 +18,7 @@ import (
 const defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
 type browserConfig struct {
-	binPath      string
-	cloakBrowser bool
+	binPath string
 }
 
 type Browser struct {
@@ -57,8 +56,8 @@ func NewBrowser(headless bool, options ...Option) *Browser {
 		opt(cfg)
 	}
 
-	binPath := resolveBrowserBinPathConfig(cfg)
-	cloakBrowser := cfg.cloakBrowser || isCloakBrowserBin(binPath)
+	binPath, explicitCloakBrowser := resolveBrowserBinPathConfig(cfg)
+	cloakBrowser := explicitCloakBrowser || isCloakBrowserBin(binPath)
 
 	l := launcher.New().
 		Headless(headless).
@@ -121,22 +120,20 @@ func (b *Browser) NewPage() *rod.Page {
 	return b.browser.MustPage()
 }
 
-func resolveBrowserBinPathConfig(cfg *browserConfig) string {
+func resolveBrowserBinPathConfig(cfg *browserConfig) (string, bool) {
 	if cfg.binPath != "" {
-		return cfg.binPath
+		return cfg.binPath, false
 	}
 	if envPath := os.Getenv("ROD_BROWSER_BIN"); envPath != "" {
-		return envPath
+		return envPath, false
 	}
 	if envPath := os.Getenv("CLOAKBROWSER_BINARY_PATH"); envPath != "" {
-		cfg.cloakBrowser = true
-		return envPath
+		return envPath, true
 	}
-	return ""
+	return "", false
 }
 
 func isCloakBrowserBin(binPath string) bool {
 	normalized := strings.ToLower(filepath.ToSlash(binPath))
-	return strings.Contains(normalized, "cloakbrowser") ||
-		strings.Contains(normalized, ".cloakbrowser")
+	return strings.Contains(normalized, "cloakbrowser")
 }

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -1,16 +1,32 @@
 package browser
 
 import (
+	"encoding/json"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/go-rod/stealth"
 	"github.com/sirupsen/logrus"
-	"github.com/xpzouying/headless_browser"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 )
 
+const defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
 type browserConfig struct {
-	binPath string
+	binPath      string
+	cloakBrowser bool
+}
+
+type Browser struct {
+	browser      *rod.Browser
+	launcher     *launcher.Launcher
+	useStealth   bool
+	cloakBrowser bool
 }
 
 type Option func(*browserConfig)
@@ -35,35 +51,92 @@ func maskProxyCredentials(proxyURL string) string {
 	return u.String()
 }
 
-func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
+func NewBrowser(headless bool, options ...Option) *Browser {
 	cfg := &browserConfig{}
 	for _, opt := range options {
 		opt(cfg)
 	}
 
-	opts := []headless_browser.Option{
-		headless_browser.WithHeadless(headless),
-	}
-	if cfg.binPath != "" {
-		opts = append(opts, headless_browser.WithChromeBinPath(cfg.binPath))
+	binPath := resolveBrowserBinPathConfig(cfg)
+	cloakBrowser := cfg.cloakBrowser || isCloakBrowserBin(binPath)
+
+	l := launcher.New().
+		Headless(headless).
+		Set("--no-sandbox")
+
+	if binPath != "" {
+		l = l.Bin(binPath)
 	}
 
-	// Read proxy from environment variable
+	if !cloakBrowser {
+		l = l.Set("user-agent", defaultUserAgent)
+	} else {
+		logrus.Infof("Using CloakBrowser binary: %s", binPath)
+	}
+
+	// Read proxy from environment variable.
 	if proxy := os.Getenv("XHS_PROXY"); proxy != "" {
-		opts = append(opts, headless_browser.WithProxy(proxy))
+		l = l.Proxy(proxy)
 		logrus.Infof("Using proxy: %s", maskProxyCredentials(proxy))
 	}
 
-	// 加载 cookies
+	url := l.MustLaunch()
+	rodBrowser := rod.New().
+		ControlURL(url).
+		MustConnect()
+
+	// Load cookies.
 	cookiePath := cookies.GetCookiesFilePath()
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
 
 	if data, err := cookieLoader.LoadCookies(); err == nil {
-		opts = append(opts, headless_browser.WithCookies(string(data)))
-		logrus.Debugf("loaded cookies from filesuccessfully")
+		var cks []*proto.NetworkCookie
+		if err = json.Unmarshal(data, &cks); err != nil {
+			logrus.Warnf("failed to unmarshal cookies: %v", err)
+		} else {
+			rodBrowser.MustSetCookies(cks...)
+			logrus.Debugf("loaded cookies from file successfully")
+		}
 	} else {
 		logrus.Warnf("failed to load cookies: %v", err)
 	}
 
-	return headless_browser.New(opts...)
+	return &Browser{
+		browser:      rodBrowser,
+		launcher:     l,
+		useStealth:   !cloakBrowser,
+		cloakBrowser: cloakBrowser,
+	}
+}
+
+func (b *Browser) Close() {
+	b.browser.MustClose()
+	b.launcher.Cleanup()
+}
+
+func (b *Browser) NewPage() *rod.Page {
+	if b.useStealth {
+		return stealth.MustPage(b.browser)
+	}
+	return b.browser.MustPage()
+}
+
+func resolveBrowserBinPathConfig(cfg *browserConfig) string {
+	if cfg.binPath != "" {
+		return cfg.binPath
+	}
+	if envPath := os.Getenv("ROD_BROWSER_BIN"); envPath != "" {
+		return envPath
+	}
+	if envPath := os.Getenv("CLOAKBROWSER_BINARY_PATH"); envPath != "" {
+		cfg.cloakBrowser = true
+		return envPath
+	}
+	return ""
+}
+
+func isCloakBrowserBin(binPath string) bool {
+	normalized := strings.ToLower(filepath.ToSlash(binPath))
+	return strings.Contains(normalized, "cloakbrowser") ||
+		strings.Contains(normalized, ".cloakbrowser")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-rod/rod v0.116.2
+	github.com/go-rod/stealth v0.4.9
 	github.com/h2non/filetype v1.1.3
 	github.com/modelcontextprotocol/go-sdk v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
-	github.com/xpzouying/headless_browser v0.3.0
 )
 
 require (
@@ -25,7 +25,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
-	github.com/go-rod/stealth v0.4.9 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,6 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/xpzouying/headless_browser v0.2.0 h1:EmuHXDVzx0tAevHJUdETs8iT/eK+QqrLiybvGd1xZDA=
-github.com/xpzouying/headless_browser v0.2.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
-github.com/xpzouying/headless_browser v0.3.0 h1:ila/Kmei1dvBbP71SXEQuWfLuvjCw5HMqsgOzK39xn0=
-github.com/xpzouying/headless_browser v0.3.0/go.mod h1:bQTSzGYHIipa1zwToMlOGHcXWDlvw8y33Cx5zzElekc=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/ysmood/fetchup v0.2.3 h1:ulX+SonA0Vma5zUFXtv52Kzip/xe7aj4vqT5AJwQ+ZQ=

--- a/service.go
+++ b/service.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
-	"github.com/xpzouying/headless_browser"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
@@ -545,7 +544,7 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 	}, nil
 }
 
-func newBrowser() *headless_browser.Browser {
+func newBrowser() *browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(), browser.WithBinPath(configs.GetBinPath()))
 }
 

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -646,28 +646,12 @@ func inputTag(contentElem *rod.Element, tag string) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	time.Sleep(1 * time.Second)
-
-	page := contentElem.Page()
-	topicContainer, err := page.Element("#creator-editor-topic-container")
-	if err != nil || topicContainer == nil {
-		slog.Warn("未找到标签联想下拉框，直接输入空格", "tag", tag)
-		return contentElem.Input(" ")
-	}
-
-	firstItem, err := topicContainer.Element(".item")
-	if err != nil || firstItem == nil {
-		slog.Warn("未找到标签联想选项，直接输入空格", "tag", tag)
-		return contentElem.Input(" ")
-	}
-
-	if err := firstItem.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return errors.Wrap(err, "点击标签联想选项失败")
-	}
-	slog.Info("成功点击标签联想选项", "tag", tag)
 	time.Sleep(200 * time.Millisecond)
-
-	time.Sleep(500 * time.Millisecond) // 等待标签处理完成
+	if err := contentElem.Input(" "); err != nil {
+		return errors.Wrap(err, "输入标签确认空格失败")
+	}
+	slog.Info("已直接输入标签并用空格确认", "tag", tag)
+	time.Sleep(200 * time.Millisecond)
 	return nil
 }
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -26,43 +28,44 @@ type FilterOption struct {
 	Location    string `json:"location,omitempty" jsonschema:"位置距离: 不限|同城|附近,默认为'不限'"`
 }
 
-// internalFilterOption 内部使用的筛选选项(基于索引)
+// internalFilterOption 内部使用的筛选选项
 type internalFilterOption struct {
 	FiltersIndex int    // 筛选组索引
 	TagsIndex    int    // 标签索引
+	GroupText    string // 筛选组标题
 	Text         string // 标签文本描述
 }
 
 // 预定义的筛选选项映射表（内部使用）
 var filterOptionsMap = map[int][]internalFilterOption{
 	1: { // 排序依据
-		{FiltersIndex: 1, TagsIndex: 1, Text: "综合"},
-		{FiltersIndex: 1, TagsIndex: 2, Text: "最新"},
-		{FiltersIndex: 1, TagsIndex: 3, Text: "最多点赞"},
-		{FiltersIndex: 1, TagsIndex: 4, Text: "最多评论"},
-		{FiltersIndex: 1, TagsIndex: 5, Text: "最多收藏"},
+		{FiltersIndex: 1, TagsIndex: 1, GroupText: "排序依据", Text: "综合"},
+		{FiltersIndex: 1, TagsIndex: 2, GroupText: "排序依据", Text: "最新"},
+		{FiltersIndex: 1, TagsIndex: 3, GroupText: "排序依据", Text: "最多点赞"},
+		{FiltersIndex: 1, TagsIndex: 4, GroupText: "排序依据", Text: "最多评论"},
+		{FiltersIndex: 1, TagsIndex: 5, GroupText: "排序依据", Text: "最多收藏"},
 	},
 	2: { // 笔记类型
-		{FiltersIndex: 2, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 2, TagsIndex: 2, Text: "视频"},
-		{FiltersIndex: 2, TagsIndex: 3, Text: "图文"},
+		{FiltersIndex: 2, TagsIndex: 1, GroupText: "笔记类型", Text: "不限"},
+		{FiltersIndex: 2, TagsIndex: 2, GroupText: "笔记类型", Text: "视频"},
+		{FiltersIndex: 2, TagsIndex: 3, GroupText: "笔记类型", Text: "图文"},
 	},
 	3: { // 发布时间
-		{FiltersIndex: 3, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 3, TagsIndex: 2, Text: "一天内"},
-		{FiltersIndex: 3, TagsIndex: 3, Text: "一周内"},
-		{FiltersIndex: 3, TagsIndex: 4, Text: "半年内"},
+		{FiltersIndex: 3, TagsIndex: 1, GroupText: "发布时间", Text: "不限"},
+		{FiltersIndex: 3, TagsIndex: 2, GroupText: "发布时间", Text: "一天内"},
+		{FiltersIndex: 3, TagsIndex: 3, GroupText: "发布时间", Text: "一周内"},
+		{FiltersIndex: 3, TagsIndex: 4, GroupText: "发布时间", Text: "半年内"},
 	},
 	4: { // 搜索范围
-		{FiltersIndex: 4, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 4, TagsIndex: 2, Text: "已看过"},
-		{FiltersIndex: 4, TagsIndex: 3, Text: "未看过"},
-		{FiltersIndex: 4, TagsIndex: 4, Text: "已关注"},
+		{FiltersIndex: 4, TagsIndex: 1, GroupText: "搜索范围", Text: "不限"},
+		{FiltersIndex: 4, TagsIndex: 2, GroupText: "搜索范围", Text: "已看过"},
+		{FiltersIndex: 4, TagsIndex: 3, GroupText: "搜索范围", Text: "未看过"},
+		{FiltersIndex: 4, TagsIndex: 4, GroupText: "搜索范围", Text: "已关注"},
 	},
 	5: { // 位置距离
-		{FiltersIndex: 5, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 5, TagsIndex: 2, Text: "同城"},
-		{FiltersIndex: 5, TagsIndex: 3, Text: "附近"},
+		{FiltersIndex: 5, TagsIndex: 1, GroupText: "位置距离", Text: "不限"},
+		{FiltersIndex: 5, TagsIndex: 2, GroupText: "位置距离", Text: "同城"},
+		{FiltersIndex: 5, TagsIndex: 3, GroupText: "位置距离", Text: "附近"},
 	},
 }
 
@@ -169,52 +172,28 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	page := s.page.Context(ctx)
 
 	searchURL := makeSearchURL(keyword)
-	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	if err := page.Navigate(searchURL); err != nil {
+		return nil, fmt.Errorf("搜索页导航失败: %w", err)
+	}
+	if err := page.Timeout(5 * time.Second).WaitStable(500 * time.Millisecond); err != nil {
+		logrus.Warnf("等待搜索页稳定失败，继续尝试读取结果: %v", err)
+	}
 
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	if err := waitForInitialState(page); err != nil {
+		return nil, err
+	}
 
 	// 如果有筛选条件，则应用筛选
 	if len(filters) > 0 {
-		// 将所有 FilterOption 转换为内部筛选选项
-		var allInternalFilters []internalFilterOption
-		for _, filter := range filters {
-			internalFilters, err := convertToInternalFilters(filter)
-			if err != nil {
-				return nil, fmt.Errorf("筛选选项转换失败: %w", err)
-			}
-			allInternalFilters = append(allInternalFilters, internalFilters...)
+		filterCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		filterPage := page.Context(filterCtx)
+		if err := s.applyFilters(filterPage, filters...); err != nil {
+			logrus.Warnf("搜索筛选应用失败，降级为未筛选搜索结果: %v", err)
 		}
-
-		// 验证所有内部筛选选项
-		for _, filter := range allInternalFilters {
-			if err := validateInternalFilterOption(filter); err != nil {
-				return nil, fmt.Errorf("筛选选项验证失败: %w", err)
-			}
-		}
-
-		// 悬停在筛选按钮上
-		filterButton := page.MustElement(`div.filter`)
-		filterButton.MustHover()
-
-		// 等待筛选面板出现
-		page.MustWait(`() => document.querySelector('div.filter-panel') !== null`)
-
-		// 应用所有筛选条件
-		for _, filter := range allInternalFilters {
-			selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
-				filter.FiltersIndex, filter.TagsIndex)
-			option := page.MustElement(selector)
-			option.MustClick()
-		}
-
-		// 等待页面更新
-		page.MustWaitStable()
-		// 重新等待 __INITIAL_STATE__ 更新
-		page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+		cancel()
 	}
 
-	result := page.MustEval(`() => {
+	resultObj, err := page.Timeout(10 * time.Second).Evaluate(rod.Eval(`() => {
 		if (window.__INITIAL_STATE__ &&
 		    window.__INITIAL_STATE__.search &&
 		    window.__INITIAL_STATE__.search.feeds) {
@@ -225,7 +204,11 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 			}
 		}
 		return "";
-	}`).String()
+	}`))
+	if err != nil {
+		return nil, fmt.Errorf("读取搜索结果失败: %w", err)
+	}
+	result := resultObj.Value.String()
 
 	if result == "" {
 		return nil, errors.ErrNoFeeds
@@ -237,6 +220,271 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	}
 
 	return feeds, nil
+}
+
+func waitForInitialState(page *rod.Page) error {
+	if err := page.Timeout(15 * time.Second).Wait(rod.Eval(`() => window.__INITIAL_STATE__ !== undefined`)); err != nil {
+		return fmt.Errorf("等待搜索结果初始化失败: %w", err)
+	}
+	return nil
+}
+
+func (s *SearchAction) applyFilters(page *rod.Page, filters ...FilterOption) error {
+	allInternalFilters, err := convertFilters(filters...)
+	if err != nil {
+		return err
+	}
+	if len(allInternalFilters) == 0 {
+		return nil
+	}
+
+	if err := openFilterPanel(page); err != nil {
+		return err
+	}
+
+	for _, filter := range allInternalFilters {
+		if err := clickFilterOptionByText(page, filter); err != nil {
+			return err
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	time.Sleep(time.Second)
+	return nil
+}
+
+func convertFilters(filters ...FilterOption) ([]internalFilterOption, error) {
+	var allInternalFilters []internalFilterOption
+	for _, filter := range filters {
+		internalFilters, err := convertToInternalFilters(filter)
+		if err != nil {
+			return nil, fmt.Errorf("筛选选项转换失败: %w", err)
+		}
+		allInternalFilters = append(allInternalFilters, internalFilters...)
+	}
+
+	for _, filter := range allInternalFilters {
+		if err := validateInternalFilterOption(filter); err != nil {
+			return nil, fmt.Errorf("筛选选项验证失败: %w", err)
+		}
+	}
+	return allInternalFilters, nil
+}
+
+func openFilterPanel(page *rod.Page) error {
+	filterButton, err := page.Timeout(5 * time.Second).Element(`div.filter`)
+	if err != nil {
+		return fmt.Errorf("未找到筛选按钮: %w", err)
+	}
+	if err := filterButton.Hover(); err != nil {
+		return fmt.Errorf("悬停筛选按钮失败: %w", err)
+	}
+	if err := page.Timeout(5 * time.Second).Wait(rod.Eval(`() => document.querySelector('div.filter-panel') !== null`)); err != nil {
+		return fmt.Errorf("筛选面板未出现: %w", err)
+	}
+	return nil
+}
+
+func clickFilterOptionByText(page *rod.Page, filter internalFilterOption) error {
+	if err := openFilterPanel(page); err != nil {
+		return err
+	}
+
+	active, err := filterOptionActiveByJS(page, filter)
+	if err == nil && active {
+		logrus.Debugf("搜索筛选已处于选中状态: %s=%s", filter.GroupText, filter.Text)
+		return nil
+	}
+	if err != nil {
+		logrus.Debugf("读取搜索筛选状态失败，继续尝试点击: %v", err)
+	}
+
+	if err := clickSearchFilterOption(page, filter); err != nil {
+		return fmt.Errorf("点击筛选项 %s=%s 失败: %w", filter.GroupText, filter.Text, err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	active, err = filterOptionActiveByJS(page, filter)
+	if err == nil && active {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return fmt.Errorf("筛选项点击后未变为选中状态: %s=%s", filter.GroupText, filter.Text)
+}
+
+func filterOptionActiveByJS(page *rod.Page, filter internalFilterOption) (bool, error) {
+	res, err := page.Timeout(2 * time.Second).Evaluate(rod.Eval(`(groupText, targetText) => {
+		const visible = (el) => {
+			const style = window.getComputedStyle(el);
+			const rect = el.getBoundingClientRect();
+			return style.display !== 'none'
+				&& style.visibility !== 'hidden'
+				&& Number(style.opacity) !== 0
+				&& rect.width > 0
+				&& rect.height > 0;
+		};
+		const groups = [...document.querySelectorAll('div.filter-panel div.filters')].filter(visible);
+		const group = groups.find(el => (el.innerText || '').includes(groupText));
+		if (!group) return false;
+		const tags = [...group.querySelectorAll('div.tags')].filter(visible);
+		return tags.some(el => {
+			const text = (el.innerText || '').trim();
+			const classes = String(el.className || '').split(/\s+/);
+			return text === targetText && classes.includes('active');
+		});
+	}`, filter.GroupText, filter.Text))
+	if err != nil {
+		return false, err
+	}
+	return res.Value.Bool(), nil
+}
+
+func clickSearchFilterOption(page *rod.Page, filter internalFilterOption) error {
+	res, err := page.Timeout(3 * time.Second).Evaluate(rod.Eval(`(groupText, targetText) => {
+		const visible = (el) => {
+			const style = window.getComputedStyle(el);
+			const rect = el.getBoundingClientRect();
+			return style.display !== 'none'
+				&& style.visibility !== 'hidden'
+				&& Number(style.opacity) !== 0
+				&& rect.width > 0
+				&& rect.height > 0;
+		};
+		const groups = [...document.querySelectorAll('div.filter-panel div.filters')].filter(visible);
+		const group = groups.find(el => (el.innerText || '').includes(groupText));
+		if (!group) return { ok: false, reason: 'group not found: ' + groupText };
+
+		const tags = [...group.querySelectorAll('div.tags')].filter(visible);
+		const candidates = tags
+			.filter(el => (el.innerText || '').trim() === targetText)
+			.map((el, index) => ({
+				el,
+				index,
+				className: el.className || '',
+				tabIndex: el.getAttribute('tabindex') || '',
+				ariaChecked: el.getAttribute('aria-checked') || '',
+				role: el.getAttribute('role') || '',
+			}));
+		if (!candidates.length) return { ok: false, reason: 'tag not found: ' + groupText + '=' + targetText };
+
+		const candidate = candidates.find(item => !String(item.className).split(/\s+/).includes('active')) || candidates[0];
+		const el = candidate.el;
+		el.scrollIntoView({ block: 'center', inline: 'center' });
+		for (const type of ['mouseover', 'mouseenter', 'mousedown', 'mouseup', 'click']) {
+			el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: window }));
+		}
+
+		return {
+			ok: true,
+			clicked: {
+				index: candidate.index,
+				className: candidate.className,
+				tabIndex: candidate.tabIndex,
+				ariaChecked: candidate.ariaChecked,
+				role: candidate.role,
+			},
+		};
+	}`, filter.GroupText, filter.Text))
+	if err != nil {
+		return err
+	}
+	if !res.Value.Get("ok").Bool() {
+		return fmt.Errorf("%s", res.Value.Get("reason").Str())
+	}
+	return nil
+}
+
+func findFilterGroup(page *rod.Page, filter internalFilterOption) (*rod.Element, error) {
+	groups, err := page.Timeout(5 * time.Second).Elements(`div.filter-panel div.filters`)
+	if err != nil {
+		return nil, fmt.Errorf("查找筛选组失败: %w", err)
+	}
+
+	for _, group := range groups {
+		if !isSearchFilterElementVisible(group) {
+			continue
+		}
+		text, err := group.Text()
+		if err != nil {
+			logrus.Debugf("读取筛选组文本失败: %v", err)
+			continue
+		}
+		if strings.Contains(strings.TrimSpace(text), filter.GroupText) {
+			return group, nil
+		}
+	}
+
+	return nil, fmt.Errorf("未找到筛选组: %s", filter.GroupText)
+}
+
+func findVisibleFilterTag(group *rod.Element, targetText string) (*rod.Element, error) {
+	tags, err := group.Elements(`div.tags`)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tag := range tags {
+		if !isSearchFilterElementVisible(tag) {
+			continue
+		}
+		text, err := tag.Text()
+		if err != nil {
+			logrus.Debugf("读取筛选项文本失败: %v", err)
+			continue
+		}
+		if strings.TrimSpace(text) == targetText {
+			return tag, nil
+		}
+	}
+
+	return nil, fmt.Errorf("组内未找到可见文本: %s", targetText)
+}
+
+func filterOptionActive(group *rod.Element, targetText string) bool {
+	tags, err := group.Elements(`div.tags`)
+	if err != nil {
+		logrus.Debugf("读取筛选项列表失败: %v", err)
+		return false
+	}
+
+	for _, tag := range tags {
+		if !isSearchFilterElementVisible(tag) {
+			continue
+		}
+		text, err := tag.Text()
+		if err != nil || strings.TrimSpace(text) != targetText {
+			continue
+		}
+
+		className, err := tag.Attribute("class")
+		if err != nil || className == nil {
+			continue
+		}
+		if hasExactClass(*className, "active") {
+			return true
+		}
+	}
+	return false
+}
+
+func isSearchFilterElementVisible(elem *rod.Element) bool {
+	res, err := elem.Eval(`() => {
+		const style = window.getComputedStyle(this);
+		const rect = this.getBoundingClientRect();
+		return style.display !== 'none'
+			&& style.visibility !== 'hidden'
+			&& Number(style.opacity) !== 0
+			&& rect.width > 0
+			&& rect.height > 0;
+	}`)
+	if err != nil {
+		logrus.Debugf("检查搜索筛选元素可见性失败: %v", err)
+		return true
+	}
+	return res.Value.Bool()
 }
 
 func makeSearchURL(keyword string) string {


### PR DESCRIPTION
## 说明

这个 PR 主要是加一个可选的 CloakBrowser 启动方式，不改变现有默认行为。

现在如果用户想用 CloakBrowser，可以通过：

- `CLOAKBROWSER_BINARY_PATH`
- `-bin`

显式指定浏览器路径。

普通 Chrome/Chromium 还是走原来的逻辑，包括默认 UA 和 `go-rod/stealth`。

如果检测到用户指定的是 CloakBrowser，就不再额外覆盖 UA，也不再启用 `go-rod/stealth`。主要是避免 CloakBrowser 自己的运行环境和额外注入逻辑产生不一致。

另外补充了中英文 README 里的使用说明。

## 验证

本地跑过：

- `go build ./...`
- `go test ./pkg/... ./browser/...`