### PR TITLE
fix: 输入改用 CDP 插入，滚动位移改读评论容器

### DIFF
--- a/humanize/input.go
+++ b/humanize/input.go
@@ -53,14 +53,27 @@ func ClickNoWait(elem *rod.Element) error {
 }
 
 // Type 逐字符输入文本，字间带间隔。
+// 元素只在开头聚焦一次，后续插入都落在该焦点上。
 func Type(ctx context.Context, elem *rod.Element, text string) error {
 	dist := defaultProvider.Timing()[Keystroke]
+
+	if err := elem.Focus(); err != nil {
+		return err
+	}
+	if err := elem.WaitEnabled(); err != nil {
+		return err
+	}
+	if err := elem.WaitWritable(); err != nil {
+		return err
+	}
+
+	page := elem.Page().Context(ctx)
 
 	for _, r := range text {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := elem.Input(string(r)); err != nil {
+		if err := page.InsertText(string(r)); err != nil {
 			return err
 		}
 

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+// 集成测试：起无头浏览器验证输入行为，本地页面、不联网、不登录。
+// 手动跑：go test -tags integration ./humanize/ -run TestTypeEventSequence -v
+package humanize
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/xpzouying/xiaohongshu-mcp/browser"
+)
+
+const typeProbeBody = `<input id="a"><div id="b" contenteditable="true"></div>`
+
+const typeProbeInstall = `() => {
+  window.__ev = [];
+  for (const t of ['input','change']) {
+    window.addEventListener(t, e => {
+      window.__ev.push({type: e.type, target: e.target.id || ''});
+    }, true);
+  }
+  return true;
+}`
+
+type typedEvent struct {
+	Type   string `json:"type"`
+	Target string `json:"target"`
+}
+
+// countEvents 统计指定元素上各类事件的次数，并清空记录。
+func countEvents(t *testing.T, page *rod.Page, target string) map[string]int {
+	t.Helper()
+
+	raw := page.MustEval(`() => { const e = window.__ev; window.__ev = []; return JSON.stringify(e) }`).Str()
+
+	var evs []typedEvent
+	if err := json.Unmarshal([]byte(raw), &evs); err != nil {
+		t.Fatalf("解析事件失败: %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, e := range evs {
+		if e.Target == target {
+			counts[e.Type]++
+		}
+	}
+	return counts
+}
+
+// assertOneInputPerRune 每个字符应恰好产生一次 input，且不应产生 change。
+func assertOneInputPerRune(t *testing.T, label string, counts map[string]int, text string) {
+	t.Helper()
+
+	want := len([]rune(text))
+	if counts["input"] != want {
+		t.Errorf("%s: input 事件 %d 次，期望 %d 次", label, counts["input"], want)
+	}
+	if counts["change"] != 0 {
+		t.Errorf("%s: 不应产生 change 事件，实际 %d 次", label, counts["change"])
+	}
+}
+
+func TestTypeEventSequence(t *testing.T) {
+	bin, err := browser.EnsureBrowser()
+	if err != nil {
+		t.Skipf("SKIP: 浏览器不可用: %v", err)
+	}
+
+	u := launcher.New().Bin(bin).Headless(true).MustLaunch()
+	b := rod.New().ControlURL(u).MustConnect()
+	defer b.MustClose()
+
+	page := b.MustPage("about:blank")
+	page.MustWaitLoad()
+	page.MustSetDocumentContent(typeProbeBody)
+	if !page.MustEval(typeProbeInstall).Bool() {
+		t.Fatal("安装事件监听器失败")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const text = "你好abc"
+
+	// 普通输入框
+	input := page.MustElement("#a")
+	if err := Type(ctx, input, text); err != nil {
+		t.Fatalf("输入框输入失败: %v", err)
+	}
+	assertOneInputPerRune(t, "<input>", countEvents(t, page, "a"), text)
+	if got := input.MustProperty("value").Str(); got != text {
+		t.Errorf("<input> 文本不符: 期望 %q，实际 %q", text, got)
+	}
+
+	// contenteditable：评论框、发布编辑器都是这种形态
+	editable := page.MustElement("#b")
+	if err := Type(ctx, editable, text); err != nil {
+		t.Fatalf("contenteditable 输入失败: %v", err)
+	}
+	assertOneInputPerRune(t, "contenteditable", countEvents(t, page, "b"), text)
+	if got := editable.MustText(); got != text {
+		t.Errorf("contenteditable 文本不符: 期望 %q，实际 %q", text, got)
+	}
+}

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -454,7 +454,7 @@ func humanScroll(ctx context.Context, page *rod.Page, speed string, largeMode bo
 		scrollDelta := calculateScrollDelta(viewportHeight, baseRatio)
 		smartScroll(page, scrollDelta)
 
-		time.Sleep(150 * time.Millisecond) // 技术 settle：等 scrollBy 后懒加载渲染，再读 scrollTop
+		time.Sleep(150 * time.Millisecond) // 技术 settle：等滚动后懒加载渲染，再读 scrollTop
 
 		currentScrollTop = getScrollTop(page)
 		deltaThisTime := currentScrollTop - beforeTop
@@ -532,9 +532,13 @@ func smartScroll(page *rod.Page, delta float64) {
 	_ = page.Mouse.Scroll(0, delta, steps)
 }
 
+// commentScrollerSelectors 评论区滚动容器，按优先级排列。
+// 滚动与测量位移必须指向同一个容器，因此共用这一份定义。
+var commentScrollerSelectors = []string{".note-scroller", ".comments-container"}
+
 // moveToCommentScroller 把指针移到评论滚动容器中心；找不到则退回视口中心。
 func moveToCommentScroller(page *rod.Page) {
-	for _, sel := range []string{".note-scroller", ".comments-container"} {
+	for _, sel := range commentScrollerSelectors {
 		el, err := page.Timeout(2 * time.Second).Element(sel)
 		if err != nil {
 			continue
@@ -571,9 +575,17 @@ func getScrollTop(page *rod.Page) int {
 	// 使用retry-go来处理可能的DOM查询失败
 	err := retry.Do(
 		func() error {
-			evalResult := page.MustEval(`() => {
+			evalResult := page.MustEval(`(sels) => {
+				// 详情页的评论是在容器内滚动的，window 的 scrollTop 恒为 0，
+				// 必须读实际滚动的那个容器；容器不可滚时才退回 window。
+				for (const sel of sels) {
+					const el = document.querySelector(sel);
+					if (el && el.scrollHeight > el.clientHeight) {
+						return el.scrollTop;
+					}
+				}
 				return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
-			}`)
+			}`, commentScrollerSelectors)
 
 			result = evalResult.Int()
 			return nil


### PR DESCRIPTION
输入与滚动链路的两处修复。

## 1. 输入改用 CDP 插入文本

`humanize.Type` 改为开头聚焦一次，之后每字符走 `page.InsertText`。保留原有的 `WaitEnabled`/`WaitWritable` 前置检查，ctx 取消语义不变。

> 注：不能改用 `Keyboard.Type` —— rod 的 `input.Key.Info()` 对未登记的 rune 直接 panic，中文字符不在 keymap 里。

影响面：评论、回复、发布图文、发布视频的全部文本输入路径。

实测（真实评论框，输入后未发送）：11 个中文字符文本完整正确，发送按钮正常激活，输入过程中焦点始终停留在输入区域。

## 2. getScrollTop 读的不是实际滚动的容器

评论区在 `.note-scroller` 容器内滚动，`window` 的 scrollTop 恒为 0，而 `getScrollTop` 一直读 `window`。实测容器 scrollTop 已从 0 涨到 282 时，`getScrollTop` 仍返回 0，导致：

- `humanScroll` 中位移恒为 0，`scrolled` 恒 false，每轮都走 `window.scrollTo` 兜底（该页 window 不可滚，兜底实际无效）
- `performScroll` 每轮判定停滞，`lastScrollTop` 停在 0，`largeMode` 常开并反复触发大冲刺
- 滚动 Debug 日志因 `scrolled` 恒 false 从不打印，问题被掩盖

改为读实际滚动的容器（`scrollHeight > clientHeight` 才认），容器不可滚时退回 window。选择器提取为 `commentScrollerSelectors`，与 `moveToCommentScroller` 共用一份定义，避免"滚一个容器、量另一个"再次出现。

实测位移读数：

| | 修复前 | 修复后 |
|---|---|---|
| `getScrollTop()` | 恒为 0 | 298 → 907 → 1504 → 2171 |
| 每轮 `scrolled` | 恒 false | true |
| 每轮位移 | 0 | 609 / 597 / 667 |

端到端（`GetFeedDetail` + 加载全部评论）：

- 165 条评论的帖子：`0→10→20→30→40→50→60` 每轮稳定 +10，全程无停滞，命中目标 60 条正常停止（31s）
- 6 条评论的帖子：1 次尝试即检测到 `THE END` 退出（15s）

## 测试

新增 `humanize/input_integration_test.go`（`//go:build integration`，本地页面、不联网、不登录）：验证 `<input>` 与 contenteditable 两种形态下每字符产生一次 input 事件、文本完整正确。

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全通过。