### PR TITLE
feat: use CloakBrowser for Docker browser runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ test_*.sh
 
 # Cookies files (contain sensitive login information)
 cookies.json
+docker/data/
+docker/images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.6
+
 # ---- build stage ----
 FROM golang:1.24 AS builder
 
@@ -26,23 +28,27 @@ RUN apt-get update && apt-get install -y ca-certificates wget gnupg && \
     sed -i 's|http://archive.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list && \
     sed -i 's|http://security.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list
 
-# 2. 添加 Google Chrome APT 源并安装 Chrome（更稳定的无头浏览器）
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg && \
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-
-# 3. 安装 Google Chrome + 依赖（无头模式运行 rod）
+# 2. 安装 CloakBrowser Chromium 运行依赖、Python 和中文字体
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     fonts-liberation \
+    fonts-noto-color-emoji \
+    fonts-unifont \
+    fonts-freefont-ttf \
+    fonts-wqy-zenhei \
     libasound2 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
     libc6 \
     libcairo2 \
+    libcairo-gobject2 \
     libcups2 \
     libdbus-1-3 \
+    libdrm2 \
     libexpat1 \
     libfontconfig1 \
+    libgdk-pixbuf-2.0-0 \
     libgbm1 \
     libgcc1 \
     libglib2.0-0 \
@@ -61,26 +67,49 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxext6 \
     libxfixes3 \
     libxi6 \
+    libxkbcommon0 \
     libxrandr2 \
     libxrender1 \
+    libxshmfence1 \
     libxss1 \
     libxtst6 \
     lsb-release \
+    python3 \
+    python3-pip \
     wget \
     xdg-utils \
-    google-chrome-stable \
     && rm -rf /var/lib/apt/lists/*
+
+# 3. 创建共享目录并设置权限。
+# /opt/cloakbrowser 保存构建阶段预下载的浏览器，不能放到运行时会被 volume 覆盖的 /app/data。
+RUN mkdir -p /opt/cloakbrowser/home /opt/cloakbrowser/cache /opt/cloakbrowser/config \
+    /app/data/home /app/data/cache /app/data/config /app/images && \
+    chmod -R 755 /opt/cloakbrowser && \
+    chmod -R 777 /app/data /app/images
+
+# 4. 安装 CloakBrowser 并在构建阶段预下载 Chromium，避免容器运行时下载失败。
+COPY build/find_cloakbrowser_binary.py /usr/local/bin/find_cloakbrowser_binary.py
+ARG CLOAKBROWSER_VERSION=0.3.31
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install "cloakbrowser[geoip]==${CLOAKBROWSER_VERSION}"
+RUN --mount=type=cache,target=/var/cache/cloakbrowser-home/.cloakbrowser \
+    HOME=/var/cache/cloakbrowser-home \
+    XDG_CACHE_HOME=/var/cache/cloakbrowser-cache \
+    XDG_CONFIG_HOME=/var/cache/cloakbrowser-config \
+    python3 /usr/local/bin/find_cloakbrowser_binary.py \
+    --install-home /opt/cloakbrowser/home \
+    --link /usr/local/bin/cloak-chromium
+RUN \
+    test -x /usr/local/bin/cloak-chromium
 
 COPY --from=builder /out/app .
 
-# 4. 创建共享目录并设置权限
-RUN mkdir -p /app/images && \
-    chmod 777 /app/images
-
-# 5. 设置默认 Chrome 路径（rod 会用）
-ENV ROD_BROWSER_BIN=/usr/bin/google-chrome
+# 5. 设置默认 CloakBrowser Chromium 路径（rod 会用）
+ENV HOME=/app/data/home
+ENV XDG_CACHE_HOME=/app/data/cache
+ENV XDG_CONFIG_HOME=/app/data/config
+ENV ROD_BROWSER_BIN=/usr/local/bin/cloak-chromium
 
 EXPOSE 18060
 
 CMD ["./app"]
-

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,7 @@
-# Dockerfile for ARM64 architecture
-# This Dockerfile uses Chromium (auto-downloaded by go-rod) instead of Google Chrome
-# because Google Chrome does not provide official Linux ARM64 builds.
+# syntax=docker/dockerfile:1.6
+
+# Dockerfile for ARM64 architecture.
+# Uses CloakBrowser Chromium instead of Google Chrome or go-rod runtime downloads.
 
 # ---- build stage ----
 FROM golang:1.24 AS builder
@@ -31,21 +32,27 @@ RUN apt-get update && apt-get install -y ca-certificates wget gnupg && \
     sed -i 's|http://archive.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list && \
     sed -i 's|http://security.ubuntu.com|https://mirrors.aliyun.com|g' /etc/apt/sources.list
 
-# 2. 安装 Chromium 运行所需的依赖库
-# 注意：不安装 Google Chrome，因为它不支持 ARM64
-# go-rod 会在首次运行时自动从 Playwright CDN 下载 ARM64 版本的 Chromium
+# 2. 安装 CloakBrowser Chromium 运行依赖、Python 和中文字体
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     fonts-liberation \
+    fonts-noto-color-emoji \
+    fonts-unifont \
+    fonts-freefont-ttf \
+    fonts-wqy-zenhei \
     libasound2 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
     libc6 \
     libcairo2 \
+    libcairo-gobject2 \
     libcups2 \
     libdbus-1-3 \
+    libdrm2 \
     libexpat1 \
     libfontconfig1 \
+    libgdk-pixbuf-2.0-0 \
     libgbm1 \
     libgcc1 \
     libglib2.0-0 \
@@ -64,24 +71,48 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxext6 \
     libxfixes3 \
     libxi6 \
+    libxkbcommon0 \
     libxrandr2 \
     libxrender1 \
+    libxshmfence1 \
     libxss1 \
     libxtst6 \
     lsb-release \
+    python3 \
+    python3-pip \
     wget \
     xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
+# 3. 创建共享目录并设置权限。
+# /opt/cloakbrowser 保存构建阶段预下载的浏览器，不能放到运行时会被 volume 覆盖的 /app/data。
+RUN mkdir -p /opt/cloakbrowser/home /opt/cloakbrowser/cache /opt/cloakbrowser/config \
+    /app/data/home /app/data/cache /app/data/config /app/images && \
+    chmod -R 755 /opt/cloakbrowser && \
+    chmod -R 777 /app/data /app/images
+
+# 4. 安装 CloakBrowser 并在构建阶段预下载 Chromium，避免容器运行时下载失败。
+COPY build/find_cloakbrowser_binary.py /usr/local/bin/find_cloakbrowser_binary.py
+ARG CLOAKBROWSER_VERSION=0.3.31
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install "cloakbrowser[geoip]==${CLOAKBROWSER_VERSION}"
+RUN --mount=type=cache,target=/var/cache/cloakbrowser-home/.cloakbrowser \
+    HOME=/var/cache/cloakbrowser-home \
+    XDG_CACHE_HOME=/var/cache/cloakbrowser-cache \
+    XDG_CONFIG_HOME=/var/cache/cloakbrowser-config \
+    python3 /usr/local/bin/find_cloakbrowser_binary.py \
+    --install-home /opt/cloakbrowser/home \
+    --link /usr/local/bin/cloak-chromium
+RUN \
+    test -x /usr/local/bin/cloak-chromium
+
 COPY --from=builder /out/app .
 
-# 3. 创建共享目录并设置权限
-RUN mkdir -p /app/images && \
-    chmod 777 /app/images
-
-# 4. 不设置 ROD_BROWSER_BIN 环境变量
-# go-rod 会自动检测并下载适合 ARM64 架构的 Chromium 浏览器
-# Chromium 下载源：https://playwright.azureedge.net/builds/chromium/
+# 5. 设置默认 CloakBrowser Chromium 路径（rod 会用）
+ENV HOME=/app/data/home
+ENV XDG_CACHE_HOME=/app/data/cache
+ENV XDG_CONFIG_HOME=/app/data/config
+ENV ROD_BROWSER_BIN=/usr/local/bin/cloak-chromium
 
 EXPOSE 18060
 

--- a/README.md
+++ b/README.md
@@ -427,8 +427,8 @@ docker build -t xpzouying/xiaohongshu-mcp .
 
 Docker 版本会自动：
 
-- 配置 Chrome 浏览器和中文字体
-- 挂载 `./data` 用于存储 cookies
+- 配置 CloakBrowser Chromium 和中文字体
+- 挂载 `./data` 用于存储 cookies 和运行数据目录
 - 挂载 `./images` 用于存储发布的图片
 - 暴露 18060 端口供 MCP 连接
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -410,8 +410,8 @@ docker build -t xpzouying/xiaohongshu-mcp .
 
 The Docker version automatically:
 
-- Configures Chrome browser and Chinese fonts
-- Mounts `./data` for storing cookies
+- Configures CloakBrowser Chromium and Chinese fonts
+- Mounts `./data` for storing cookies and runtime data directories
 - Mounts `./images` for storing publish images
 - Exposes port 18060 for MCP connection
 

--- a/build/find_cloakbrowser_binary.py
+++ b/build/find_cloakbrowser_binary.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Prepare CloakBrowser Chromium for Docker images."""
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+from cloakbrowser import ensure_binary
+
+
+def disable_nonessential_build_hooks() -> None:
+    """Disable CloakBrowser side effects that are not needed while building images."""
+    # Docker builds only need the binary. CloakBrowser's welcome output and
+    # background update check have caused ARM64/QEMU build exits to segfault.
+    globals_ = ensure_binary.__globals__
+    globals_["_show_welcome"] = lambda: None
+    globals_["_maybe_trigger_update_check"] = lambda: None
+
+
+def find_binary() -> Path:
+    disable_nonessential_build_hooks()
+    binary = Path(ensure_binary()).expanduser()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise SystemExit(f"CloakBrowser Chromium binary is not executable: {binary}")
+
+    return binary
+
+
+def copy_to_install_home(binary: Path, install_home: Path) -> Path:
+    source_home = Path.home()
+    source_cache = source_home / ".cloakbrowser"
+    if not source_cache.is_dir():
+        raise SystemExit(f"CloakBrowser cache directory not found: {source_cache}")
+
+    try:
+        relative_binary = binary.relative_to(source_home)
+    except ValueError as exc:
+        raise SystemExit(f"CloakBrowser binary is outside HOME: {binary}") from exc
+
+    install_home.mkdir(parents=True, exist_ok=True)
+    target_cache = install_home / ".cloakbrowser"
+    if target_cache.exists():
+        shutil.rmtree(target_cache)
+    shutil.copytree(source_cache, target_cache, symlinks=True)
+
+    installed_binary = install_home / relative_binary
+    if not installed_binary.is_file() or not os.access(installed_binary, os.X_OK):
+        raise SystemExit(f"Installed CloakBrowser binary is not executable: {installed_binary}")
+
+    return installed_binary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--install-home", help="Copy CloakBrowser cache into this HOME")
+    parser.add_argument("--link", help="Create or replace a symlink to the binary")
+    args = parser.parse_args()
+
+    binary = find_binary()
+    if args.install_home:
+        binary = copy_to_install_home(binary, Path(args.install_home))
+
+    print(binary)
+
+    if args.link:
+        link = Path(args.link)
+        if link.exists() or link.is_symlink():
+            link.unlink()
+        link.symlink_to(binary)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,7 @@
 
 - 启动后，会产生一个 `images/` 目录，用于存储发布的图片。它会挂载到 Docker 容器里面。
   如果要使用本地图片发布的话，请确保图片拷贝到 `./images/` 目录下，并且让 MCP 在发布的时候，指定文件夹为：`/app/images`，否则一定失败。
+- Docker 镜像内置 CloakBrowser Chromium，并在构建阶段预下载浏览器。请挂载 `./data:/app/data`，用于持久化 cookies 和运行数据目录。
 
 ## 1. 获取 Docker 镜像
 
@@ -108,8 +109,11 @@ docker run -e XHS_PROXY=http://user:pass@proxy:port xpzouying/xiaohongshu-mcp
 
 ```yaml
 environment:
-  - ROD_BROWSER_BIN=/usr/bin/google-chrome
+  - ROD_BROWSER_BIN=/usr/local/bin/cloak-chromium
   - COOKIES_PATH=/app/data/cookies.json
+  - HOME=/app/data/home
+  - XDG_CACHE_HOME=/app/data/cache
+  - XDG_CONFIG_HOME=/app/data/config
   - XHS_PROXY=http://user:pass@proxy:port
 ```
 
@@ -133,5 +137,3 @@ Using proxy: http://***:***@proxy:port
 扫码成功后，再次扫码后，就会提示已经完成登录了。
 
 <img width="2614" height="994" alt="image" src="https://github.com/user-attachments/assets/5356914a-3241-4bfd-b6b2-49c1cc5e3394" />
-
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,10 @@ services:
       - ./data:/app/data
       - ./images:/app/images
     environment:
-      - ROD_BROWSER_BIN=/usr/bin/google-chrome
+      - ROD_BROWSER_BIN=/usr/local/bin/cloak-chromium
       - COOKIES_PATH=/app/data/cookies.json
+      - HOME=/app/data/home
+      - XDG_CACHE_HOME=/app/data/cache
+      - XDG_CONFIG_HOME=/app/data/config
     ports:
       - "18060:18060"

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -51,7 +51,7 @@ func (s *AppServer) checkLoginStatusHandler(c *gin.Context) {
 	respondSuccess(c, status, "检查登录状态成功")
 }
 
-// getLoginQrcodeHandler 处理 [GET /api/login/qrcode] 请求。
+// getLoginQrcodeHandler 处理 [GET /api/v1/login/qrcode] 请求。
 // 用于生成并返回登录二维码（Base64 图片 + 超时时间），供前端展示给用户扫码登录。
 func (s *AppServer) getLoginQrcodeHandler(c *gin.Context) {
 	result, err := s.xiaohongshuService.GetLoginQrcode(c.Request.Context())

--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ func main() {
 	if len(binPath) == 0 {
 		binPath = os.Getenv("ROD_BROWSER_BIN")
 	}
+	if binPath != "" {
+		logrus.Infof("using browser binary: %s", binPath)
+	} else {
+		logrus.Infof("browser binary is not configured; rod will auto-detect or download Chromium")
+	}
 
 	configs.InitHeadless(headless)
 	configs.SetBinPath(binPath)


### PR DESCRIPTION
## Summary

- Replace the Docker image browser runtime with CloakBrowser Chromium for both amd64 and arm64 Dockerfiles.
- Add a build helper that pre-downloads CloakBrowser Chromium, pins the CloakBrowser package version, and exposes a stable `/usr/local/bin/cloak-chromium` path for go-rod.
- Update docker compose defaults, startup logging, documentation, and ignore Docker runtime data directories.

## Why

The Docker image previously used Google Chrome on amd64 and go-rod runtime Chromium downloads on arm64. This made browser fingerprint behavior inconsistent across image variants and could fail at runtime when browser downloads were unavailable. Pre-installing CloakBrowser in the image keeps the browser layer explicit and consistent.

## Impact

- Docker users will use CloakBrowser Chromium by default through `ROD_BROWSER_BIN=/usr/local/bin/cloak-chromium`.
- Native/non-Docker users can still provide any Chrome-compatible browser through `ROD_BROWSER_BIN` or `-bin`.
- Browser automation remains implemented through the existing Go/rod flow; this PR does not migrate behavior-level automation to the CloakBrowser Python/JS wrapper.

## Validation

- `python3 -m py_compile build/find_cloakbrowser_binary.py`
- `go test $(go list ./... | grep -v '/xiaohongshu$')`
- `git diff --check`

Full `go test ./...` was not used as the `xiaohongshu` package contains browser integration tests that launch a real browser and can block on external page state.

