### PR TITLE
fix(feed): 评论加载滚动改用 go-rod 原生滚轮

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -256,10 +256,8 @@ func findCommentElement(ctx context.Context, page *rod.Page, commentID, userID s
 
 		// === 5. 继续向下滚动 ===
 		logrus.Infof("继续向下滚动...")
-		_, err := page.Eval(`() => { window.scrollBy(0, window.innerHeight * 0.8); return true; }`)
-		if err != nil {
-			logrus.Warnf("滚动失败: %v", err)
-		}
+		vh := page.MustEval(`() => window.innerHeight`).Int()
+		smartScroll(page, float64(vh)*0.8)
 		time.Sleep(500 * time.Millisecond) // 技术 settle：等滚动后内容加载
 
 		// === 6. 滚动后立即查找（边滚动边查找）===

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/errors"
 	"github.com/xpzouying/xiaohongshu-mcp/humanize"
@@ -451,7 +452,7 @@ func humanScroll(ctx context.Context, page *rod.Page, speed string, largeMode bo
 
 	for i := 0; i < max(1, pushCount); i++ {
 		scrollDelta := calculateScrollDelta(viewportHeight, baseRatio)
-		page.MustEval(`(delta) => { window.scrollBy(0, delta); }`, scrollDelta)
+		smartScroll(page, scrollDelta)
 
 		time.Sleep(150 * time.Millisecond) // 技术 settle：等 scrollBy 后懒加载渲染，再读 scrollTop
 
@@ -519,24 +520,36 @@ func scrollToCommentsArea(page *rod.Page) {
 	smartScroll(page, 100)
 }
 
-// smartScroll 智能滚动：触发滚轮事件以正确触发懒加载
+// smartScroll 用真实滚轮向下滚 delta 像素（触发评论懒加载）。
 func smartScroll(page *rod.Page, delta float64) {
-	page.MustEval(`(delta) => {
-		// 查找滚动目标元素
-		let targetElement = document.querySelector('.note-scroller') 
-			|| document.querySelector('.interaction-container') 
-			|| document.documentElement;
-		
-		// 触发滚轮事件（关键！这样才能触发懒加载）
-		const wheelEvent = new WheelEvent('wheel', {
-			deltaY: delta,
-			deltaMode: 0, // 像素模式
-			bubbles: true,
-			cancelable: true,
-			view: window
-		});
-		targetElement.dispatchEvent(wheelEvent);
-	}`, delta)
+	// 指针落在评论滚动容器上，滚轮才只作用于评论区（否则会滚整页）
+	moveToCommentScroller(page)
+
+	steps := int(delta / 120)
+	if steps < 1 {
+		steps = 1
+	}
+	_ = page.Mouse.Scroll(0, delta, steps)
+}
+
+// moveToCommentScroller 把指针移到评论滚动容器中心；找不到则退回视口中心。
+func moveToCommentScroller(page *rod.Page) {
+	for _, sel := range []string{".note-scroller", ".comments-container"} {
+		el, err := page.Timeout(2 * time.Second).Element(sel)
+		if err != nil {
+			continue
+		}
+		shape, err := el.Shape()
+		if err != nil || len(shape.Quads) == 0 {
+			continue
+		}
+		q := shape.Quads[0]
+		_ = page.Mouse.MoveTo(proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2})
+		return
+	}
+	vw := page.MustEval(`() => window.innerWidth`).Int()
+	vh := page.MustEval(`() => window.innerHeight`).Int()
+	_ = page.Mouse.MoveTo(proto.Point{X: float64(vw) / 2, Y: float64(vh) / 2})
 }
 
 func scrollToLastComment(page *rod.Page) {


### PR DESCRIPTION
## 概述

评论加载的滚动改用 go-rod 原生滚轮（CDP），并把滚轮精准作用到评论滚动容器。

### 改动

- `smartScroll` 改走 `page.Mouse.Scroll`
- 新增 `moveToCommentScroller`：滚动前把指针移到评论容器（`.note-scroller`）中心，修复滚动误作用于整页
- `humanScroll` 主滚动与 `findCommentElement` 统一走 `smartScroll`
- 保留 `scrollIntoView`（元素定位）与卡住兜底的 `scrollTo`

## 测试

- 真机（有头）验证 `get_feed_detail` 加载评论：多次滚动稳定触发懒加载（0→60 条），滚动仅作用评论区、不再滚整页
- `gofmt` / `go build ./...` / `go vet` 通过