### PR TITLE
fix: 登录状态接口返回真实账号信息

### DIFF
--- a/configs/username.go
+++ b/configs/username.go
@@ -1,5 +1,0 @@
-package configs
-
-const (
-	Username = "xiaohongshu-mcp"
-)

--- a/service.go
+++ b/service.go
@@ -41,7 +41,8 @@ type PublishRequest struct {
 // LoginStatusResponse 登录状态响应
 type LoginStatusResponse struct {
 	IsLoggedIn bool   `json:"is_logged_in"`
-	Username   string `json:"username,omitempty"`
+	Username   string `json:"username,omitempty"` // 当前登录账号的昵称
+	UserID     string `json:"user_id,omitempty"`  // 用户唯一标识（个人主页 URL 中的 ID）
 }
 
 // LoginQrcodeResponse 登录扫码二维码
@@ -117,7 +118,16 @@ func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatus
 
 	response := &LoginStatusResponse{
 		IsLoggedIn: isLoggedIn,
-		Username:   configs.Username,
+	}
+
+	// 已登录时从当前页读取真实账号信息；读不到只记 warn，不影响状态返回。
+	if isLoggedIn {
+		if user, err := loginAction.CurrentUser(ctx); err != nil {
+			logrus.Warnf("failed to get current user info: %v", err)
+		} else {
+			response.Username = user.Nickname
+			response.UserID = user.UserID
+		}
 	}
 
 	return response, nil

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -2,6 +2,7 @@ package xiaohongshu
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -33,6 +34,40 @@ func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// CurrentUser 当前登录用户的基础信息。
+type CurrentUser struct {
+	Nickname string `json:"nickname"`
+	UserID   string `json:"userId"`
+}
+
+// CurrentUser 从当前页面的 __INITIAL_STATE__ 读取登录用户信息。
+// 需在 CheckLoginStatus 之后调用：复用已加载的 explore 页，不做额外导航。
+func (a *LoginAction) CurrentUser(ctx context.Context) (*CurrentUser, error) {
+	pp := a.page.Context(ctx).Timeout(10 * time.Second)
+
+	res, err := pp.Eval(`() => {
+		const u = window.__INITIAL_STATE__ && window.__INITIAL_STATE__.user;
+		const info = u && u.userInfo && u.userInfo.value !== undefined ? u.userInfo.value : (u && u.userInfo);
+		if (!info || info.guest) return "";
+		return JSON.stringify({nickname: info.nickname, userId: info.userId || info.user_id});
+	}`)
+	if err != nil {
+		return nil, errors.Wrap(err, "read current user state failed")
+	}
+
+	raw := res.Value.String()
+	if raw == "" {
+		return nil, errors.New("current user not found in page state")
+	}
+
+	var user CurrentUser
+	if err := json.Unmarshal([]byte(raw), &user); err != nil {
+		return nil, errors.Wrap(err, "unmarshal current user failed")
+	}
+
+	return &user, nil
 }
 
 func (a *LoginAction) Login(ctx context.Context) error {


### PR DESCRIPTION
## 问题

`/api/v1/login/status` 的 `username` 一直返回写死的占位符 `"xiaohongshu-mcp"`（`configs.Username`），无法分辨当前 cookie 登录的是哪个账号。

## 修改

- `CheckLoginStatus` 已登录时从 explore 页 `__INITIAL_STATE__.user.userInfo` 读取真实昵称与 `user_id`（个人主页 URL 中的稳定唯一标识），复用登录检查已加载的页面，零额外导航
- 读取失败仅记 warn，不影响登录态判断
- 删除不再使用的 `configs/username.go`

## JS 注入说明

新增的 Eval 为只读取页面数据快照（昵称不在 DOM 中，无法用 go-rod DOM 操作替代），与 feeds.go / like_favorite.go 既有惯例一致。

## 验证

```json
{"is_logged_in":true,"username":"吉安吴彦祖","user_id":"58ecd45b50c4b446fe824766"}
```

gofmt / go vet / 单测通过；本机部署实测 health、login/status、user/me、feeds/list、search、MCP handshake 全部正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)