### PR TITLE
fix: 评论查找先查后判、滚轮按格发送、去掉多余的指针瞬移

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -190,117 +190,82 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 	return nil
 }
 
-// findCommentElement 查找指定评论元素（参考 feed_detail.go 的滚动逻辑）
+// findCommentElement 滚动查找指定评论：优先按 commentID 命中，否则按 userID 匹配。
+// 每轮先在已渲染的评论里查一次，再判断是否到底，最后滚动加载更多。
 func findCommentElement(ctx context.Context, page *rod.Page, commentID, userID string) (*rod.Element, error) {
 	logrus.Infof("开始查找评论 - commentID: %s, userID: %s", commentID, userID)
 
 	const maxAttempts = 100
 
-	// 先滚动到评论区
 	scrollToCommentsArea(page)
 	humanize.Delay(ctx, humanize.BetweenScroll)
 
-	var lastCommentCount = 0
+	lastCommentCount := 0
 	stagnantChecks := 0
 
-	logrus.Infof("开始循环查找，最大尝试次数: %d", maxAttempts)
-
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		logrus.Infof("=== 查找尝试 %d/%d ===", attempt+1, maxAttempts)
+		// 1. 先查已渲染的评论——目标可能一开始就在页面上
+		if el := lookupComment(page, commentID, userID); el != nil {
+			logrus.Infof("✓ 找到目标评论（尝试 %d 次）", attempt+1)
+			return el, nil
+		}
 
-		// === 1. 检查是否到达底部 ===
+		// 2. 到底则不再加载
 		if checkEndContainer(page) {
 			logrus.Info("已到达评论底部，未找到目标评论")
 			break
 		}
 
-		// === 2. 获取当前评论数量 ===
+		// 3. 评论数停滞说明加载不动了
 		currentCount := getCommentCount(page)
-		logrus.Infof("当前评论数: %d", currentCount)
-
 		if currentCount != lastCommentCount {
-			logrus.Infof("✓ 评论数增加: %d -> %d", lastCommentCount, currentCount)
 			lastCommentCount = currentCount
 			stagnantChecks = 0
 		} else {
 			stagnantChecks++
-			if stagnantChecks%5 == 0 {
-				logrus.Infof("评论数停滞 %d 次", stagnantChecks)
+			if stagnantChecks >= 10 {
+				logrus.Info("评论数量停滞，停止查找")
+				break
 			}
 		}
 
-		// === 3. 停滞检测 ===
-		if stagnantChecks >= 10 {
-			logrus.Info("评论数量停滞超过10次，可能已加载完所有评论")
-			break
-		}
-
-		// === 4. 先滚动到最后一个评论（触发懒加载）===
+		// 4. 滚到最后一条评论再继续下滚，触发懒加载
 		if currentCount > 0 {
-			logrus.Infof("滚动到最后一个评论（共 %d 条）", currentCount)
-
-			// 使用 Go 获取所有评论元素
-			elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
-			if err == nil && len(elements) > 0 {
-				// 滚动到最后一个评论
-				lastComment := elements[len(elements)-1]
-				err := lastComment.ScrollIntoView()
-				if err != nil {
-					logrus.Warnf("滚动到最后一个评论失败: %v", err)
+			if elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment"); err == nil && len(elements) > 0 {
+				if err := elements[len(elements)-1].ScrollIntoView(); err != nil {
+					logrus.Debugf("滚动到最后一条评论失败: %v", err)
 				}
-			} else {
-				logrus.Warnf("未找到评论元素: %v", err)
 			}
-			time.Sleep(300 * time.Millisecond) // 技术 settle：等懒加载渲染
+			humanize.Delay(ctx, humanize.BetweenScroll)
 		}
 
-		// === 5. 继续向下滚动 ===
-		logrus.Infof("继续向下滚动...")
-		vh := page.MustEval(`() => window.innerHeight`).Int()
-		smartScroll(page, float64(vh)*0.8)
-		time.Sleep(500 * time.Millisecond) // 技术 settle：等滚动后内容加载
-
-		// === 6. 滚动后立即查找（边滚动边查找）===
-		// 优先通过 commentID 查找（使用 Timeout 避免长时间等待）
-		if commentID != "" {
-			selector := fmt.Sprintf("#comment-%s", commentID)
-			logrus.Infof("尝试通过 commentID 查找: %s", selector)
-
-			// 使用 Timeout 避免长时间等待
-			el, err := page.Timeout(2 * time.Second).Element(selector)
-			if err == nil && el != nil {
-				logrus.Infof("✓ 通过 commentID 找到评论: %s (尝试 %d 次)", commentID, attempt+1)
-				return el, nil
-			}
-			logrus.Infof("未找到 commentID (2秒超时)")
-		}
-
-		// 通过 userID 查找
-		if userID != "" {
-			logrus.Infof("尝试通过 userID 查找: %s", userID)
-
-			// 使用 Timeout 避免长时间等待
-			elements, err := page.Timeout(2 * time.Second).Elements(".comment-item, .comment, .parent-comment")
-			if err == nil && len(elements) > 0 {
-				logrus.Infof("找到 %d 个评论元素", len(elements))
-				for i, el := range elements {
-					// 快速检查，不等待
-					userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID))
-					if err == nil && userEl != nil {
-						logrus.Infof("✓ 通过 userID 在第 %d 个元素中找到评论: %s (尝试 %d 次)", i+1, userID, attempt+1)
-						return el, nil
-					}
-				}
-				logrus.Infof("在 %d 个元素中未找到匹配的 userID", len(elements))
-			} else {
-				logrus.Infof("获取评论元素失败或超时: %v", err)
-			}
-		}
-
-		logrus.Infof("本次尝试未找到目标评论，继续下一轮...")
-
+		humanScroll(ctx, page, "normal", false, 1)
 		humanize.Delay(ctx, humanize.BetweenScroll)
 	}
 
-	return nil, fmt.Errorf("未找到评论 (commentID: %s, userID: %s), 尝试次数: %d", commentID, userID, maxAttempts)
+	return nil, fmt.Errorf("未找到评论 (commentID: %s, userID: %s)", commentID, userID)
+}
+
+// lookupComment 在当前已渲染的评论里查找目标，找不到返回 nil。
+func lookupComment(page *rod.Page, commentID, userID string) *rod.Element {
+	if commentID != "" {
+		if el, err := page.Timeout(2 * time.Second).Element(fmt.Sprintf("#comment-%s", commentID)); err == nil && el != nil {
+			return el
+		}
+	}
+
+	if userID == "" {
+		return nil
+	}
+
+	elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
+	if err != nil {
+		return nil
+	}
+	for _, el := range elements {
+		if userEl, err := el.Timeout(500 * time.Millisecond).Element(fmt.Sprintf(`[data-user-id="%s"]`, userID)); err == nil && userEl != nil {
+			return el
+		}
+	}
+	return nil
 }

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -391,22 +391,13 @@ func clickElementWithHumanBehavior(ctx context.Context, page *rod.Page, el *rod.
 	err := retry.Do(
 		func() error {
 			// 滚动到元素
-			el.MustEval(`() => {
-				try {
-					this.scrollIntoView({behavior: 'smooth', block: 'center'});
-				} catch (e) {}
-			}`)
+			if err := el.ScrollIntoView(); err != nil {
+				return err
+			}
 
 			humanize.Delay(ctx, humanize.Reading)
 
-			if box, err := el.Shape(); err == nil && len(box.Quads) > 0 {
-				x := float64(box.Quads[0][0]+box.Quads[0][4]) / 2
-				y := float64(box.Quads[0][1]+box.Quads[0][5]) / 2
-				page.Mouse.MustMoveTo(x, y)
-				humanize.Delay(ctx, humanize.BeforeClick)
-			}
-
-			// 点击
+			// 点击（humanize.Click 自己取落点并移动过去）
 			if err := humanize.Click(el); err != nil {
 				return err // 返回错误以触发重试
 			}
@@ -521,22 +512,44 @@ func scrollToCommentsArea(page *rod.Page) {
 }
 
 // smartScroll 向下滚动 delta 像素，触发评论区懒加载。
+// 按滚轮格逐格发送，每格幅度小幅浮动、格间留间隔。
 func smartScroll(page *rod.Page, delta float64) {
 	// 指针落在评论滚动容器上，滚轮才只作用于评论区（否则会滚整页）
 	moveToCommentScroller(page)
 
-	steps := int(delta / 120)
-	if steps < 1 {
-		steps = 1
+	for remain := delta; remain > 0; {
+		notch := scrollNotchSize()
+		if notch > remain {
+			notch = remain
+		}
+
+		if err := page.Mouse.Scroll(0, notch, 1); err != nil {
+			return
+		}
+		remain -= notch
+
+		if remain > 0 {
+			time.Sleep(scrollNotchInterval())
+		}
 	}
-	_ = page.Mouse.Scroll(0, delta, steps)
+}
+
+// scrollNotchSize 单格滚轮的幅度，围绕标准的 120px 浮动。
+func scrollNotchSize() float64 {
+	return 100 + rand.Float64()*40
+}
+
+// scrollNotchInterval 连续滚轮格之间的间隔。
+func scrollNotchInterval() time.Duration {
+	return time.Duration(20+rand.Intn(45)) * time.Millisecond
 }
 
 // commentScrollerSelectors 评论区滚动容器，按优先级排列。
 // 滚动与测量位移必须指向同一个容器，因此共用这一份定义。
 var commentScrollerSelectors = []string{".note-scroller", ".comments-container"}
 
-// moveToCommentScroller 把指针移到评论滚动容器中心；找不到则退回视口中心。
+// moveToCommentScroller 把指针移到评论滚动容器内；找不到则退回视口中心。
+// 指针已在容器内时不再移动，避免重复落到同一点。
 func moveToCommentScroller(page *rod.Page) {
 	for _, sel := range commentScrollerSelectors {
 		el, err := page.Timeout(2 * time.Second).Element(sel)
@@ -548,7 +561,18 @@ func moveToCommentScroller(page *rod.Page) {
 			continue
 		}
 		q := shape.Quads[0]
-		_ = page.Mouse.MoveTo(proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2})
+		left, top, right, bottom := q[0], q[1], q[4], q[5]
+
+		if pos := page.Mouse.Position(); pos.X > left && pos.X < right && pos.Y > top && pos.Y < bottom {
+			return
+		}
+
+		// 落点在容器中心附近随机偏移，不固定在几何中心
+		cx, cy := (left+right)/2, (top+bottom)/2
+		_ = page.Mouse.MoveTo(proto.Point{
+			X: cx + (rand.Float64()-0.5)*(right-left)*0.3,
+			Y: cy + (rand.Float64()-0.5)*(bottom-top)*0.3,
+		})
 		return
 	}
 	vw := page.MustEval(`() => window.innerWidth`).Int()


### PR DESCRIPTION
## 1. findCommentElement 会漏查（真实缺陷）

原循环顺序是「先判断是否到达评论底部 → 到底就退出 → …… → 最后才查找」。页面一开始就在底部时，它一次都不查就退出了。

影响：**评论数少、整个列表一屏装得下的帖子，「THE END」从一开始就可见，回复功能必然失败**，报「未找到评论」。

实测复现：在已加载完全部评论的页面上调用，目标元素就在 DOM 里（`#comment-<id>` 可命中），仍然立即返回未找到。

改为每轮先查已渲染的评论，再判断是否到底，最后滚动加载更多。查找逻辑抽成 `lookupComment`。

实测修复后：33 条父评论的帖子，2 秒内定位到最后一条。

## 2. 滚动与点击的几处调整

- `smartScroll` 原先一次调用把整段位移交给 rod，rod 内部会在同一时刻连发多个幅度完全相同的滚轮事件。改为按滚轮格逐格发送，每格幅度小幅浮动、格间留间隔。
- `moveToCommentScroller` 原先每次都移到容器几何中心，一次加载会重复落到同一点。改为落点在中心附近随机偏移，指针已在容器内时不再移动。
- `clickElementWithHumanBehavior` 原先先用 JS `scrollIntoView({behavior:'smooth'})` 再把指针瞬移到元素中心，导致随后 `humanize.Click` 的移动因起止点重合而失效；且 smooth 动画未结束就读取元素坐标存在竞态。改为用 CDP 滚动定位，落点交给 `humanize.Click` 自己处理。
- `findCommentElement` 里写死的滚动幅度（`vh*0.8`）与固定等待改为复用 `humanScroll`，消掉与评论加载器重复的一套滚动逻辑。

## 影响的接口

| 接口 | 涉及改动 |
|---|---|
| `reply_comment_in_feed` / `POST /api/v1/feeds/comment/reply` | 1、2（滚动查找） |
| `get_feed_detail` / `POST /api/v1/feeds/detail` | 2（评论加载滚动；`click_more_replies=true` 时的点击） |

## 实测

真实页面走查（只读，未发表任何内容）：

- 滚轮事件：14 个事件 13 个不同幅度，同刻连发 0 次，间隔中位数 50ms
- 指针移动：落点 11 个各不相同；连续滚动时不再重复移动
- 展开回复的点击正常生效
- 评论加载端到端正常：30/38、30/149 等多条帖子均正常加载并收敛

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全通过。