### PR TITLE
fix: 评论操作遇风控拦截页时自动重试导航

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -5,10 +5,47 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/humanize"
 )
+
+func retryFeedDetailNavigation(
+	ctx context.Context,
+	operation func() error,
+	options ...retry.Option,
+) error {
+	defaultOptions := []retry.Option{
+		retry.Attempts(3),
+		retry.Delay(2 * time.Second),
+		retry.MaxJitter(time.Second),
+		retry.Context(ctx),
+		retry.RetryIf(func(err error) bool {
+			return !isPermanentAccessError(err)
+		}),
+		retry.OnRetry(func(n uint, err error) {
+			logrus.Warnf("feed 详情页暂不可访问，准备重试 #%d: %v", n+1, err)
+		}),
+	}
+
+	return retry.Do(operation, append(defaultOptions, options...)...)
+}
+
+// navigateToFeedDetail 导航到 feed 详情页并确认页面可访问。
+// 临时风控拦截页可通过重新导航恢复，删除、私密、违规等永久错误不重试。
+func navigateToFeedDetail(ctx context.Context, page *rod.Page, url string) error {
+	return retryFeedDetailNavigation(ctx, func() error {
+		if err := page.Navigate(url); err != nil {
+			return err
+		}
+		if err := page.WaitDOMStable(time.Second, 0); err != nil {
+			return err
+		}
+		humanize.Delay(ctx, humanize.AfterNavigate)
+		return checkPageAccessible(page)
+	})
+}
 
 // CommentFeedAction 表示 Feed 评论动作
 type CommentFeedAction struct {
@@ -28,13 +65,8 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 	url := makeFeedDetailURL(feedID, xsecToken)
 	logrus.Infof("打开 feed 详情页: %s", url)
 
-	// 导航到详情页
-	page.MustNavigate(url)
-	page.MustWaitDOMStable()
-	humanize.Delay(ctx, humanize.AfterNavigate)
-
-	// 检测页面是否可访问
-	if err := checkPageAccessible(page); err != nil {
+	// 导航到详情页并确认可访问（偶发风控拦截页自动重试）
+	if err := navigateToFeedDetail(ctx, page, url); err != nil {
 		return err
 	}
 
@@ -118,13 +150,8 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	url := makeFeedDetailURL(feedID, xsecToken)
 	logrus.Infof("打开 feed 详情页进行回复: %s", url)
 
-	// 导航到详情页
-	page.MustNavigate(url)
-	page.MustWaitDOMStable()
-	humanize.Delay(ctx, humanize.AfterNavigate)
-
-	// 检测页面是否可访问
-	if err := checkPageAccessible(page); err != nil {
+	// 导航到详情页并确认可访问（偶发风控拦截页自动重试）
+	if err := navigateToFeedDetail(ctx, page, url); err != nil {
 		return err
 	}
 

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -723,6 +723,33 @@ func checkEndContainer(page *rod.Page) bool {
 
 // ========== 页面检查 ==========
 
+// permanentInaccessibleKeywords 表示笔记本身不可访问（删除、私密、违规等），
+// 这类错误重新导航也无法恢复。
+var permanentInaccessibleKeywords = []string{
+	"当前笔记暂时无法浏览",
+	"该内容因违规已被删除",
+	"该笔记已被删除",
+	"内容不存在",
+	"笔记不存在",
+	"已失效",
+	"私密笔记",
+	"仅作者可见",
+	"因用户设置，你无法查看",
+	"因违规无法查看",
+}
+
+func isPermanentAccessError(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, keyword := range permanentInaccessibleKeywords {
+		if strings.Contains(err.Error(), keyword) {
+			return true
+		}
+	}
+	return false
+}
+
 func checkPageAccessible(page *rod.Page) error {
 	// 等错误提示 UI 渲染出来再检查
 	time.Sleep(500 * time.Millisecond)
@@ -741,21 +768,7 @@ func checkPageAccessible(page *rod.Page) error {
 		return nil
 	}
 
-	// 检查关键词
-	keywords := []string{
-		"当前笔记暂时无法浏览",
-		"该内容因违规已被删除",
-		"该笔记已被删除",
-		"内容不存在",
-		"笔记不存在",
-		"已失效",
-		"私密笔记",
-		"仅作者可见",
-		"因用户设置，你无法查看",
-		"因违规无法查看",
-	}
-
-	for _, kw := range keywords {
+	for _, kw := range permanentInaccessibleKeywords {
 		if strings.Contains(text, kw) {
 			logrus.Warnf("笔记不可访问: %s", kw)
 			return fmt.Errorf("笔记不可访问: %s", kw)

--- a/xiaohongshu/feed_detail_test.go
+++ b/xiaohongshu/feed_detail_test.go
@@ -1,0 +1,108 @@
+package xiaohongshu
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/avast/retry-go/v4"
+)
+
+func TestIsPermanentAccessError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is retryable",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "deleted note is permanent",
+			err:  errors.New("笔记不可访问: 该笔记已被删除"),
+			want: true,
+		},
+		{
+			name: "private note is permanent",
+			err:  errors.New("笔记不可访问: 私密笔记"),
+			want: true,
+		},
+		{
+			name: "user restriction is permanent",
+			err:  errors.New("笔记不可访问: 因用户设置，你无法查看"),
+			want: true,
+		},
+		{
+			name: "risk control page is transient",
+			err:  errors.New("笔记不可访问: Sorry, This Page Isn't Available Right Now."),
+			want: false,
+		},
+		{
+			name: "unknown access error is transient",
+			err:  errors.New("笔记不可访问: some unknown error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isPermanentAccessError(tt.err); got != tt.want {
+				t.Fatalf("isPermanentAccessError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryFeedDetailNavigationRetriesTransientErrors(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	err := retryFeedDetailNavigation(
+		context.Background(),
+		func() error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("笔记不可访问: Sorry, This Page Isn't Available Right Now.")
+			}
+			return nil
+		},
+		retry.Delay(0),
+		retry.DelayType(retry.FixedDelay),
+	)
+
+	if err != nil {
+		t.Fatalf("retryFeedDetailNavigation() error = %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestRetryFeedDetailNavigationStopsOnPermanentError(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	err := retryFeedDetailNavigation(
+		context.Background(),
+		func() error {
+			attempts++
+			return errors.New("笔记不可访问: 该笔记已被删除")
+		},
+		retry.Delay(0),
+		retry.DelayType(retry.FixedDelay),
+	)
+
+	if err == nil {
+		t.Fatal("retryFeedDetailNavigation() error = nil, want permanent access error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}


### PR DESCRIPTION
## Summary

`post_comment_to_feed` 和 `reply_comment_in_feed` 导航到笔记详情页后只检查一次可访问性。小红书 Web 端偶发返回 `"Sorry, This Page Isn't Available Right Now."` 风控拦截页时，操作会立即失败；同一参数重新导航通常可以恢复。

本 PR：

- 将导航、DOM 稳定等待、可访问性检查作为一个整体重试，最多 3 次（2s delay + jitter）
- 使用返回 `error` 的 go-rod API，导航/DOM 等待错误也可进入重试，不依赖 `Must*` panic
- 删除、私密、违规等永久不可访问错误不重试；未知/风控错误视为临时错误
- 同时用于发表评论和回复评论，并尊重调用方 context 取消
- 基于当前 `main` 重写，保留 #737 新增的 humanize 交互和提交后就地成功校验

## Root cause

`checkPageAccessible` 正确识别了拦截页，但评论操作的调用方没有恢复路径，一次临时拦截就终止。

## Verification

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] 单元测试覆盖：
  - 临时风控错误连续两次后恢复，共执行 3 次
  - 删除/私密/用户限制等永久错误只执行 1 次
  - nil、未知错误和永久错误分类

原问题来自真实环境的间歇性失败日志；风控拦截无法稳定触发，因此当前重写版本未声称可重复录制该路径。代码未注入额外 JavaScript。

## Scope

本 PR 只修评论操作的临时导航拦截。评论查找和提交后成功校验继续使用当前主线实现。
