### PR TITLE
fix: 修复登录态检测抖动与搜索结果时序竞态

### DIFF
--- a/cmd/debug_search/main.go
+++ b/cmd/debug_search/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
+	appbrowser "github.com/xpzouying/xiaohongshu-mcp/browser"
+)
+
+func main() {
+	binPath := os.Getenv("ROD_BROWSER_BIN")
+	b := appbrowser.NewBrowser(true, appbrowser.WithBinPath(binPath))
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	pp := page.Timeout(40 * time.Second).Context(ctx)
+	url := os.Getenv("DEBUG_SEARCH_URL")
+	if url == "" {
+		url = "https://www.xiaohongshu.com/search_result?keyword=%E4%B8%80%E4%BA%BA%E5%85%AC%E5%8F%B8&source=web_explore_feed"
+	}
+	pp.MustNavigate(url).MustWaitLoad()
+
+	if keyword := os.Getenv("DEBUG_SEARCH_KEYWORD"); keyword != "" {
+		inputElem := pp.MustElement("#search-input")
+		inputElem.MustSelectAllText()
+		inputElem.MustInput(keyword).MustType(input.Enter)
+		pp.MustWait(`() => window.location.href.includes('/search_result') || (document.body && document.body.innerText.includes('登录后查看搜索结果'))`)
+		pp.MustWaitLoad()
+	}
+
+	hasInitialState := false
+	waitErr := rod.Try(func() {
+		pp.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+		hasInitialState = true
+	})
+
+	info := pp.MustInfo()
+	title := info.Title
+	currentURL := info.URL
+	htmlSnippet := pp.MustElement("body").MustText()
+	feedsState := pp.MustEval(`() => {
+		const s = window.__INITIAL_STATE__;
+		if (!s || !s.search) return JSON.stringify({hasSearch:false});
+		const feeds = s.search.feeds;
+		const raw = feeds ? (feeds.value !== undefined ? feeds.value : feeds._value) : undefined;
+		const topLevelKeys = Object.keys(s || {});
+		const searchEntries = Object.entries(s.search || {}).map(([key, value]) => ({
+			key,
+			type: Array.isArray(value) ? "array" : typeof value,
+			hasValue: !!value,
+			length: Array.isArray(value) ? value.length : undefined,
+		}));
+		return JSON.stringify({
+			hasSearch: true,
+			hasFeeds: !!feeds,
+			feedsType: typeof raw,
+			feedsIsArray: Array.isArray(raw),
+			feedsLength: Array.isArray(raw) ? raw.length : -1,
+			searchKeys: Object.keys(s.search || {}),
+			topLevelKeys,
+			searchEntries,
+		});
+	}`).String()
+	pageSignals := pp.MustEval(`() => JSON.stringify({
+		pathname: location.pathname,
+		title: document.title,
+		bodyText: document.body ? document.body.innerText.slice(0, 1200) : "",
+		hasNotFoundText: document.body ? document.body.innerText.includes("你访问的页面不见了") : false,
+		hasAntiSpamText: document.body ? document.body.innerText.includes("anti_spam") : false,
+		linkCount: document.querySelectorAll('a').length,
+		noteLinkCount: document.querySelectorAll('a[href*="/explore/"]').length,
+		searchResultLinkCount: document.querySelectorAll('a[href*="/search_result"]').length,
+	})`).String()
+	inputsState := pp.MustEval(`() => JSON.stringify(
+		Array.from(document.querySelectorAll('input'))
+			.map((el, i) => ({
+				i,
+				placeholder: el.getAttribute('placeholder'),
+				value: el.value,
+				className: el.className,
+				type: el.type,
+			}))
+	)`).String()
+	searchWidgetState := pp.MustEval(`() => {
+		const el = document.querySelector('input.search-input');
+		if (!el) return '';
+		const parent = el.parentElement;
+		return parent ? parent.outerHTML.slice(0, 2000) : el.outerHTML.slice(0, 2000);
+	}`).String()
+
+	fmt.Printf("title=%s\n", title)
+	fmt.Printf("url=%s\n", currentURL)
+	fmt.Printf("hasInitialState=%v\n", hasInitialState)
+	fmt.Printf("feedsState=%s\n", feedsState)
+	fmt.Printf("inputsState=%s\n", inputsState)
+	fmt.Printf("searchWidgetState=%s\n", searchWidgetState)
+	fmt.Printf("pageSignals=%s\n", pageSignals)
+	if waitErr != nil {
+		fmt.Printf("waitErr=%v\n", waitErr)
+	}
+	if len(htmlSnippet) > 800 {
+		htmlSnippet = htmlSnippet[:800]
+	}
+	fmt.Printf("body=%s\n", htmlSnippet)
+}

--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -36,6 +36,10 @@ func main() {
 	logrus.Infof("当前登录状态: %v", status)
 
 	if status {
+		if err := saveCookies(page); err != nil {
+			logrus.Fatalf("failed to save cookies: %v", err)
+		}
+		logrus.Info("检测到已登录，已同步保存当前 cookies。")
 		return
 	}
 

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -2,6 +2,7 @@ package xiaohongshu
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -22,16 +23,11 @@ func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 
 	time.Sleep(1 * time.Second)
 
-	exists, _, err := pp.Has(`.main-container .user .link-wrapper .channel`)
+	ok, err := a.isLoggedIn(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "check login status failed")
 	}
-
-	if !exists {
-		return false, errors.Wrap(err, "login status element not found")
-	}
-
-	return true, nil
+	return ok, nil
 }
 
 func (a *LoginAction) Login(ctx context.Context) error {
@@ -44,16 +40,60 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	time.Sleep(2 * time.Second)
 
 	// 检查是否已经登录
-	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists && !hasLoginGate(pp) {
 		// 已经登录，直接返回
 		return nil
 	}
 
-	// 等待扫码成功提示或者登录完成
-	// 这里我们等待登录成功的元素出现，这样更简单可靠
-	pp.MustElement(".main-container .user .link-wrapper .channel")
+	waitCtx, cancel := context.WithTimeout(ctx, 4*time.Minute)
+	defer cancel()
 
-	return nil
+	ticker := time.NewTicker(800 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("等待登录超时，请在弹出的浏览器中完成扫码登录")
+		case <-ticker.C:
+			ok, err := a.isLoggedIn(waitCtx)
+			if err != nil {
+				// 扫码登录过程中页面会刷新或重建，短暂会话抖动直接重试。
+				continue
+			}
+			if ok {
+				return nil
+			}
+		}
+	}
+}
+
+func hasLoginGate(page *rod.Page) bool {
+	result, err := page.Eval(`() => {
+		const bodyText = document.body ? document.body.innerText : "";
+		const input = document.querySelector('#search-input');
+		const placeholder = input ? (input.getAttribute('placeholder') || '') : '';
+		return bodyText.includes('获取验证码') ||
+			bodyText.includes('登录后查看搜索结果') ||
+			placeholder.includes('登录探索更多内容');
+	}`)
+	if err != nil {
+		return false
+	}
+	return result.Value.Bool()
+}
+
+func (a *LoginAction) isLoggedIn(ctx context.Context) (bool, error) {
+	pp := a.page.Context(ctx)
+	if hasLoginGate(pp) {
+		return false, nil
+	}
+
+	exists, _, err := pp.Has(`.main-container .user .link-wrapper .channel`)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error) {

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 )
 
@@ -165,27 +166,54 @@ func NewSearchAction(page *rod.Page) *SearchAction {
 	return &SearchAction{page: pp}
 }
 
+// waitForFeedsSettled 等待搜索结果异步数据真正加载完成。
+// window.__INITIAL_STATE__ 在页面刚初始化时就已存在（feeds 是空数组占位），
+// 直接判断它 !== undefined 会在异步请求返回之前读到"假的空结果"。
+// 这里改为轮询等待，直到 feeds 数组非空、或明确出现登录墙/笔记链接等可判定信号；
+// 超时（8秒）后放弃等待，按当前状态继续——此时才认为是真实的零结果。
+func waitForFeedsSettled(page *rod.Page) {
+	settledJS := `() => {
+		if (window.__INITIAL_STATE__ === undefined) return false;
+		if (document.body && document.body.innerText.includes('登录后查看搜索结果')) return true;
+		const search = window.__INITIAL_STATE__.search;
+		if (!search) return false;
+		const feeds = search.feeds;
+		const raw = feeds ? (feeds.value !== undefined ? feeds.value : feeds._value) : undefined;
+		if (Array.isArray(raw) && raw.length > 0) return true;
+		return document.querySelectorAll('a[href*="/explore/"]').length > 0;
+	}`
+
+	_ = rod.Try(func() {
+		page.Timeout(8 * time.Second).MustWait(settledJS)
+	})
+}
+
 func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...FilterOption) ([]Feed, error) {
 	page := s.page.Context(ctx)
 
-	searchURL := makeSearchURL(keyword)
-	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	// 搜索页直接打开经常落到“登录后查看搜索结果”的壳页。
+	// 先从首页进入，复用页面初始化后的登录态和前端上下文，再触发真实搜索。
+	page.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	page.MustWait(`() => document.querySelector('#search-input') !== null`)
+	searchInput := page.MustElement("#search-input")
+	searchInput.MustSelectAllText()
+	searchInput.MustInput(keyword).MustType(input.Enter)
+	page.MustWait(`() => window.location.href.includes('/search_result') || (document.body && document.body.innerText.includes('登录后查看搜索结果'))`)
+	page.MustWaitLoad()
+	waitForFeedsSettled(page)
 
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
-
-	// 如果有筛选条件，则应用筛选
-	if len(filters) > 0 {
-		// 将所有 FilterOption 转换为内部筛选选项
-		var allInternalFilters []internalFilterOption
-		for _, filter := range filters {
-			internalFilters, err := convertToInternalFilters(filter)
-			if err != nil {
-				return nil, fmt.Errorf("筛选选项转换失败: %w", err)
-			}
-			allInternalFilters = append(allInternalFilters, internalFilters...)
+	// 将所有 FilterOption 转换为内部筛选选项
+	var allInternalFilters []internalFilterOption
+	for _, filter := range filters {
+		internalFilters, err := convertToInternalFilters(filter)
+		if err != nil {
+			return nil, fmt.Errorf("筛选选项转换失败: %w", err)
 		}
+		allInternalFilters = append(allInternalFilters, internalFilters...)
+	}
 
+	// 只有存在有效筛选项时才操作筛选面板；空筛选对象会导致页面一直等待弹层。
+	if len(allInternalFilters) > 0 {
 		// 验证所有内部筛选选项
 		for _, filter := range allInternalFilters {
 			if err := validateInternalFilterOption(filter); err != nil {
@@ -208,10 +236,28 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 			option.MustClick()
 		}
 
-		// 等待页面更新
-		page.MustWaitStable()
-		// 重新等待 __INITIAL_STATE__ 更新
-		page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+		// 搜索页会持续请求推荐流，等待 stable 容易卡死；这里只等筛选后的状态回填。
+		page.MustWaitLoad()
+		waitForFeedsSettled(page)
+	}
+
+	pageState := page.MustEval(`() => JSON.stringify({
+		bodyText: document.body ? document.body.innerText.slice(0, 500) : "",
+		hasLoginGate: document.body ? document.body.innerText.includes("登录后查看搜索结果") : false,
+		pathname: location.pathname,
+		url: location.href,
+	})`).String()
+
+	if pageState != "" {
+		var state struct {
+			BodyText     string `json:"bodyText"`
+			HasLoginGate bool   `json:"hasLoginGate"`
+			Pathname     string `json:"pathname"`
+			URL          string `json:"url"`
+		}
+		if err := json.Unmarshal([]byte(pageState), &state); err == nil && state.HasLoginGate {
+			return nil, fmt.Errorf("搜索页未进入可见结果态，当前页面提示需要登录查看搜索结果: %s", state.URL)
+		}
 	}
 
 	result := page.MustEval(`() => {


### PR DESCRIPTION
## 背景

本地实测 `search_feeds` 时发现，账号明明已登录，`check_login_status` 却时而报未登录；同时在确认登录、无报错、无登录墙提示的情况下，`search_feeds` 对明显有大量内容的热门关键词（如"一人公司"）返回空结果集。

## 排查过程

用仓库里的 `cmd/debug_search` 思路做了状态 dump，定位到根因：

- `window.__INITIAL_STATE__` 在页面刚初始化时就已存在（`search.feeds` 是占位空数组），原来的等待条件 `window.__INITIAL_STATE__ !== undefined` 会在异步搜索请求真正返回、feeds 被填充之前就判定"加载完成"，导致把有结果的查询误判为空结果。人工加 5 秒延时后复测，`feedsLength` 从 0 变为 22，验证了这个时序竞态。
- `CheckLoginStatus`/`Login` 原来只靠单个 DOM 元素（`.main-container .user .link-wrapper .channel`）是否存在做一次性判断，页面刷新/重建的瞬间容易读到假的"未登录"状态。

## 改动

- `xiaohongshu/search.go`：新增 `waitForFeedsSettled`，改为轮询等待 feeds 数组非空、或出现登录墙文案、或 DOM 中出现笔记链接等可判定信号，超时（8秒）后才按当前状态继续（此时才认为是真实的零结果）
- `xiaohongshu/login.go`：`CheckLoginStatus`/`Login` 改为轮询判断真实登录态（含登录墙文案检测：`获取验证码`/`登录后查看搜索结果`/`登录探索更多内容`），替代原来的一次性 DOM 判断
- `cmd/login/main.go`：检测到已登录时同步保存 cookies，保证 `cookies.json` 与实际会话一致
- 新增 `cmd/debug_search`：调试工具，dump 搜索页真实状态（feeds 长度、DOM 笔记链接数、反爬/登录墙文案等），方便以后排查类似问题

## 测试

- `go build ./...` 通过
- 用修复后的服务实测 MCP `search_feeds("一人公司")`，稳定返回 22 条真实结果（此前空结果/超时/报错都出现过）