### PR TITLE
fix: 收口三处裸鼠标调用，指针不再瞬移

### DIFF
--- a/humanize/input.go
+++ b/humanize/input.go
@@ -52,6 +52,22 @@ func ClickNoWait(elem *rod.Element) error {
 	return mouse.Click(proto.InputMouseButtonLeft, 1)
 }
 
+// MoveTo 沿曲线把指针移到指定坐标，不点击。
+// 用于目标不是元素的场景，比如把指针放进某个滚动容器让滚轮作用在它上面。
+func MoveTo(page *rod.Page, pt proto.Point) error {
+	return moveMouseCurved(page.Mouse, pt)
+}
+
+// ClickAt 沿曲线移到指定坐标再点击。
+// 用于点不到元素、只能算坐标的场景（如取元素区域内的偏移点、点击空白处）；
+// 有元素可点时用 Click。
+func ClickAt(page *rod.Page, pt proto.Point) error {
+	if err := moveMouseCurved(page.Mouse, pt); err != nil {
+		return err
+	}
+	return page.Mouse.Click(proto.InputMouseButtonLeft, 1)
+}
+
 // Type 逐字符输入文本，字间带间隔。
 // 元素只在开头聚焦一次，后续插入都落在该焦点上。
 func Type(ctx context.Context, elem *rod.Element, text string) error {

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -569,7 +569,7 @@ func moveToCommentScroller(page *rod.Page) {
 
 		// 落点在容器中心附近随机偏移，不固定在几何中心
 		cx, cy := (left+right)/2, (top+bottom)/2
-		_ = page.Mouse.MoveTo(proto.Point{
+		_ = humanize.MoveTo(page, proto.Point{
 			X: cx + (rand.Float64()-0.5)*(right-left)*0.3,
 			Y: cy + (rand.Float64()-0.5)*(bottom-top)*0.3,
 		})
@@ -577,7 +577,7 @@ func moveToCommentScroller(page *rod.Page) {
 	}
 	vw := page.MustEval(`() => window.innerWidth`).Int()
 	vh := page.MustEval(`() => window.innerHeight`).Int()
-	_ = page.Mouse.MoveTo(proto.Point{X: float64(vw) / 2, Y: float64(vh) / 2})
+	_ = humanize.MoveTo(page, proto.Point{X: float64(vw) / 2, Y: float64(vh) / 2})
 }
 
 func scrollToLastComment(page *rod.Page) {

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -113,9 +113,14 @@ func removePopCover(page *rod.Page) {
 }
 
 func clickEmptyPosition(page *rod.Page) {
-	x := 380 + rand.Intn(100)
-	y := 20 + rand.Intn(60)
-	page.Mouse.MustMoveTo(float64(x), float64(y)).MustClick(proto.InputMouseButtonLeft)
+	pt := proto.Point{
+		X: float64(380 + rand.Intn(100)),
+		Y: float64(20 + rand.Intn(60)),
+	}
+	// 兜底操作，点不动就算了，不该 panic
+	if err := humanize.ClickAt(page, pt); err != nil {
+		logrus.Debugf("点击空位置失败: %v", err)
+	}
 }
 
 func mustClickPublishTab(page *rod.Page, tabname string) error {
@@ -516,11 +521,8 @@ func clickPublishWidget(page *rod.Page, widget *rod.Element) error {
 
 	x := minX + (maxX-minX)*0.65
 	y := minY + (maxY-minY)/2
-	if err := page.Mouse.MoveTo(proto.Point{X: x, Y: y}); err != nil {
-		return errors.Wrap(err, "移动到新版发布按钮失败")
-	}
-	if err := page.Mouse.Click(proto.InputMouseButtonLeft, 1); err != nil {
-		return errors.Wrap(err, "点击发布按钮失败")
+	if err := humanize.ClickAt(page, proto.Point{X: x, Y: y}); err != nil {
+		return errors.Wrap(err, "点击新版发布按钮失败")
 	}
 	return nil
 }


### PR DESCRIPTION
## 问题

`humanize/provider.go` 开头声明了一条不变量：

> 约定：业务代码统一调 `humanize.*`，不直接调 `time.Sleep` / rod 的 `Mouse.MoveTo` / `elem.Input` 等裸原语。

但代码里还有三处在裸调 `Mouse.MoveTo`。根因是曲线移动函数 `moveMouseCurved` 没有导出，`humanize.Click(elem)` 只接受元素——**点坐标而非点元素**的场景没有对应原语可用，只能退回瞬移。

| 位置 | 现状 | 性质 |
|---|---|---|
| `publish.go` 新版发布按钮 | `MoveTo` 瞬移 + `Click` | 点的是 quad 内 65% 处的坐标，用不上 `Click(elem)` |
| `publish.go` `clickEmptyPosition` | `MustMoveTo` + `MustClick` | 点空白处，本就没有元素 |
| `feed_detail.go` 移到评论滚动容器 | `MoveTo` 瞬移，不点击 | 功能性移动（滚轮要作用在评论区），但同样是瞬移 |

## 改动

补两个原语：`humanize.MoveTo`（移动不点击）和 `humanize.ClickAt`（移动后点击），都走既有的 `moveMouseCurved`。三处调用改造完成后，业务代码里已无任何裸 `Mouse.MoveTo`。

`clickEmptyPosition` 顺带去掉 `Must`：它是兜底操作，点不动记日志即可，不该 panic。

## 验证

真实账号走查评论加载（只读，未做任何写操作），覆盖 `feed_detail` 那处移动：

```
✓ 评论增加: 140 -> 150 (+10)
✓ 检测到 'THE END' 元素，已滑动到底部
✓ 加载完成: 152 条评论, 尝试次数: 16
```

滚轮定位未受影响——曲线移动的终点与瞬移一致，只是多了中间过程。

`gofmt` / `go build ./...` / `go vet ./...` / `go test ./...` 全过。

## 未验证的部分

`publish.go` 那两处在发布路径上，真机验证需要实际发一篇笔记，本次**没有走查**。改动本身是同一函数的等价替换（终点坐标计算逻辑一字未动，只把瞬移换成曲线移动），风险低，但按仓库惯例这类改动应当真机验证过再上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)