### PR TITLE
fix: 补 reply 工具 panic 保护、评论总数改读结构化数据、修正 feeds 列表文档

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -280,11 +280,7 @@ GET /api/v1/feeds/list
           },
           "interactInfo": {
             "liked": false,
-            "likedCount": "100",
-            "collected": false,
-            "collectedCount": "50",
-            "commentCount": "30",
-            "sharedCount": "10"
+            "likedCount": "100"
           },
           "cover": {
             "width": 1080,
@@ -324,11 +320,11 @@ GET /api/v1/feeds/list
   - `capa.duration`: 视频时长（秒）
 - `noteCard.interactInfo`: 互动信息
   - `liked`: 当前用户是否已点赞
-  - `collected`: 当前用户是否已收藏
-  - `likedCount`: 点赞数
-  - `collectedCount`: 收藏数
-  - `commentCount`: 评论数
-  - `sharedCount`: 分享数
+  - `likedCount`: 点赞数（格式化字符串，如 `"1.7万"`、`"10万+"`）
+
+> 注意：推荐流只下发 `liked` 和 `likedCount`。`commentCount`、`collectedCount`、
+> `sharedCount` 等字段虽然在响应结构里存在，但推荐流不提供数据，取到的是空字符串。
+> 需要评论数请改用「搜索 Feeds」或「获取 Feed 详情」。
 ```
 
 #### 4.2 搜索 Feeds

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -356,7 +356,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 				DestructiveHint: boolPtr(true),
 			},
 		},
-		func(ctx context.Context, req *mcp.CallToolRequest, args ReplyCommentArgs) (*mcp.CallToolResult, any, error) {
+		withPanicRecovery("reply_comment_in_feed", func(ctx context.Context, req *mcp.CallToolRequest, args ReplyCommentArgs) (*mcp.CallToolResult, any, error) {
 			if args.CommentID == "" && args.UserID == "" {
 				return &mcp.CallToolResult{
 					IsError: true,
@@ -373,7 +373,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 			}
 			result := appServer.handleReplyComment(ctx, argsMap)
 			return convertToMCPResult(result), nil, nil
-		},
+		}),
 	)
 
 	// 工具 11: 发布视频（仅本地文件）

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -636,53 +636,28 @@ func getCommentCount(page *rod.Page) int {
 	return result
 }
 
+// getTotalCommentCount 取笔记的评论总数，读 __INITIAL_STATE__ 里的
+// interactInfo.commentCount，不依赖评论区文案。取不到返回 0。
 func getTotalCommentCount(page *rod.Page) int {
-	var result int
-
-	// 使用retry-go来处理可能的DOM查询失败
-	err := retry.Do(
-		func() error {
-			// 使用 Go 获取总评论数元素
-			totalEl, err := page.Timeout(2 * time.Second).Element(".comments-container .total")
-			if err != nil {
-				return err
-			}
-
-			// 获取文本内容
-			text, err := totalEl.Text()
-			if err != nil {
-				return err
-			}
-
-			// 使用正则提取数字
-			re := regexp.MustCompile(`共(\d+)条评论`)
-			matches := re.FindStringSubmatch(text)
-			if len(matches) > 1 {
-				count, err := strconv.Atoi(matches[1])
-				if err != nil {
-					return err
-				}
-				result = count
-			} else {
-				result = 0
-			}
-
-			return nil
-		},
-		retry.Attempts(3),
-		retry.Delay(100*time.Millisecond),
-		retry.MaxJitter(200*time.Millisecond),
-		retry.OnRetry(func(n uint, err error) {
-			logrus.Debugf("获取总评论计数重试 #%d: %v", n, err)
-		}),
-	)
-
+	res, err := page.Eval(`() => {
+		const m = window.__INITIAL_STATE__?.note?.noteDetailMap;
+		if (!m) return "";
+		for (const v of Object.values(m)) {
+			const c = v?.note?.interactInfo?.commentCount;
+			if (c !== undefined && c !== null) return String(c);
+		}
+		return "";
+	}`)
 	if err != nil {
-		logrus.Warnf("获取总评论计数失败: %v", err)
-		return 0 // 失败时返回0
+		logrus.Debugf("获取总评论计数失败: %v", err)
+		return 0
 	}
 
-	return result
+	count, err := strconv.Atoi(strings.TrimSpace(res.Value.Str()))
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 func checkNoCommentsArea(page *rod.Page) bool {


### PR DESCRIPTION
三处独立的小修复，均已实测确认。

## 1. `reply_comment_in_feed` 缺 panic 保护

13 个 MCP 工具里只有它没包 `withPanicRecovery`，而它的调用链有 `MustEval`（`comment_feed.go`）和 `MustScrollIntoView`，page 超时或被取消时 panic 会逃逸到 SDK。

## 2. `getTotalCommentCount` 恒返回 0

原先取 `.comments-container .total` 的文案再正则提取「共 N 条评论」。实测在详情页（含滚动到评论区之后）都取不到，恒返回 0。该值只用于一行 Debug 日志，所以一直没被发现——日志里「目标」永远显示 0。

改为读 `noteDetailMap` 里的 `interactInfo.commentCount`，不依赖评论区文案。

实测：两条笔记分别返回 7 / 23，与页面结构化数据一致（修复前均为 0）。端到端加载评论未受影响——112 条评论的笔记正常加载到目标 40 条停止，20 条评论的笔记 3 次尝试后正常结束。

## 3. feeds 列表接口文档与实际不符

推荐流实际只下发 `liked` 和 `likedCount`（实测 34 条全部如此，深度递归扫描 comment 相关字段零命中），但文档样例写了 `commentCount: "30"`、`collectedCount`、`sharedCount` 并逐条解释，使用者照着写会取到空字符串。

样例改为真实形态，并补充说明：需要评论数请改用「搜索 Feeds」或「获取 Feed 详情」。

> 这两个接口确实下发这些字段（实测：搜索结果 `interactInfo` 含 `commentCount`/`sharedCount`/`collectedCount`；详情页同样含有），因此 4.2 与 4.3 章节的样例**保持不变**。三个接口共用同一套 struct，所以搜索接口现在就已经返回评论数。

顺带给 `likedCount` 补注它是格式化字符串（`"1.7万"`、`"10万+"`）。

## 校验

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全通过。