### PR TITLE
feat: add user search support

### DIFF
--- a/handlers_api.go
+++ b/handlers_api.go
@@ -172,6 +172,40 @@ func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 	respondSuccess(c, result, "搜索Feeds成功")
 }
 
+// searchUsersHandler 搜索用户
+func (s *AppServer) searchUsersHandler(c *gin.Context) {
+	var keyword string
+
+	switch c.Request.Method {
+	case http.MethodPost:
+		var searchReq SearchUsersRequest
+		if err := c.ShouldBindJSON(&searchReq); err != nil {
+			respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+				"请求参数错误", err.Error())
+			return
+		}
+		keyword = searchReq.Keyword
+	default:
+		keyword = c.Query("keyword")
+	}
+
+	if keyword == "" {
+		respondError(c, http.StatusBadRequest, "MISSING_KEYWORD",
+			"缺少关键词参数", "keyword parameter is required")
+		return
+	}
+
+	result, err := s.xiaohongshuService.SearchUsers(c.Request.Context(), keyword)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "SEARCH_USERS_FAILED",
+			"搜索用户失败", err.Error())
+		return
+	}
+
+	c.Set("account", "ai-report")
+	respondSuccess(c, result, "搜索用户成功")
+}
+
 // getFeedDetailHandler 获取Feed详情
 func (s *AppServer) getFeedDetailHandler(c *gin.Context) {
 	var req FeedDetailRequest

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -357,6 +357,52 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 	}
 }
 
+// handleSearchUsers 处理搜索用户
+func (s *AppServer) handleSearchUsers(ctx context.Context, args SearchUsersArgs) *MCPToolResult {
+	logrus.Info("MCP: 搜索用户")
+
+	if args.Keyword == "" {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "搜索用户失败: 缺少关键词参数",
+			}},
+			IsError: true,
+		}
+	}
+
+	logrus.Infof("MCP: 搜索用户 - 关键词: %s", args.Keyword)
+
+	result, err := s.xiaohongshuService.SearchUsers(ctx, args.Keyword)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: "搜索用户失败: " + err.Error(),
+			}},
+			IsError: true,
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("搜索用户成功，但序列化失败: %v", err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{
+			Type: "text",
+			Text: string(jsonData),
+		}},
+	}
+}
+
 // handleGetFeedDetail 处理获取Feed详情
 func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取Feed详情")

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -44,6 +44,11 @@ type SearchFeedsArgs struct {
 	Filters FilterOption `json:"filters,omitempty" jsonschema:"筛选选项"`
 }
 
+// SearchUsersArgs 搜索用户的参数
+type SearchUsersArgs struct {
+	Keyword string `json:"keyword" jsonschema:"搜索用户关键词，如运动员姓名、职业、机构名"`
+}
+
 // FilterOption 筛选选项结构体
 type FilterOption struct {
 	SortBy      string `json:"sort_by,omitempty" jsonschema:"排序依据: 综合|最新|最多点赞|最多评论|最多收藏,默认为'综合'"`
@@ -260,7 +265,23 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 7: 获取Feed详情
+	// 工具 7: 搜索用户
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "search_users",
+			Description: "搜索小红书用户（需要已登录）",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Search Users",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("search_users", func(ctx context.Context, req *mcp.CallToolRequest, args SearchUsersArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleSearchUsers(ctx, args)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 8: 获取Feed详情
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
@@ -305,7 +326,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 8: 获取用户主页
+	// 工具 9: 获取用户主页
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "user_profile",
@@ -325,7 +346,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 9: 发表评论
+	// 工具 10: 发表评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "post_comment_to_feed",
@@ -346,7 +367,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 10: 回复评论
+	// 工具 11: 回复评论
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "reply_comment_in_feed",
@@ -376,7 +397,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		},
 	)
 
-	// 工具 11: 发布视频（仅本地文件）
+	// 工具 12: 发布视频（仅本地文件）
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "publish_with_video",
@@ -401,7 +422,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 12: 点赞笔记
+	// 工具 13: 点赞笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "like_feed",
@@ -422,7 +443,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	// 工具 13: 收藏笔记
+	// 工具 14: 收藏笔记
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "favorite_feed",
@@ -443,7 +464,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 13)
+	logrus.Infof("Registered %d MCP tools", 14)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/routes.go
+++ b/routes.go
@@ -46,6 +46,8 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.GET("/feeds/list", appServer.listFeedsHandler)
 		api.GET("/feeds/search", appServer.searchFeedsHandler)
 		api.POST("/feeds/search", appServer.searchFeedsHandler)
+		api.GET("/users/search", appServer.searchUsersHandler)
+		api.POST("/users/search", appServer.searchUsersHandler)
 		api.POST("/feeds/detail", appServer.getFeedDetailHandler)
 		api.POST("/user/profile", appServer.userProfileHandler)
 		api.POST("/feeds/comment", appServer.postCommentHandler)

--- a/service.go
+++ b/service.go
@@ -86,6 +86,12 @@ type FeedsListResponse struct {
 	Count int                `json:"count"`
 }
 
+// SearchUsersResponse 用户搜索响应
+type SearchUsersResponse struct {
+	Users []xiaohongshu.SearchUser `json:"users"`
+	Count int                      `json:"count"`
+}
+
 // UserProfileResponse 用户主页响应
 type UserProfileResponse struct {
 	UserBasicInfo xiaohongshu.UserBasicInfo      `json:"userBasicInfo"`
@@ -386,6 +392,29 @@ func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, fi
 	response := &FeedsListResponse{
 		Feeds: feeds,
 		Count: len(feeds),
+	}
+
+	return response, nil
+}
+
+// SearchUsers 搜索用户
+func (s *XiaohongshuService) SearchUsers(ctx context.Context, keyword string) (*SearchUsersResponse, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	action := xiaohongshu.NewSearchUserAction(page)
+
+	users, err := action.SearchUsers(ctx, keyword)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SearchUsersResponse{
+		Users: users,
+		Count: len(users),
 	}
 
 	return response, nil

--- a/types.go
+++ b/types.go
@@ -59,6 +59,10 @@ type SearchFeedsRequest struct {
 	Filters xiaohongshu.FilterOption `json:"filters,omitempty"`
 }
 
+type SearchUsersRequest struct {
+	Keyword string `json:"keyword" binding:"required"`
+}
+
 // FeedDetailResponse Feed详情响应
 type FeedDetailResponse struct {
 	FeedID string `json:"feed_id"`

--- a/xiaohongshu/search_user.go
+++ b/xiaohongshu/search_user.go
@@ -1,0 +1,64 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-rod/rod"
+)
+
+type SearchUserAction struct {
+	page *rod.Page
+}
+
+// NewSearchUserAction 创建用户搜索动作
+func NewSearchUserAction(page *rod.Page) *SearchUserAction {
+	pp := page.Timeout(60 * time.Second)
+
+	return &SearchUserAction{page: pp}
+}
+
+// SearchUsers 根据关键词搜索用户
+func (s *SearchUserAction) SearchUsers(ctx context.Context, keyword string) ([]SearchUser, error) {
+	page := s.page.Context(ctx)
+
+	// 打开搜索页，默认进入笔记搜索结果
+	searchURL := makeSearchURL(keyword)
+	page.MustNavigate(searchURL)
+	page.MustWaitStable()
+	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+
+	// 切换到用户搜索结果
+	userTab := page.MustElement(`div#user.channel`)
+	userTab.MustClick()
+
+	// 等待用户列表加载完成，或者页面明确显示没有相关用户
+	page.MustWait(`() => {
+		const userLists = window.__INITIAL_STATE__?.search?.userLists;
+		const users = userLists?.value !== undefined ? userLists.value : userLists?._value;
+		return Array.isArray(users) && users.length > 0;
+	}`)
+
+	// 从页面初始状态中读取用户列表
+	result := page.MustEval(`() => {
+		const userLists = window.__INITIAL_STATE__?.search?.userLists;
+		const users = userLists?.value !== undefined ? userLists.value : userLists?._value;
+		if (users) {
+			return JSON.stringify(users);
+		}
+		return "";
+	}`).String()
+
+	if result == "" {
+		return nil, fmt.Errorf("search.userLists.value not found in __INITIAL_STATE__")
+	}
+
+	var users []SearchUser
+	if err := json.Unmarshal([]byte(result), &users); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal users: %w", err)
+	}
+
+	return users, nil
+}

--- a/xiaohongshu/search_user.go
+++ b/xiaohongshu/search_user.go
@@ -36,8 +36,13 @@ func (s *SearchUserAction) SearchUsers(ctx context.Context, keyword string) ([]S
 
 	// 等待用户列表加载完成，或者页面明确显示没有相关用户
 	page.MustWait(`() => {
-		const userLists = window.__INITIAL_STATE__?.search?.userLists;
-		const users = userLists?.value !== undefined ? userLists.value : userLists?._value;
+		const bodyText = document.body ? document.body.innerText : '';
+		if (bodyText.includes('没找到相关用户')) return true;
+
+		const search = window.__INITIAL_STATE__?.search;
+		const userLists = search?.userLists;
+		const users = userLists ? (userLists.value !== undefined ? userLists.value : userLists._value) : undefined;
+
 		return Array.isArray(users) && users.length > 0;
 	}`)
 

--- a/xiaohongshu/search_user_test.go
+++ b/xiaohongshu/search_user_test.go
@@ -1,0 +1,71 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xpzouying/xiaohongshu-mcp/browser"
+)
+
+func TestSearchUsers(t *testing.T) {
+	if os.Getenv("XHS_RUN_BROWSER_TESTS") != "1" {
+		t.Skip("skip browser integration test; set XHS_RUN_BROWSER_TESTS=1 to enable")
+	}
+
+	b := browser.NewBrowser(false)
+	defer b.Close()
+
+	page := b.NewPage()
+	defer func() {
+		_ = page.Close()
+	}()
+
+	action := NewSearchUserAction(page)
+
+	users, err := action.SearchUsers(context.Background(), "张雨霏")
+	require.NoError(t, err)
+	require.NotEmpty(t, users, "users should not be empty")
+
+	fmt.Printf("成功获取到 %d 个用户\n", len(users))
+
+	for _, user := range users {
+		fmt.Printf("User ID: %s\n", user.ID)
+		fmt.Printf("User Name: %s\n", user.Name)
+	}
+}
+
+func TestSearchUserUnmarshal(t *testing.T) {
+	raw := `{
+		"id": "test_user_id",
+		"xsecToken": "test_xsec_token",
+		"redId": "test_red_id",
+		"name": "测试用户",
+		"subTitle": "小红书号：test_red_id",
+		"profession": "运动员",
+		"fans": "1.2万",
+		"noteCount": 10,
+		"redOfficialVerified": true,
+		"redOfficialVerifyType": 1,
+		"image": "https://example.com/avatar.webp"
+	}`
+
+	var user SearchUser
+	err := json.Unmarshal([]byte(raw), &user)
+	require.NoError(t, err)
+
+	require.Equal(t, "test_user_id", user.ID)
+	require.Equal(t, "test_xsec_token", user.XsecToken)
+	require.Equal(t, "test_red_id", user.RedID)
+	require.Equal(t, "测试用户", user.Name)
+	require.Equal(t, "小红书号：test_red_id", user.SubTitle)
+	require.Equal(t, "运动员", user.Profession)
+	require.Equal(t, "1.2万", user.Fans)
+	require.Equal(t, 10, user.NoteCount)
+	require.True(t, user.Verified)
+	require.Equal(t, 1, user.VerificationType)
+	require.Equal(t, "https://example.com/avatar.webp", user.AvatarURL)
+}

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -168,3 +168,18 @@ type UserInteractions struct {
 	Name  string `json:"name"`  // 关注 粉丝 获赞与收藏
 	Count string `json:"count"` // 数量
 }
+
+// SearchUser 表示用户搜索结果中的用户卡片
+type SearchUser struct {
+	ID               string `json:"id"`
+	XsecToken        string `json:"xsecToken"`
+	RedID            string `json:"redId"`
+	Name             string `json:"name"`
+	SubTitle         string `json:"subTitle"`
+	Profession       string `json:"profession"`
+	Fans             string `json:"fans"`
+	NoteCount        int    `json:"noteCount"`
+	Verified         bool   `json:"redOfficialVerified"`
+	VerificationType int    `json:"redOfficialVerifyType"`
+	AvatarURL        string `json:"image"`
+}


### PR DESCRIPTION
## Summary

新增小红书用户搜索能力，用于根据关键词搜索用户。

- 新增 `SearchUserAction`，支持切换到搜索页的用户 tab 并读取 `search.userLists`
- 新增 `SearchUser` 类型，返回用户 ID、小红书号、昵称、职业、粉丝数、笔记数、认证状态、头像等信息
- 新增 MCP 工具 `search_users`
- 新增 HTTP API：`GET/POST /api/v1/users/search`
- 新增用户搜索相关测试

SearchUser 类型说明

字段 | JSON 字段 | 说明
-- | -- | --
ID | id | 用户主页 ID，可用于定位用户主页
XsecToken | xsecToken | 访问用户相关页面时可能需要的安全 token
RedID | redId | 小红书号
Name | name | 用户昵称
SubTitle | subTitle | 用户副标题，通常包含“小红书号：xxx”
Profession | profession | 用户职业或身份标签，例如“运动员”
Fans | fans | 粉丝数展示文本，例如 75.7万
NoteCount | noteCount | 笔记数量
Verified | redOfficialVerified | 是否为官方认证用户
VerificationType | redOfficialVerifyType | 官方认证类型
AvatarURL | image | 用户头像地址


## Verification

- [x] 本地已验证：

```bash
COOKIES_PATH=$(pwd)/cookies.json \
XHS_RUN_BROWSER_TESTS=1 \
go test ./xiaohongshu -run '^TestSearchUser*'
```

包含两个测试

- 一个单元测试，验证用户搜索结果 JSON 能否正确反序列化到 `SearchUser` 结构体中。
- 一个浏览器集成测试，由于该测试依赖登录 cookies 和代理网络环境，默认不会执行。需要显式设置环境变量 `XHS_RUN_BROWSER_TESTS=1` 后才会运行

- [x] 上传Demo视频

https://github.com/user-attachments/assets/fb2946ef-a1d0-4e85-851e-5e6b42582f11

## Notes

该 PR 可能会与 #716 中的浏览器 action 重构产生冲突。

当前实现沿用了项目现有的 `*rod.Page` 写法。如果 #716 先合并，本 PR 需要在合并前同步调整为新的浏览器封装方式。