### PR TITLE
fix: 只用内置浏览器，拿不到就不启动

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,31 +81,34 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. 创建目录并设置权限。/opt/browser 保存构建阶段预置的浏览器。
-RUN mkdir -p /opt/browser \
-    /app/data/home /app/data/cache /app/data/config /app/images && \
-    chmod -R 755 /opt/browser && \
+# 3. 创建目录并设置权限。
+RUN mkdir -p /app/data/home /app/data/config /app/images && \
     chmod -R 777 /app/data /app/images
 
 # 4. 下载并解压内置浏览器。构建阶段预置，运行时零下载。
 # 版本号唯一来源：browser/browser_version.txt（Go 也读它，避免两处漂移）。
 # 从自建 CDN 下载中性文件名，并校验 SHA256。
+#
+# 解压位置必须与 Go 端 EnsureBrowser 找的缓存路径一致：
+# $XDG_CACHE_HOME/xiaohongshu-mcp/browser/<版本>/，这样运行时零下载、也不需要任何参数。
+# 注意 XDG_CACHE_HOME 指向 /app/cache 而非挂载卷内，否则预置的浏览器会被挂载盖掉。
+ENV XDG_CACHE_HOME=/app/cache
 COPY browser/browser_version.txt /tmp/browser_version.txt
 RUN VER="$(cat /tmp/browser_version.txt | tr -d '[:space:]')" && \
     BASE="https://cdn.one-world.ai/browsers/${VER}" && \
+    BROWSER_DIR="${XDG_CACHE_HOME}/xiaohongshu-mcp/browser/${VER}" && \
+    mkdir -p "${BROWSER_DIR}" && \
     curl -fsSL -o /tmp/browser.tar.xz "${BASE}/linux-x64.tar.xz" && \
     curl -fsSL "${BASE}/SHA256SUMS" | grep " linux-x64.tar.xz$" | awk '{print $1"  /tmp/browser.tar.xz"}' | sha256sum -c - && \
-    tar -xJf /tmp/browser.tar.xz -C /opt/browser --strip-components=1 && \
+    tar -xJf /tmp/browser.tar.xz -C "${BROWSER_DIR}" --strip-components=1 && \
     rm /tmp/browser.tar.xz /tmp/browser_version.txt && \
-    test -x /opt/browser/chrome
+    test -x "${BROWSER_DIR}/chrome" && \
+    chmod -R 755 /app/cache
 
 COPY --from=builder /out/app .
 
-# 5. 设置内置浏览器路径（rod 通过 ROD_BROWSER_BIN 启动它）
 ENV HOME=/app/data/home
-ENV XDG_CACHE_HOME=/app/data/cache
 ENV XDG_CONFIG_HOME=/app/data/config
-ENV ROD_BROWSER_BIN=/opt/browser/chrome
 
 EXPOSE 18060
 

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 )
 
 type browserConfig struct {
-	binPath string
 	// fingerprintSeed 固定指纹 seed；>0 时钉死，同账号每次同一套指纹。0 = 每次随机。
 	fingerprintSeed int
 	// proxy 代理地址；非空时启用。
@@ -18,12 +18,6 @@ type browserConfig struct {
 }
 
 type Option func(*browserConfig)
-
-func WithBinPath(binPath string) Option {
-	return func(c *browserConfig) {
-		c.binPath = binPath
-	}
-}
 
 // WithProxy 设置代理（http/https/socks5）。空字符串视为不启用。
 func WithProxy(proxy string) Option {
@@ -60,6 +54,15 @@ func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
 		opt(cfg)
 	}
 
+	// 只用内置浏览器，没有别的来源。二进制必须显式传给 go-rod，
+	// 否则 rod 会自行下载一个默认 Chromium：它不是内置浏览器，也不认识下面
+	// 这些 flag（未知 flag 被静默忽略，日志照样打印 "fingerprint enabled"），
+	// 属于无声降级。宁可不启动，也不启动一个不对的浏览器。
+	binPath, err := EnsureBrowser()
+	if err != nil {
+		panic(fmt.Sprintf("内置浏览器不可用，拒绝启动: %v", err))
+	}
+
 	opts := []headless_browser.Option{
 		headless_browser.WithHeadless(headless),
 		// 用内置浏览器的默认配置，不强制 UA。
@@ -70,9 +73,7 @@ func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
 		// 注：hardware-concurrency 不设，交给 seed 派生。
 		headless_browser.WithExtraFlags(map[string]string{"fingerprint-brand": "Chrome"}),
 	}
-	if cfg.binPath != "" {
-		opts = append(opts, headless_browser.WithChromeBinPath(cfg.binPath))
-	}
+	opts = append(opts, headless_browser.WithChromeBinPath(binPath))
 
 	// 代理（由调用方经 Option 传入，env 读取放在入口层）。
 	if cfg.proxy != "" {

--- a/browser/browser_download.go
+++ b/browser/browser_download.go
@@ -71,7 +71,7 @@ func browserCacheDir() (string, error) {
 func EnsureBrowser() (string, error) {
 	asset, binName, ok := platformAsset()
 	if !ok {
-		return "", fmt.Errorf("当前平台 %s/%s 无预编译浏览器，请手动指定 --bin", runtime.GOOS, runtime.GOARCH)
+		return "", fmt.Errorf("当前平台 %s/%s 无预编译浏览器，暂不支持", runtime.GOOS, runtime.GOARCH)
 	}
 
 	cacheDir, err := browserCacheDir()
@@ -102,9 +102,8 @@ func EnsureBrowser() (string, error) {
 	}
 	if dlErr != nil {
 		return "", fmt.Errorf("下载内置浏览器失败: %w\n"+
-			"  浏览器是反检测核心，缺它等于裸奔，故不继续。请任选其一：\n"+
-			"  1) 检查网络后重试；\n"+
-			"  2) 手动下载 %s，解压后用 --bin 指定其中的浏览器二进制。", dlErr, browserURL(asset))
+			"  本项目只用内置浏览器，缺它不继续。请检查网络后重试；\n"+
+			"  离线环境可手动下载 %s，解压到 %s 后重启。", dlErr, browserURL(asset), cacheDir)
 	}
 	defer os.Remove(archivePath)
 

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -30,11 +30,9 @@ func TestMaskProxyCredentials(t *testing.T) {
 // TestOptions 校验 Option 正确写入 browserConfig（New+Option 的接线）。
 func TestOptions(t *testing.T) {
 	cfg := &browserConfig{}
-	WithBinPath("/opt/browser/chrome")(cfg)
 	WithFingerprintSeed(98759)(cfg)
 	WithProxy("http://127.0.0.1:8080")(cfg)
 
-	assert.Equal(t, "/opt/browser/chrome", cfg.binPath)
 	assert.Equal(t, 98759, cfg.fingerprintSeed)
 	assert.Equal(t, "http://127.0.0.1:8080", cfg.proxy)
 }
@@ -42,7 +40,6 @@ func TestOptions(t *testing.T) {
 // TestOptions_Defaults 未传 Option 时各字段为零值（回退随机 seed / 不设代理）。
 func TestOptions_Defaults(t *testing.T) {
 	cfg := &browserConfig{}
-	assert.Equal(t, "", cfg.binPath)
 	assert.Equal(t, 0, cfg.fingerprintSeed)
 	assert.Equal(t, "", cfg.proxy)
 }

--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"os"
 
 	"github.com/go-rod/rod"
 	"github.com/sirupsen/logrus"
@@ -15,28 +14,11 @@ import (
 )
 
 func main() {
-	var (
-		binPath string // 浏览器二进制文件路径
-	)
-	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.Parse()
-
-	if binPath == "" {
-		binPath = os.Getenv("ROD_BROWSER_BIN")
-	}
-	// 未指定浏览器：自动准备内置浏览器，失败即退出。
-	if binPath == "" {
-		bin, err := browser.EnsureBrowser()
-		if err != nil {
-			logrus.Fatalf("%v", err)
-		}
-		binPath = bin
-	}
 
 	// 登录的时候，需要界面，所以不能无头模式。
 	// 登录与后续运行用相同的固定指纹（若设了 XHS_FP_SEED）。
 	b := browser.NewBrowser(false,
-		browser.WithBinPath(binPath),
 		browser.WithFingerprintSeed(configs.FingerprintSeedFromEnv()),
 		browser.WithProxy(configs.ProxyFromEnv()),
 	)

--- a/configs/browser.go
+++ b/configs/browser.go
@@ -10,8 +10,6 @@ import (
 var (
 	useHeadless = true
 
-	binPath = ""
-
 	fingerprintSeed = 0
 
 	proxy = ""
@@ -24,14 +22,6 @@ func InitHeadless(h bool) {
 // IsHeadless 是否无头模式。
 func IsHeadless() bool {
 	return useHeadless
-}
-
-func SetBinPath(b string) {
-	binPath = b
-}
-
-func GetBinPath() string {
-	return binPath
 }
 
 func SetFingerprintSeed(s int) {

--- a/docker/README.md
+++ b/docker/README.md
@@ -109,10 +109,8 @@ docker run -e XHS_PROXY=http://user:pass@proxy:port xpzouying/xiaohongshu-mcp
 
 ```yaml
 environment:
-  - ROD_BROWSER_BIN=/opt/browser/chrome
   - COOKIES_PATH=/app/data/cookies.json
   - HOME=/app/data/home
-  - XDG_CACHE_HOME=/app/data/cache
   - XDG_CONFIG_HOME=/app/data/config
   - XHS_PROXY=http://user:pass@proxy:port
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,10 +12,8 @@ services:
       - ./data:/app/data
       - ./images:/app/images
     environment:
-      - ROD_BROWSER_BIN=/opt/browser/chrome
       - COOKIES_PATH=/app/data/cookies.json
       - HOME=/app/data/home
-      - XDG_CACHE_HOME=/app/data/cache
       - XDG_CONFIG_HOME=/app/data/config
     ports:
       - "18060:18060"

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
@@ -15,31 +14,22 @@ var version = "dev"
 func main() {
 	var (
 		headless bool
-		binPath  string // 浏览器二进制文件路径
 		port     string
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
-	flag.StringVar(&binPath, "bin", "", "浏览器二进制文件路径")
 	flag.StringVar(&port, "port", ":18060", "端口")
 	flag.Parse()
 
 	logrus.Infof("xiaohongshu-mcp version: %s", version)
 
-	if len(binPath) == 0 {
-		binPath = os.Getenv("ROD_BROWSER_BIN")
-	}
-	// 未显式指定浏览器：自动准备内置浏览器，失败即退出。
-	if binPath == "" {
-		bin, err := browser.EnsureBrowser()
-		if err != nil {
-			logrus.Fatalf("%v", err)
-		}
-		binPath = bin
+	// 只用内置浏览器。启动时就备好，缺它直接退出，不拖到第一个请求才失败。
+	binPath, err := browser.EnsureBrowser()
+	if err != nil {
+		logrus.Fatalf("%v", err)
 	}
 	logrus.Infof("using browser binary: %s", binPath)
 
 	configs.InitHeadless(headless)
-	configs.SetBinPath(binPath)
 	// 入口层读 env、解析成固定指纹 seed 和代理，经 configs 透传给浏览器工厂。
 	configs.SetFingerprintSeed(configs.FingerprintSeedFromEnv())
 	configs.SetProxy(configs.ProxyFromEnv())

--- a/service.go
+++ b/service.go
@@ -557,7 +557,6 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 
 func newBrowser() *headless_browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(),
-		browser.WithBinPath(configs.GetBinPath()),
 		browser.WithFingerprintSeed(configs.FingerprintSeed()),
 		browser.WithProxy(configs.Proxy()),
 	)


### PR DESCRIPTION
## 问题

未指定 `--bin` 时，之前不会给 go-rod 传二进制路径，rod 会**自行下载并启动一个默认 Chromium**。

它与内置浏览器完全是两个东西：版本不同（rod 默认 128 vs 内置 148）、编解码器不全、也不认识我们传的那些启动参数。而 Chromium 对不认识的命令行参数是**静默忽略**的，所以日志照样打印 `fingerprint enabled: platform=macos seed=xxxxx`——看上去一切正常，实际启动的根本不是我们要的浏览器。

任何直接调 `browser.NewBrowser(headless)` 而没传 `WithBinPath` 的代码都会踩到，且没有任何报错。

## 改动

浏览器来源收敛到唯一一处：内置浏览器，准备不出来就不启动。

- `NewBrowser` 直接调 `EnsureBrowser()` 并**永远显式**把路径传给 go-rod，失败即 `panic`
- 删掉 `--bin` 参数和 `WithBinPath` Option。当前平台没有预编译浏览器就是不支持，比让用户自己塞一个来路不明的二进制安全
- 不再读 `ROD_BROWSER_BIN`。那是 go-rod 自己的环境变量，可能因无关原因被设过；显式传路径也顺带堵掉了 rod 内部读它的那条路
- `main.go` / `cmd/login` 的重复解析逻辑删除，启动时就准备浏览器，缺它直接退出，不拖到第一个请求才失败
- Dockerfile 把预置浏览器放到 Go 端会查的缓存路径 `$XDG_CACHE_HOME/xiaohongshu-mcp/browser/<版本>/`，运行时零下载、零参数；`XDG_CACHE_HOME` 相应从 `/app/data/cache` 移到 `/app/cache`，否则预置内容会被挂载卷盖掉（compose 与文档里的同名覆盖也一并删除）

## 验证

本机（macOS）不传任何参数、并把 `ROD_BROWSER_BIN` 指向假路径：

```
ROD_BROWSER_BIN=/nonexistent/fake-chrome
→ UA coherence: version=Chrome/148.0.7778.215   （改动前是 128.0.6568.0）
```

Docker 镜像实际构建并启动：

```
/app/cache/xiaohongshu-mcp/browser/148.0.7778.215/chrome   （构建期预置，482MB）
using browser binary: /app/cache/xiaohongshu-mcp/browser/148.0.7778.215/chrome
```

零下载、零参数，路径对得上。

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全过。

## 未覆盖的部分

- `EnsureBrowser()` 只在**下载时**校验 SHA256，命中缓存时不校验。所以往缓存路径塞同名二进制仍然能绕过——这道改动挡的是误用，不是刻意绕过。要补成强校验是另一件事。
- `panic` 分支（内置浏览器准备失败）没有做运行时验证，需要构造下载失败或不支持的平台才能触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)