### PR TITLE
fix: 不再发布无法启动的平台二进制

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -69,15 +69,12 @@ jobs:
       run: |
         # 主程序构建
         # 禁用 CGO 生成静态二进制；通过 ldflags 注入版本号
+        # 只构建有内置浏览器的平台，其余平台即使编译出来也无法启动
         LDFLAGS="-s -w -X main.version=${VERSION}"
 
         # macOS ARM64 (Apple Silicon)
         CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o xiaohongshu-mcp-darwin-arm64 .
         CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o xiaohongshu-login-darwin-arm64 ./cmd/login
-
-        # macOS Intel
-        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o xiaohongshu-mcp-darwin-amd64 .
-        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o xiaohongshu-login-darwin-amd64 ./cmd/login
 
         # Windows x64
         CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$LDFLAGS" -o xiaohongshu-mcp-windows-amd64.exe .
@@ -86,10 +83,6 @@ jobs:
         # Linux x64
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o xiaohongshu-mcp-linux-amd64 .
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -o xiaohongshu-login-linux-amd64 ./cmd/login
-
-        # Linux ARM64
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o xiaohongshu-mcp-linux-arm64 .
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o xiaohongshu-login-linux-arm64 ./cmd/login
 
     - name: Generate changelog
       id: changelog
@@ -135,17 +128,13 @@ jobs:
 
           **主程序（MCP 服务）：**
           - **macOS Apple Silicon**: `xiaohongshu-mcp-darwin-arm64`
-          - **macOS Intel**: `xiaohongshu-mcp-darwin-amd64`
           - **Windows x64**: `xiaohongshu-mcp-windows-amd64.exe`
           - **Linux x64**: `xiaohongshu-mcp-linux-amd64`
-          - **Linux ARM64**: `xiaohongshu-mcp-linux-arm64`
 
           **登录工具：**
           - **macOS Apple Silicon**: `xiaohongshu-login-darwin-arm64`
-          - **macOS Intel**: `xiaohongshu-login-darwin-amd64`
           - **Windows x64**: `xiaohongshu-login-windows-amd64.exe`
           - **Linux x64**: `xiaohongshu-login-linux-amd64`
-          - **Linux ARM64**: `xiaohongshu-login-linux-arm64`
 
           ### 🔧 使用方法
 
@@ -173,12 +162,8 @@ jobs:
           - **Build Time**: ${{ github.event.repository.updated_at }}
         files: |
           xiaohongshu-mcp-darwin-arm64
-          xiaohongshu-mcp-darwin-amd64
           xiaohongshu-mcp-windows-amd64.exe
           xiaohongshu-mcp-linux-amd64
-          xiaohongshu-mcp-linux-arm64
           xiaohongshu-login-darwin-arm64
-          xiaohongshu-login-darwin-amd64
           xiaohongshu-login-windows-amd64.exe
           xiaohongshu-login-linux-amd64
-          xiaohongshu-login-linux-arm64

--- a/README.md
+++ b/README.md
@@ -334,16 +334,16 @@ https://github.com/user-attachments/assets/cc385b6c-422c-489b-a5fc-63e92c695b80
 **主程序（MCP 服务）：**
 
 - **macOS Apple Silicon**: `xiaohongshu-mcp-darwin-arm64`
-- **macOS Intel**: `xiaohongshu-mcp-darwin-amd64`
 - **Windows x64**: `xiaohongshu-mcp-windows-amd64.exe`
 - **Linux x64**: `xiaohongshu-mcp-linux-amd64`
 
 **登录工具：**
 
 - **macOS Apple Silicon**: `xiaohongshu-login-darwin-arm64`
-- **macOS Intel**: `xiaohongshu-login-darwin-amd64`
 - **Windows x64**: `xiaohongshu-login-windows-amd64.exe`
 - **Linux x64**: `xiaohongshu-login-linux-amd64`
+
+> 目前支持以上三个平台。macOS Intel 与 Linux ARM64 暂不支持。
 
 使用步骤：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -315,16 +315,16 @@ Download pre-compiled binaries for your platform directly from [GitHub Releases]
 **Main Program (MCP Service):**
 
 - **macOS Apple Silicon**: `xiaohongshu-mcp-darwin-arm64`
-- **macOS Intel**: `xiaohongshu-mcp-darwin-amd64`
 - **Windows x64**: `xiaohongshu-mcp-windows-amd64.exe`
 - **Linux x64**: `xiaohongshu-mcp-linux-amd64`
 
 **Login Tool:**
 
 - **macOS Apple Silicon**: `xiaohongshu-login-darwin-arm64`
-- **macOS Intel**: `xiaohongshu-login-darwin-amd64`
 - **Windows x64**: `xiaohongshu-login-windows-amd64.exe`
 - **Linux x64**: `xiaohongshu-login-linux-amd64`
+
+> Only the three platforms above are supported. macOS Intel and Linux ARM64 are not supported.
 
 Usage Steps:
 


### PR DESCRIPTION
## 问题

我们发布 5 个平台的二进制，但其中 **2 个下载下来无法启动**：

| 平台 | 内置浏览器 | 结果 |
|---|---|---|
| `darwin-arm64` | ✅ | 正常 |
| `linux-amd64` | ✅ | 正常 |
| `windows-amd64` | ✅ | 正常 |
| **`darwin-amd64`（macOS Intel）** | ❌ 无 | **启动即退出** |
| **`linux-arm64`** | ❌ 无 | **启动即退出** |

后两者没有可用的内置浏览器，启动时 `EnsureBrowser()` 直接返回错误、进程退出：

```
当前平台 darwin/amd64 无预编译浏览器，暂不支持
```

而 README 里明确列着 **"macOS Intel: `xiaohongshu-mcp-darwin-amd64`"**，等于引导用户下载一个必定失败的文件。

## 改动

- `tag-release.yml`：停止构建与上传这两个平台的产物
- `README.md` / `README_EN.md`：下载列表删掉对应条目，补一行支持范围说明

`test.yml` 的五平台交叉编译**保留**——那是代码健康检查（防止写出平台相关的编译错误），与是否发布产物无关。

## 影响

macOS Intel 与 Linux ARM64 用户不再能下到二进制。这不是能力回退，而是把一直存在的事实变得可见：这两个平台从来没有可用的浏览器，之前即使下载下来也跑不了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)