### PR TITLE
feat: 添加小红书 AI 搜索问答功能及相关接口文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,10 @@ npx mcporter list xiaohongshu-mcp
     - `publish_time`: 发布时间 - `不限`（默认）| `一天内` | `一周内` | `半年内`
     - `search_scope`: 搜索范围 - `不限`（默认）| `已看过` | `未看过` | `已关注`
     - `location`: 位置距离 - `不限`（默认）| `同城` | `附近`
+- `ai_search_chat` - 调用小红书 AI 搜索问答（必需：prompt）
+  - `include_sources`: 是否返回 AI 引用的来源笔记列表（可选），默认 false
+  - `source_limit`: 最多返回多少条来源笔记（可选），默认 30
+  - `timeout_seconds`: 等待 AI 回答完成的超时时间（可选），默认 90 秒
 - `get_feed_detail` - 获取帖子详情，包括互动数据和评论（必需：feed_id, xsec_token）
   - `load_all_comments`: 是否加载全部评论（可选），默认 false 仅返回前 10 条一级评论
   - `limit`: 限制加载的一级评论数量（可选），仅当 load_all_comments=true 时生效，默认 20

--- a/README_EN.md
+++ b/README_EN.md
@@ -672,7 +672,7 @@ Usage steps:
 
 - Use MCP Inspector to test connection
 - Test Ping Server functionality to verify connection
-- Check if List Tools returns 13 tools
+- Check if List Tools returns 14 tools
 
 </details>
 
@@ -772,6 +772,10 @@ After successful connection, you can use the following MCP tools:
     - `publish_time`: Publish time - `unlimited` (default) | `last day` | `last week` | `last 6 months`
     - `search_scope`: Search scope - `unlimited` (default) | `viewed` | `not viewed` | `followed`
     - `location`: Location - `unlimited` (default) | `same city` | `nearby`
+- `ai_search_chat` - Ask RedNote AI Search and return the final answer (required: prompt)
+  - `include_sources`: Whether to return AI source notes (optional), default false
+  - `source_limit`: Maximum source notes to return (optional), default 30
+  - `timeout_seconds`: Timeout for waiting for the AI answer (optional), default 90 seconds
 - `get_feed_detail` - Get post details including interaction data and comments (required: feed_id, xsec_token)
   - `load_all_comments`: Whether to load all comments (optional), default false returns only first 10 top-level comments
   - `limit`: Limit number of top-level comments to load (optional), only effective when load_all_comments=true, default 20

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,7 @@
 | POST | `/api/v1/publish_video` | 发布视频内容 |
 | GET | `/api/v1/feeds/list` | 获取 Feeds 列表 |
 | GET/POST | `/api/v1/feeds/search` | 搜索 Feeds |
+| POST | `/api/v1/ai/search` | 小红书 AI 搜索问答 |
 | POST | `/api/v1/feeds/detail` | 获取 Feed 详情 |
 | POST | `/api/v1/user/profile` | 获取用户主页信息 |
 | GET | `/api/v1/user/me` | 获取当前登录用户信息 |
@@ -418,7 +419,64 @@ Content-Type: application/json
 - `video`: 视频笔记时有此字段，图文笔记为 null
 ```
 
-#### 4.3 获取 Feed 详情
+#### 4.3 小红书 AI 搜索问答
+
+通过小红书网页 AI Chat 发送问题，等待 AI 回答完成；可选打开“参考来源”抽屉并返回 AI 引用的笔记列表。该接口复用浏览器登录态，由页面自己生成签名和接收流式结果。
+
+**请求**
+```
+POST /api/v1/ai/search
+Content-Type: application/json
+```
+
+**请求体**
+```json
+{
+  "prompt": "上海最近活动",
+  "include_sources": true,
+  "source_limit": 30,
+  "timeout_seconds": 90
+}
+```
+
+**参数说明:**
+- `prompt` (string, required): 发送给小红书 AI 搜索的问题
+- `include_sources` (boolean, optional): 是否返回 AI 引用的来源笔记列表，默认 false
+- `source_limit` (number, optional): 最多返回多少条来源笔记，默认 30
+- `timeout_seconds` (number, optional): 等待 AI 回答完成的超时时间，默认 90 秒
+
+**响应**
+```json
+{
+  "success": true,
+  "data": {
+    "prompt": "上海最近活动",
+    "conversationId": "conversation_id",
+    "messageId": "message_id",
+    "answer": "AI 回答内容",
+    "fragmentCount": 12,
+    "sources": {
+      "ok": true,
+      "progressEntries": 1,
+      "notes": [
+        {
+          "idx": 0,
+          "noteId": "6a1821760000000036019d70",
+          "title": "上海6月高质量展览",
+          "url": "https://www.xiaohongshu.com/search_result/...",
+          "cover": "https://...",
+          "author": "作者昵称",
+          "time": "05-28",
+          "likedCount": "416"
+        }
+      ]
+    }
+  },
+  "message": "小红书 AI 搜索成功"
+}
+```
+
+#### 4.4 获取 Feed 详情
 
 获取指定 Feed 的详细信息，支持加载全部评论和自定义评论加载配置。
 

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -172,6 +172,26 @@ func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 	respondSuccess(c, result, "搜索Feeds成功")
 }
 
+// aiSearchChatHandler 小红书 AI 搜索问答
+func (s *AppServer) aiSearchChatHandler(c *gin.Context) {
+	var req AISearchChatRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	result, err := s.xiaohongshuService.AISearchChat(c.Request.Context(), req)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "AI_SEARCH_FAILED",
+			"小红书 AI 搜索失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "小红书 AI 搜索成功")
+}
+
 // getFeedDetailHandler 获取Feed详情
 func (s *AppServer) getFeedDetailHandler(c *gin.Context) {
 	var req FeedDetailRequest

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -357,6 +357,57 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 	}
 }
 
+// handleAISearchChat 处理小红书 AI 搜索问答
+func (s *AppServer) handleAISearchChat(ctx context.Context, args AISearchChatArgs) *MCPToolResult {
+	logrus.Info("MCP: 小红书 AI 搜索问答")
+
+	if strings.TrimSpace(args.Prompt) == "" {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "小红书 AI 搜索失败: 缺少 prompt 参数",
+			}},
+			IsError: true,
+		}
+	}
+
+	req := AISearchChatRequest{
+		Prompt:         args.Prompt,
+		IncludeSources: args.IncludeSources,
+		SourceLimit:    args.SourceLimit,
+		TimeoutSeconds: args.TimeoutSeconds,
+	}
+
+	result, err := s.xiaohongshuService.AISearchChat(ctx, req)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "小红书 AI 搜索失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("小红书 AI 搜索成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleGetFeedDetail 处理获取Feed详情
 func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取Feed详情")

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -44,6 +44,14 @@ type SearchFeedsArgs struct {
 	Filters FilterOption `json:"filters,omitempty" jsonschema:"筛选选项"`
 }
 
+// AISearchChatArgs 小红书 AI 搜索问答参数
+type AISearchChatArgs struct {
+	Prompt         string `json:"prompt" jsonschema:"要发送给小红书 AI 搜索的问题"`
+	IncludeSources bool   `json:"include_sources,omitempty" jsonschema:"是否打开参考来源抽屉并返回 AI 引用的笔记列表，默认 false"`
+	SourceLimit    int    `json:"source_limit,omitempty" jsonschema:"最多返回多少条来源笔记，默认 30"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty" jsonschema:"等待 AI 回答完成的超时时间，单位秒，默认 90"`
+}
+
 // FilterOption 筛选选项结构体
 type FilterOption struct {
 	SortBy      string `json:"sort_by,omitempty" jsonschema:"排序依据: 综合|最新|最多点赞|最多评论|最多收藏,默认为'综合'"`
@@ -443,7 +451,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	// 工具 14: 小红书 AI 搜索问答
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "ai_search_chat",
+			Description: "调用小红书 AI 搜索问答。通过浏览器页面发送问题，等待 AI 回答，可选返回 AI 引用的来源笔记列表。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "AI Search Chat",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("ai_search_chat", func(ctx context.Context, req *mcp.CallToolRequest, args AISearchChatArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleAISearchChat(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/routes.go
+++ b/routes.go
@@ -46,6 +46,7 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.GET("/feeds/list", appServer.listFeedsHandler)
 		api.GET("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/search", appServer.searchFeedsHandler)
+		api.POST("/ai/search", appServer.aiSearchChatHandler)
 		api.POST("/feeds/detail", appServer.getFeedDetailHandler)
 		api.POST("/user/profile", appServer.userProfileHandler)
 		api.POST("/feeds/comment", appServer.postCommentHandler)

--- a/service.go
+++ b/service.go
@@ -86,6 +86,13 @@ type FeedsListResponse struct {
 	Count int                `json:"count"`
 }
 
+type AISearchChatRequest struct {
+	Prompt         string `json:"prompt" binding:"required"`
+	IncludeSources bool   `json:"include_sources,omitempty"`
+	SourceLimit    int    `json:"source_limit,omitempty"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+}
+
 // UserProfileResponse 用户主页响应
 type UserProfileResponse struct {
 	UserBasicInfo xiaohongshu.UserBasicInfo      `json:"userBasicInfo"`
@@ -389,6 +396,28 @@ func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, fi
 	}
 
 	return response, nil
+}
+
+func (s *XiaohongshuService) AISearchChat(ctx context.Context, req AISearchChatRequest) (*xiaohongshu.AISearchResult, error) {
+	if req.TimeoutSeconds <= 0 {
+		req.TimeoutSeconds = 90
+	}
+	if req.SourceLimit <= 0 {
+		req.SourceLimit = 30
+	}
+
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewAISearchAction(page)
+	return action.Chat(ctx, req.Prompt, xiaohongshu.AISearchOptions{
+		IncludeSources: req.IncludeSources,
+		SourceLimit:    req.SourceLimit,
+		Timeout:        time.Duration(req.TimeoutSeconds) * time.Second,
+	})
 }
 
 // GetFeedDetail 获取Feed详情

--- a/xiaohongshu/ai_search.go
+++ b/xiaohongshu/ai_search.go
@@ -1,0 +1,371 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/sirupsen/logrus"
+)
+
+const aiChatURL = "https://www.xiaohongshu.com/ai_chat"
+
+type AISearchOptions struct {
+	IncludeSources bool
+	SourceLimit    int
+	Timeout        time.Duration
+}
+
+type AISearchResult struct {
+	Prompt         string          `json:"prompt"`
+	ConversationID string          `json:"conversationId,omitempty"`
+	MessageID      string          `json:"messageId,omitempty"`
+	UUID           string          `json:"uuid,omitempty"`
+	Answer         string          `json:"answer"`
+	QuerySource    any             `json:"querySource,omitempty"`
+	ThinkProgress  any             `json:"thinkProgress,omitempty"`
+	FragmentCount  int             `json:"fragmentCount"`
+	Sources        *AISourceResult `json:"sources,omitempty"`
+}
+
+type AISourceResult struct {
+	OK              bool           `json:"ok"`
+	Reason          string         `json:"reason,omitempty"`
+	ProgressEntries int            `json:"progressEntries,omitempty"`
+	Notes           []AISourceNote `json:"notes"`
+}
+
+type AISourceNote struct {
+	Index      int    `json:"idx"`
+	NoteID     string `json:"noteId,omitempty"`
+	Title      string `json:"title,omitempty"`
+	URL        string `json:"url,omitempty"`
+	Cover      string `json:"cover,omitempty"`
+	Author     string `json:"author,omitempty"`
+	Time       string `json:"time,omitempty"`
+	LikedCount string `json:"likedCount,omitempty"`
+	Text       string `json:"text,omitempty"`
+}
+
+type aiAnswerState struct {
+	Found          bool   `json:"found"`
+	Finished       bool   `json:"finished"`
+	Text           string `json:"text"`
+	ConversationID string `json:"conversationId"`
+	MessageID      string `json:"messageId"`
+	UUID           string `json:"uuid"`
+	QuerySource    any    `json:"querySource"`
+	ThinkProgress  any    `json:"thinkProgress"`
+	FragmentCount  int    `json:"fragmentCount"`
+	AIMessageCount int    `json:"aiMessageCount"`
+}
+
+type AISearchAction struct {
+	page *rod.Page
+}
+
+func NewAISearchAction(page *rod.Page) *AISearchAction {
+	return &AISearchAction{page: page}
+}
+
+func (a *AISearchAction) Chat(ctx context.Context, prompt string, opts AISearchOptions) (*AISearchResult, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	if opts.Timeout <= 0 {
+		opts.Timeout = 90 * time.Second
+	}
+	if opts.SourceLimit <= 0 {
+		opts.SourceLimit = 30
+	}
+
+	page := a.page.Context(ctx).Timeout(opts.Timeout + 30*time.Second)
+	logrus.Infof("打开小红书 AI Chat: %s", aiChatURL)
+	page.MustNavigate(aiChatURL)
+	page.MustWaitDOMStable()
+
+	if err := waitForAIChatReady(page, opts.Timeout); err != nil {
+		return nil, err
+	}
+
+	beforeCount := countAIMessages(page)
+	if err := sendAIChatPrompt(page, prompt, opts.Timeout); err != nil {
+		return nil, err
+	}
+
+	answerState, err := waitForAIAnswer(page, beforeCount, opts.Timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &AISearchResult{
+		Prompt:         prompt,
+		ConversationID: answerState.ConversationID,
+		MessageID:      answerState.MessageID,
+		UUID:           answerState.UUID,
+		Answer:         strings.TrimSpace(answerState.Text),
+		QuerySource:    answerState.QuerySource,
+		ThinkProgress:  answerState.ThinkProgress,
+		FragmentCount:  answerState.FragmentCount,
+	}
+
+	if opts.IncludeSources {
+		sources, err := getAISources(page, opts.SourceLimit, opts.Timeout)
+		if err != nil {
+			result.Sources = &AISourceResult{
+				OK:     false,
+				Reason: err.Error(),
+				Notes:  []AISourceNote{},
+			}
+		} else {
+			result.Sources = sources
+		}
+	}
+
+	return result, nil
+}
+
+func waitForAIChatReady(page *rod.Page, timeout time.Duration) error {
+	err := waitForJSFlag(page, `() => {
+		return document.querySelector("textarea.textarea, .ai-chat-input-box textarea, textarea") ? "1" : "";
+	}`, timeout)
+	if err != nil {
+		return fmt.Errorf("could not find AI chat textarea: %w", err)
+	}
+	return nil
+}
+
+func sendAIChatPrompt(page *rod.Page, prompt string, timeout time.Duration) error {
+	textarea, err := page.Element("textarea.textarea, .ai-chat-input-box textarea, textarea")
+	if err != nil {
+		return fmt.Errorf("could not find AI chat textarea: %w", err)
+	}
+
+	if err := textarea.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("could not focus AI chat textarea: %w", err)
+	}
+	if err := textarea.SelectAllText(); err != nil {
+		return fmt.Errorf("could not select AI chat textarea text: %w", err)
+	}
+	if err := page.Keyboard.Press(input.Backspace); err != nil {
+		return fmt.Errorf("could not clear AI chat textarea: %w", err)
+	}
+	if err := textarea.Input(prompt); err != nil {
+		return fmt.Errorf("could not input AI chat prompt: %w", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	err = waitForJSFlag(page, `() => {
+		const button = document.querySelector(".submit-button-wrapper");
+		return button && !String(button.className || "").includes("disabled") ? "1" : "";
+	}`, timeout)
+	if err != nil {
+		return fmt.Errorf("AI chat submit button did not become enabled: %w", err)
+	}
+
+	button, err := page.Element(".submit-button-wrapper")
+	if err != nil {
+		return fmt.Errorf("could not find AI chat submit button: %w", err)
+	}
+	if err := button.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return fmt.Errorf("could not click AI chat submit button: %w", err)
+	}
+
+	return nil
+}
+
+func countAIMessages(page *rod.Page) int {
+	raw := page.MustEval(aiAnswerStateJS, 0).String()
+	var state aiAnswerState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return 0
+	}
+	return state.AIMessageCount
+}
+
+func waitForAIAnswer(page *rod.Page, beforeCount int, timeout time.Duration) (*aiAnswerState, error) {
+	deadline := time.Now().Add(timeout)
+	var lastRaw string
+
+	for time.Now().Before(deadline) {
+		lastRaw = page.MustEval(aiAnswerStateJS, beforeCount).String()
+		var state aiAnswerState
+		if err := json.Unmarshal([]byte(lastRaw), &state); err == nil {
+			if state.Found && state.Finished && strings.TrimSpace(state.Text) != "" {
+				return &state, nil
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if len(lastRaw) > 1000 {
+		lastRaw = lastRaw[:1000]
+	}
+	return nil, fmt.Errorf("timed out waiting for AI answer; last state: %s", lastRaw)
+}
+
+func getAISources(page *rod.Page, limit int, timeout time.Duration) (*AISourceResult, error) {
+	rawProgressCount := page.MustEval(`() => String(document.querySelectorAll(".progress-wrapper").length)`).String()
+	if rawProgressCount == "" || rawProgressCount == "0" {
+		return nil, fmt.Errorf("no rendered source/progress entry was found for this answer")
+	}
+
+	clicked := page.MustEval(`() => {
+		const nodes = Array.from(document.querySelectorAll(".progress-wrapper"));
+		const last = nodes[nodes.length - 1];
+		if (!last) return "";
+		last.scrollIntoView({ block: "center", inline: "center" });
+		last.click();
+		return "1";
+	}`).String()
+	if clicked != "1" {
+		return nil, fmt.Errorf("could not click source/progress entry")
+	}
+
+	if err := waitForJSFlag(page, `() => {
+		return document.querySelector("section.note-item") ? "1" : "";
+	}`, timeout); err != nil {
+		return nil, fmt.Errorf("source drawer did not show note cards: %w", err)
+	}
+
+	raw := page.MustEval(aiSourceNotesJS, limit).String()
+	var notes []AISourceNote
+	if err := json.Unmarshal([]byte(raw), &notes); err != nil {
+		return nil, fmt.Errorf("failed to parse AI source notes: %w", err)
+	}
+
+	result := &AISourceResult{
+		OK:              len(notes) > 0,
+		ProgressEntries: atoiDefault(rawProgressCount, 0),
+		Notes:           notes,
+	}
+	if len(notes) == 0 {
+		result.Reason = "the source drawer opened, but no note cards were found"
+	}
+	return result, nil
+}
+
+func waitForJSFlag(page *rod.Page, js string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if page.MustEval(js).String() == "1" {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout after %s", timeout)
+}
+
+func atoiDefault(value string, fallback int) int {
+	var n int
+	if _, err := fmt.Sscanf(value, "%d", &n); err != nil {
+		return fallback
+	}
+	return n
+}
+
+const aiAnswerStateJS = `(before) => {
+	function clone(value) {
+		try { return JSON.parse(JSON.stringify(value)); } catch { return null; }
+	}
+	function buildText(message) {
+		if (!message) return "";
+		if (message.text) return message.text;
+		return (message.dataFragments || [])
+			.filter((fragment) => fragment && fragment.fragmentType === 1)
+			.sort((a, b) => (a.indexInConversation || 0) - (b.indexInConversation || 0))
+			.map((fragment) => fragment.text || "")
+			.join("");
+	}
+	function collectAIMessages(debug) {
+		const messages = clone(debug.messages) || [];
+		const rounds = clone(debug.rounds) || [];
+		const candidates = [
+			...messages.filter((message) => message && message.sender === "ai"),
+			...rounds.map((round) => round && round.aiMessage).filter(Boolean)
+		];
+		const seen = new Set();
+		const result = [];
+		for (const message of candidates) {
+			const key = String(message.msgId || message.id || message.uuid || buildText(message).slice(0, 80));
+			if (seen.has(key)) continue;
+			seen.add(key);
+			result.push(message);
+		}
+		return result;
+	}
+
+	const debug = window.__XHS_AI_DEBUG__;
+	if (!debug) return JSON.stringify({ found: false, aiMessageCount: 0 });
+
+	const messages = collectAIMessages(debug);
+	const beforeCount = Number(before || 0);
+	const aiMessage = messages[beforeCount] || messages[messages.length - 1];
+	if (!aiMessage) {
+		return JSON.stringify({ found: false, aiMessageCount: messages.length });
+	}
+
+	const fragments = aiMessage.dataFragments || [];
+	return JSON.stringify({
+		found: true,
+		finished: !!aiMessage.isFinished,
+		text: buildText(aiMessage),
+		conversationId: aiMessage.conversationId || "",
+		messageId: String(aiMessage.msgId || "").replace(/^ai-/, ""),
+		uuid: aiMessage.uuid || "",
+		querySource: aiMessage.querySource || null,
+		thinkProgress: aiMessage.thinkProgress || [],
+		fragmentCount: fragments.length,
+		aiMessageCount: messages.length
+	});
+}`
+
+const aiSourceNotesJS = `(limit) => {
+	function abs(href) {
+		try { return href ? new URL(href, location.origin).href : ""; }
+		catch { return href || ""; }
+	}
+	function noteIdFromUrl(url) {
+		const match = String(url || "").match(/(?:explore|search_result|discovery\/item)\/([0-9a-fA-F]+)/);
+		return match ? match[1] : "";
+	}
+
+	const notes = Array.from(document.querySelectorAll("section.note-item"))
+		.slice(0, Number(limit || 30))
+		.map((el, idx) => {
+			const titleEl = el.querySelector("a.title");
+			const coverEl = el.querySelector("a.cover");
+			const authorEl = el.querySelector("a.author");
+			const img = el.querySelector("img");
+			const url = abs(
+				(titleEl && titleEl.getAttribute("href")) ||
+				(coverEl && coverEl.getAttribute("href")) ||
+				""
+			);
+			const nameEl = el.querySelector(".name");
+			const likedCountEl = el.querySelector(".like-wrapper .count, .like-wrapper");
+			return {
+				idx,
+				noteId: noteIdFromUrl(url),
+				title: (titleEl && titleEl.textContent.trim()) || "",
+				url,
+				cover: (img && (img.currentSrc || img.src)) || "",
+				author: (nameEl && nameEl.textContent.trim()) ||
+					(authorEl && authorEl.textContent.replace(/\n.*/s, "").trim()) ||
+					"",
+				time: (el.querySelector(".time") && el.querySelector(".time").textContent.trim()) || "",
+				likedCount: (likedCountEl && likedCountEl.textContent.trim()) || "",
+				text: el.innerText.trim()
+			};
+		})
+		.filter((note) => note.title || note.url);
+
+	return JSON.stringify(notes);
+}`


### PR DESCRIPTION
This pull request introduces a new feature: integration with Xiaohongshu's (RedNote) AI Search Chat, allowing users to send prompts to Xiaohongshu's AI and receive answers, optionally with referenced source notes. The change includes full backend implementation, API documentation, and MCP tool registration. Documentation in both English and Chinese has been updated to reflect the new feature.

**New AI Search Chat feature:**

- Added a new API endpoint `POST /api/v1/ai/search` to enable AI-powered question answering via Xiaohongshu's web AI chat, with options to include referenced source notes, control source limit, and set a timeout. [[1]](diffhunk://#diff-d6c18da6d533ae648d3ae7766cfafd9f873c51db02ecb1d92fc93730035aea48R49) [[2]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R45) [[3]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L421-R479) [[4]](diffhunk://#diff-c52daedaeda258db15ec11d57bbf299412a20328f6cd026980ef07f01960dd3aR89-R95) [[5]](diffhunk://#diff-c52daedaeda258db15ec11d57bbf299412a20328f6cd026980ef07f01960dd3aR401-R422) [[6]](diffhunk://#diff-89d56893bec86b5d953cf240b4450885b258c0aa4512f118f956312bfa471fc3R1-R371)
- Implemented backend logic for handling AI search chat requests, including request/response structures, service logic, and browser automation for interacting with Xiaohongshu's AI chat page. [[1]](diffhunk://#diff-c92d1eaafa5a4c6977c313ddbba66080af12480849b82f691b4cfbed5d25e053R175-R194) [[2]](diffhunk://#diff-b87e50944777f72f1fafffa0ea91d7c9e75d5118a4ec3a8f4d03730fd6b7a03fR47-R54) [[3]](diffhunk://#diff-b87e50944777f72f1fafffa0ea91d7c9e75d5118a4ec3a8f4d03730fd6b7a03fL446-R470) [[4]](diffhunk://#diff-64fe963ed87bdd3756cc84652ab24ef8739a905471f1f17a48be02613c5a3de0R360-R410) [[5]](diffhunk://#diff-89d56893bec86b5d953cf240b4450885b258c0aa4512f118f956312bfa471fc3R1-R371)

**Documentation updates:**

- Updated English and Chinese README files to describe the new `ai_search_chat` tool, its parameters, and its inclusion in the tool list (now 14 tools). [[1]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL675-R675) [[2]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abR775-R778) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R874-R877)
- Extended API documentation in `docs/API.md` to detail the new endpoint, request/response formats, and parameter explanations.

**MCP tool integration:**

- Registered the new AI Search Chat as the 14th MCP tool, including its argument structure, handler, and error handling. [[1]](diffhunk://#diff-b87e50944777f72f1fafffa0ea91d7c9e75d5118a4ec3a8f4d03730fd6b7a03fL446-R470) [[2]](diffhunk://#diff-64fe963ed87bdd3756cc84652ab24ef8739a905471f1f17a48be02613c5a3de0R360-R410)

These changes collectively provide users and developers with seamless access to Xiaohongshu's AI search capabilities, both through API and MCP tool interfaces.