### PR TITLE
chore: 收敛两处注释表述

### DIFF
--- a/humanize/provider.go
+++ b/humanize/provider.go
@@ -75,7 +75,7 @@ func (DefaultProvider) Timing() TimingProfile {
 	}
 }
 
-// defaultProvider 是包级默认 Provider。一账号一进程，进程级 Provider 即该账号的行为参数。
+// defaultProvider 是包级默认 Provider。
 // 启动时可用 SetProvider 注入替换，业务代码零改动。
 var defaultProvider Provider = DefaultProvider{}
 

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -520,7 +520,7 @@ func scrollToCommentsArea(page *rod.Page) {
 	smartScroll(page, 100)
 }
 
-// smartScroll 用真实滚轮向下滚 delta 像素（触发评论懒加载）。
+// smartScroll 向下滚动 delta 像素，触发评论区懒加载。
 func smartScroll(page *rod.Page, delta float64) {
 	// 指针落在评论滚动容器上，滚轮才只作用于评论区（否则会滚整页）
 	moveToCommentScroller(page)


### PR DESCRIPTION
仅注释改动，无行为变更。

- `smartScroll` 的函数注释改为描述它做什么
- `defaultProvider` 去掉与实现无关的补充说明

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全通过。