### PR TITLE
feat: 视频笔记返回视频直链与官方字幕 (#271)

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -856,10 +856,34 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 		return nil, fmt.Errorf("feed %s not found in noteDetailMap", feedID)
 	}
 
+	// 视频笔记：video.mediaV2 是一个 JSON 字符串，官方字幕埋在 video.subtitles 里。
+	// 解析出来挂到 Note.Video.Subtitles，让调用方可直接拿到字幕。
+	enrichVideoSubtitles(&noteDetail.Note)
+
 	return &FeedDetailResponse{
 		Note:     noteDetail.Note,
 		Comments: noteDetail.Comments,
 	}, nil
+}
+
+// enrichVideoSubtitles 把 video.mediaV2（JSON 字符串）里的官方字幕解析到 Video.Subtitles，
+// 并清空体积庞大的 RawMediaV2 原始串。解析失败不影响主流程（字幕只是增益）。
+func enrichVideoSubtitles(note *FeedDetail) {
+	if note == nil || note.Video == nil || note.Video.RawMediaV2 == "" {
+		return
+	}
+	raw := note.Video.RawMediaV2
+	note.Video.RawMediaV2 = "" // 不在响应里回传巨大的原始串
+
+	var payload mediaV2Payload
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		logrus.Debugf("解析 mediaV2 字幕失败（忽略）: %v", err)
+		return
+	}
+	if len(payload.Video.Subtitles) > 0 {
+		note.Video.Subtitles = payload.Video.Subtitles
+		logrus.Infof("✓ 提取到官方字幕语种: %d 种", len(payload.Video.Subtitles))
+	}
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -75,12 +75,65 @@ type ImageInfo struct {
 
 // Video 表示视频信息
 type Video struct {
-	Capa VideoCapability `json:"capa"`
+	Capa  VideoCapability `json:"capa"`
+	Media *VideoMedia     `json:"media,omitempty"` // 详情页才有；搜索列表里通常为 nil
+
+	// RawMediaV2 捕获 __INITIAL_STATE__.note.video.mediaV2（一个 JSON 字符串），
+	// 仅用于在 extractFeedDetail 后解析出官方字幕；解析完会被清空，不出现在响应里。
+	RawMediaV2 string `json:"mediaV2,omitempty"`
+
+	// Subtitles 官方字幕，按语种分组（如 source / zh-CN / en-US）。
+	// 有字幕时可直接下载对应 .srt 拿到视频文案。
+	Subtitles map[string][]SubtitleItem `json:"subtitles,omitempty"`
+}
+
+// SubtitleItem 单条字幕轨：URL 指向 .srt 文件（带 sign+t 时效签名，过期即失效）
+type SubtitleItem struct {
+	URL      string `json:"url"`
+	Language string `json:"language"`
+	Format   int    `json:"format"`
+	Type     int    `json:"type"`
+}
+
+// mediaV2Payload 用于解析 video.mediaV2 字符串里的字幕（其余字段忽略）
+type mediaV2Payload struct {
+	Video struct {
+		Subtitles map[string][]SubtitleItem `json:"subtitles"`
+	} `json:"video"`
 }
 
 // VideoCapability 表示视频能力信息
 type VideoCapability struct {
 	Duration int `json:"duration"` // 视频时长，单位秒
+}
+
+// VideoMedia 表示视频媒体信息（详情页 __INITIAL_STATE__.note.video.media）
+type VideoMedia struct {
+	VideoID int64            `json:"videoId"`
+	Stream  VideoStreamGroup `json:"stream"`
+}
+
+// VideoStreamGroup 按编码分组的视频流列表（h264 通用兼容性最好）
+type VideoStreamGroup struct {
+	H264 []VideoStreamItem `json:"h264"`
+	H265 []VideoStreamItem `json:"h265"`
+	H266 []VideoStreamItem `json:"h266"`
+	AV1  []VideoStreamItem `json:"av1"`
+}
+
+// VideoStreamItem 单个视频流：MasterURL 带 sign+t 时效签名，过期回退 BackupURLs
+type VideoStreamItem struct {
+	MasterURL   string   `json:"masterUrl"`
+	BackupURLs  []string `json:"backupUrls"`
+	Format      string   `json:"format"`
+	Width       int      `json:"width"`
+	Height      int      `json:"height"`
+	Duration    int      `json:"duration"` // 毫秒
+	Size        int64    `json:"size"`
+	VideoCodec  string   `json:"videoCodec"`
+	AudioCodec  string   `json:"audioCodec"`
+	StreamType  int      `json:"streamType"`
+	QualityType string   `json:"qualityType"`
 }
 
 // ================ Feed 详情页相关结构体 ================
@@ -103,6 +156,7 @@ type FeedDetail struct {
 	User         User              `json:"user"`
 	InteractInfo InteractInfo      `json:"interactInfo"`
 	ImageList    []DetailImageInfo `json:"imageList"`
+	Video        *Video            `json:"video,omitempty"` // 视频笔记才有；含 media.stream.h264[].masterUrl
 }
 
 // DetailImageInfo 表示详情页的图片信息


### PR DESCRIPTION
## 背景

closes #271

`get_feed_detail` 此前对 `type=video` 的笔记不返回任何视频媒体信息——`imageList` 里只有封面图，拿不到视频地址。本 PR 补全视频直链与官方字幕。

## 改动

仅改 `xiaohongshu/types.go` 和 `xiaohongshu/feed_detail.go`，**无 JS 注入**，沿用既有的 `__INITIAL_STATE__` 解析路径。

### 1. 视频直链
`FeedDetail.Video` 补全 `media.stream`（h264/h265/h266/av1），每条流含 `masterUrl`（带 `sign`+`t` 时效签名）、`backupUrls`、分辨率、时长、大小等。这些字段 `__INITIAL_STATE__.note.video` 本就有，原 struct 未声明而被 `json.Unmarshal` 丢弃，补上 struct 即自动透传。

### 2. 官方字幕
`video.mediaV2` 是一个 **JSON 字符串**，官方字幕埋在 `mediaV2.video.subtitles`（`source` / `zh-CN` / `en-US`，每条是 `.srt` 地址）。新增 `enrichVideoSubtitles` 解析该字符串填充 `Video.Subtitles`，并清空体积庞大的原始串避免污染响应。调用方有字幕时可直接下载 srt 拿到视频文案。

## 本地验证

真实视频笔记（账号信息已打码，签名以 `***` 替代）一次拿到 mp4 直链 + 三语种字幕：

```json
{
  "note": {
    "type": "video",
    "title": "别让这些行为害了你的猫",
    "video": {
      "capa": { "duration": 262 },
      "media": { "stream": { "h264": [{
        "masterUrl": "http://sns-video-v6.xhscdn.com/stream/1/110/259/...&sign=***&t=***",
        "width": 720, "height": 1280, "duration": 262223,
        "size": 27103190, "videoCodec": "h264", "format": "mp4"
      }]}},
      "subtitles": {
        "zh-CN":  [{ "url": "https://sns-subtitle-s2.xhscdn.com/subtitle/.../11.srt?sign=***&t=***", "language": "zh-CN" }],
        "source": [{ "url": "https://sns-subtitle-s2.xhscdn.com/subtitle/.../1.srt?sign=***&t=***",  "language": "zh-CN" }],
        "en-US":  [{ "url": "https://sns-subtitle-s2.xhscdn.com/subtitle/.../12.srt?sign=***&t=***", "language": "en-US" }]
      }
    }
  }
}
```

下载 `zh-CN` 字幕的 srt 内容（节选），可见官方字幕带精确时间戳、人名术语准确：

```
1
00:00:00,030 --> 00:00:02,110
没文化真的是高危家长

4
00:00:08,680 --> 00:00:14,000
胡邦颖医生的，他发了一条关于猫猫这个慢性压力的一条视频，里面列举了非常多
```

## Checklist
- [x] 代码已在本地运行并验证通过
- [x] 一个 PR 仅包含一个功能（视频笔记媒体信息提取，对应 #271）
- [x] 演示已对账号信息/签名打码
- [x] 无 JS 注入，纯 Go struct + json 解析
- [x] 已 `gofmt`，中文注释

> 备注：`sign`/`t` 是 CDN 时效签名，需当场使用；过期重新调用即可。