### PR TITLE
fix: 收敛输入与点击的交互原语，修评论加载上限与滚动兜底

### DIFF
--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -2,6 +2,7 @@ package humanize
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -40,7 +41,7 @@ func TestLogNormal_noMax(t *testing.T) {
 func TestDefaultProvider_Timing(t *testing.T) {
 	tp := DefaultProvider{}.Timing()
 
-	for _, action := range []Action{AfterClick, AfterType, AfterNavigate, BetweenScroll, BeforeSubmit, BeforeClick, Reading} {
+	for _, action := range []Action{AfterClick, AfterType, AfterNavigate, BetweenScroll, BeforeSubmit, BeforeClick, Reading, Keystroke, ClickHold} {
 		dist, ok := tp[action]
 		assert.True(t, ok, "缺少动作 %s 的时延分布", action)
 		assert.Greater(t, dist.Max, dist.Min, "%s: Max 应大于 Min", action)
@@ -84,6 +85,55 @@ func TestEaseInOut(t *testing.T) {
 	assert.Equal(t, 1.0, easeInOut(1))
 	assert.InDelta(t, 0.5, easeInOut(0.5), 1e-9) // 中点对称
 	assert.Less(t, easeInOut(0.25), easeInOut(0.75))
+}
+
+// TestJitterOffset_Bounds 抖动幅度受两个上限约束：边长的 15%、且不超过 8px。
+func TestJitterOffset_Bounds(t *testing.T) {
+	cases := []struct {
+		size  float64
+		limit float64
+		desc  string
+	}{
+		{size: 20, limit: 3, desc: "小元素按 15% 取"}, // 20*0.15=3 < 8
+		{size: 600, limit: 8, desc: "宽元素封顶 8px"}, // 600*0.15=90，封到 8
+		{size: -40, limit: 6, desc: "负边长按绝对值处理"}, // |−40|*0.15=6
+		{size: 0, limit: 0, desc: "零边长不抖动"},
+	}
+
+	for _, c := range cases {
+		for i := 0; i < 200; i++ { // 采样够多次，覆盖到边界附近
+			got := jitterOffset(c.size)
+			assert.LessOrEqual(t, math.Abs(got), c.limit, "%s: 偏移 %v 超出上限 %v", c.desc, got, c.limit)
+		}
+	}
+}
+
+// TestJitterInQuad_StaysInside 抖动后的落点必须仍在元素框内。
+func TestJitterInQuad_StaysInside(t *testing.T) {
+	// 100x40 的框，左上角 (10,20)；四角顺序：左上、右上、右下、左下
+	q := proto.DOMQuad{10, 20, 110, 20, 110, 60, 10, 60}
+	center := proto.Point{X: 60, Y: 40}
+
+	for i := 0; i < 500; i++ {
+		p := jitterInQuad(center, q)
+		assert.GreaterOrEqual(t, p.X, 10.0)
+		assert.LessOrEqual(t, p.X, 110.0)
+		assert.GreaterOrEqual(t, p.Y, 20.0)
+		assert.LessOrEqual(t, p.Y, 60.0)
+	}
+}
+
+// TestJitterInQuad_Scatters 同一元素多次抖动应产生不同落点，
+// 否则等于没抖动（rod 返回的可点位置本身是常量）。
+func TestJitterInQuad_Scatters(t *testing.T) {
+	q := proto.DOMQuad{0, 0, 200, 0, 200, 60, 0, 60}
+	center := proto.Point{X: 100, Y: 30}
+
+	seen := map[proto.Point]struct{}{}
+	for i := 0; i < 50; i++ {
+		seen[jitterInQuad(center, q)] = struct{}{}
+	}
+	assert.Greater(t, len(seen), 40, "50 次抖动应产生大量不同落点，实际只有 %d 个", len(seen))
 }
 
 // TestDelay_UnknownActionFallback 未知动作应回退而非 panic 或零等待。

--- a/humanize/input.go
+++ b/humanize/input.go
@@ -3,11 +3,54 @@ package humanize
 import (
 	"context"
 	"errors"
+	"math"
+	"math/rand"
 	"time"
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 )
+
+// pressAndRelease 按下、停留一段采样出的时长、再抬起。
+//
+// rod 的 Mouse.Click 是 Down 紧接着 Up，中间没有间隔；这里按 ClickHold 的
+// 分布补上停留时间。
+func pressAndRelease(mouse *rod.Mouse) error {
+	if err := mouse.Down(proto.InputMouseButtonLeft, 1); err != nil {
+		return err
+	}
+
+	time.Sleep(defaultProvider.Timing()[ClickHold].Sample())
+
+	return mouse.Up(proto.InputMouseButtonLeft, 1)
+}
+
+// jitterOffset 给定边长，返回 ±min(边长的 15%, 8px) 内的随机偏移。
+//
+// 两个上限缺一不可：按比例是为了小元素上不至于偏出去；封顶 8px 是因为宽元素
+// 里真正可点的常常只是中间一小块（比如一整行里只有个图标可点），偏太远会落空。
+func jitterOffset(size float64) float64 {
+	limit := math.Min(math.Abs(size)*0.15, 8)
+	return (rand.Float64() - 0.5) * 2 * limit
+}
+
+// jitterInQuad 在元素框内围绕 pt 取一个带小幅随机偏移的落点。
+// rod 对同一元素返回的可点位置是常量，这里让它在元素内有些变化。
+func jitterInQuad(pt proto.Point, q proto.DOMQuad) proto.Point {
+	return proto.Point{
+		X: pt.X + jitterOffset(q[4]-q[0]),
+		Y: pt.Y + jitterOffset(q[5]-q[1]),
+	}
+}
+
+// jitterOn 取元素外框后围绕 pt 抖动；取不到外框就原样返回。
+func jitterOn(elem *rod.Element, pt proto.Point) proto.Point {
+	shape, err := elem.Shape()
+	if err != nil || len(shape.Quads) == 0 {
+		return pt
+	}
+	return jitterInQuad(pt, shape.Quads[0])
+}
 
 func Click(elem *rod.Element) error {
 	pt, err := elem.WaitInteractable()
@@ -16,7 +59,7 @@ func Click(elem *rod.Element) error {
 	}
 
 	mouse := elem.Page().Mouse
-	if err := moveMouseCurved(mouse, *pt); err != nil {
+	if err := moveMouseCurved(mouse, jitterOn(elem, *pt)); err != nil {
 		return err
 	}
 
@@ -24,7 +67,7 @@ func Click(elem *rod.Element) error {
 		return err
 	}
 
-	return mouse.Click(proto.InputMouseButtonLeft, 1)
+	return pressAndRelease(mouse)
 }
 
 // ClickNoWait 移到元素中心再点击，跳过 rod 的 WaitInteractable 遮挡重试。
@@ -46,10 +89,10 @@ func ClickNoWait(elem *rod.Element) error {
 	center := proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2}
 
 	mouse := elem.Page().Mouse
-	if err := moveMouseCurved(mouse, center); err != nil {
+	if err := moveMouseCurved(mouse, jitterInQuad(center, q)); err != nil {
 		return err
 	}
-	return mouse.Click(proto.InputMouseButtonLeft, 1)
+	return pressAndRelease(mouse)
 }
 
 // MoveTo 沿曲线把指针移到指定坐标，不点击。
@@ -61,11 +104,13 @@ func MoveTo(page *rod.Page, pt proto.Point) error {
 // ClickAt 沿曲线移到指定坐标再点击。
 // 用于点不到元素、只能算坐标的场景（如取元素区域内的偏移点、点击空白处）；
 // 有元素可点时用 Click。
+//
+// 落点由调用方决定，这里不抖动——调用方挑那个坐标通常有它的理由。
 func ClickAt(page *rod.Page, pt proto.Point) error {
 	if err := moveMouseCurved(page.Mouse, pt); err != nil {
 		return err
 	}
-	return page.Mouse.Click(proto.InputMouseButtonLeft, 1)
+	return pressAndRelease(page.Mouse)
 }
 
 // Type 逐字符输入文本，字间带间隔。

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 
 // 集成测试：起无头浏览器验证输入行为，本地页面、不联网、不登录。
-// 手动跑：go test -tags integration ./humanize/ -run TestTypeEventSequence -v
+// 手动跑：go test -tags integration ./humanize/ -v
 package humanize
 
 import (
@@ -53,6 +53,9 @@ func countEvents(t *testing.T, page *rod.Page, target string) map[string]int {
 }
 
 // assertOneInputPerRune 每个字符应恰好产生一次 input，且不应产生 change。
+//
+// 这两条一起把输入的事件序列钉死：任何人把 Type 换成一次性写入、或换成
+// elem.Input（它在 CDP 插入之外还会多派发一轮 input/change），这里都会红。
 func assertOneInputPerRune(t *testing.T, label string, counts map[string]int, text string) {
 	t.Helper()
 
@@ -106,4 +109,83 @@ func TestTypeEventSequence(t *testing.T) {
 	if got := editable.MustText(); got != text {
 		t.Errorf("contenteditable 文本不符: 期望 %q，实际 %q", text, got)
 	}
+}
+
+const clickProbeBody = `<button id="btn" style="position:absolute;top:120px;left:80px;width:200px;height:60px">click</button>`
+
+const clickProbeInstall = `() => {
+  window.__clicks = [];
+  const b = document.getElementById('btn');
+  b.addEventListener('mousedown', e => window.__clicks.push(
+    {t:'down', ts:e.timeStamp, x:e.offsetX, y:e.offsetY}));
+  b.addEventListener('mouseup', e => window.__clicks.push(
+    {t:'up', ts:e.timeStamp, x:e.offsetX, y:e.offsetY}));
+  return true;
+}`
+
+type clickRecord struct {
+	T  string  `json:"t"`
+	TS float64 `json:"ts"`
+	X  float64 `json:"x"`
+	Y  float64 `json:"y"`
+}
+
+// TestClickPressAndScatter 校验 Click 的两条约定：
+//   - 按下与抬起之间有停留（rod 原生 Mouse.Click 是 Down 紧接 Up，没有间隔）
+//   - 同一元素多次点击的落点不固定（rod 返回的可点位置是常量）
+func TestClickPressAndScatter(t *testing.T) {
+	bin, err := browser.EnsureBrowser()
+	if err != nil {
+		t.Skipf("SKIP: 浏览器不可用: %v", err)
+	}
+
+	u := launcher.New().Bin(bin).Headless(true).MustLaunch()
+	b := rod.New().ControlURL(u).MustConnect()
+	defer b.MustClose()
+
+	page := b.MustPage("about:blank")
+	page.MustWaitLoad()
+	page.MustSetDocumentContent(clickProbeBody)
+	if !page.MustEval(clickProbeInstall).Bool() {
+		t.Fatal("安装点击监听器失败")
+	}
+
+	const rounds = 12
+	btn := page.MustElement("#btn")
+	for i := 0; i < rounds; i++ {
+		if err := Click(btn); err != nil {
+			t.Fatalf("第 %d 次点击失败: %v", i+1, err)
+		}
+	}
+
+	var recs []clickRecord
+	raw := page.MustEval(`() => JSON.stringify(window.__clicks)`).Str()
+	if err := json.Unmarshal([]byte(raw), &recs); err != nil {
+		t.Fatalf("解析点击记录失败: %v", err)
+	}
+	if len(recs) != rounds*2 {
+		t.Fatalf("应记录 %d 条 down/up，实际 %d 条", rounds*2, len(recs))
+	}
+
+	minHold := DefaultProvider{}.Timing()[ClickHold].Min
+	points := map[[2]float64]struct{}{}
+
+	for i := 0; i < len(recs); i += 2 {
+		down, up := recs[i], recs[i+1]
+		if down.T != "down" || up.T != "up" {
+			t.Fatalf("第 %d 组事件顺序异常: %s/%s", i/2+1, down.T, up.T)
+		}
+		// timeStamp 单位是毫秒；留 10ms 余量给时钟精度
+		hold := time.Duration(up.TS-down.TS) * time.Millisecond
+		if hold+10*time.Millisecond < minHold {
+			t.Errorf("第 %d 次按压时长 %v，短于下限 %v", i/2+1, hold, minHold)
+		}
+
+		points[[2]float64{down.X, down.Y}] = struct{}{}
+	}
+
+	if len(points) < 2 {
+		t.Errorf("%d 次点击落点完全相同（%v），抖动未生效", rounds, points)
+	}
+	t.Logf("%d 次点击产生 %d 个不同落点", rounds, len(points))
 }

--- a/humanize/provider.go
+++ b/humanize/provider.go
@@ -24,6 +24,7 @@ const (
 	BeforeClick   Action = "before_click"   // 移到元素上、点击前
 	Reading       Action = "reading"        // 浏览内容时的驻留
 	Keystroke     Action = "keystroke"      // 逐字符输入的字间间隔
+	ClickHold     Action = "click_hold"     // 单次点击里按下到抬起的按压时长
 )
 
 // LogNormal 描述一个右偏时延分布：ln(时延/秒) ~ Normal(Mu, Sigma)，采样后 clamp 到 [Min, Max]。
@@ -72,6 +73,7 @@ func (DefaultProvider) Timing() TimingProfile {
 		BeforeClick:   {Mu: -1.61, Sigma: 0.45, Min: 80 * time.Millisecond, Max: 1 * time.Second},        // ~0.2s
 		Reading:       {Mu: -0.36, Sigma: 0.40, Min: 300 * time.Millisecond, Max: 3 * time.Second},       // ~0.7s
 		Keystroke:     {Mu: -2.12, Sigma: 0.50, Min: 30 * time.Millisecond, Max: 400 * time.Millisecond}, // ~120ms/字
+		ClickHold:     {Mu: -2.47, Sigma: 0.33, Min: 45 * time.Millisecond, Max: 250 * time.Millisecond}, // ~85ms
 	}
 }
 

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -38,13 +38,42 @@ type CommentLoadConfig struct {
 	ScrollSpeed         string
 }
 
+// 未显式指定时的默认值。
+const (
+	defaultMaxCommentItems     = 20
+	defaultMaxRepliesThreshold = 10
+	defaultScrollSpeed         = "normal"
+)
+
 func DefaultCommentLoadConfig() CommentLoadConfig {
 	return CommentLoadConfig{
 		ClickMoreReplies:    false,
-		MaxRepliesThreshold: 10,
-		MaxCommentItems:     0,
-		ScrollSpeed:         "normal",
+		MaxRepliesThreshold: defaultMaxRepliesThreshold,
+		MaxCommentItems:     defaultMaxCommentItems,
+		ScrollSpeed:         defaultScrollSpeed,
 	}
+}
+
+// normalize 把零值字段填回默认值。零值一律按「未设置」处理，不再按「无上限」。
+//
+// 之所以必须在这一层做：配置从 MCP 和 HTTP 两条路进来，字段名和结构都不一样，
+// 漏传很容易发生。HTTP 侧要的是嵌套的 comment_config，传扁平字段会被
+// ShouldBindJSON 静默丢掉，于是 MaxCommentItems=0；而 0 以前表示「无上限」，
+// 一次详情请求就会滚满 defaultMaxAttempts(500) 轮——正是要避免的给平台刷日志。
+// 放在 action 层而不是某个 handler 里，两条路径和以后新增的调用方都能覆盖到。
+//
+// 真要拉更多评论，显式传一个大的 MaxCommentItems。
+func (c CommentLoadConfig) normalize() CommentLoadConfig {
+	if c.MaxCommentItems <= 0 {
+		c.MaxCommentItems = defaultMaxCommentItems
+	}
+	if c.MaxRepliesThreshold <= 0 {
+		c.MaxRepliesThreshold = defaultMaxRepliesThreshold
+	}
+	if c.ScrollSpeed == "" {
+		c.ScrollSpeed = defaultScrollSpeed
+	}
+	return c
 }
 
 type FeedDetailAction struct {
@@ -62,6 +91,8 @@ func (f *FeedDetailAction) GetFeedDetail(ctx context.Context, feedID, xsecToken 
 }
 
 func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, xsecToken string, loadAllComments bool, config CommentLoadConfig) (*FeedDetailResponse, error) {
+	config = config.normalize()
+
 	page := f.page.Context(ctx).Timeout(10 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 
@@ -462,11 +493,14 @@ func humanScroll(ctx context.Context, page *rod.Page, speed string, largeMode bo
 		}
 	}
 
+	// 兜底：常规幅度没推动，加大力度再滚一次，仍走真实滚轮。
+	// 不能用 window.scrollTo：详情页评论是在容器内滚动的，window 的 scrollTop 恒为 0
+	// （见 getScrollTop），滚 window 既滚错对象、又是一次 JS 注入。
 	if !scrolled && pushCount > 0 {
-		page.MustEval(`() => window.scrollTo(0, document.body.scrollHeight)`)
-		time.Sleep(400 * time.Millisecond) // 技术 settle：等 scrollTo 落位
+		smartScroll(page, float64(viewportHeight)*3)
+		time.Sleep(400 * time.Millisecond) // 技术 settle：等滚动落位
 		currentScrollTop = getScrollTop(page)
-		actualDelta = currentScrollTop - beforeTop + actualDelta
+		actualDelta += currentScrollTop - beforeTop
 		scrolled = actualDelta > 5
 	}
 

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -59,8 +59,8 @@ func DefaultCommentLoadConfig() CommentLoadConfig {
 // 之所以必须在这一层做：配置从 MCP 和 HTTP 两条路进来，字段名和结构都不一样，
 // 漏传很容易发生。HTTP 侧要的是嵌套的 comment_config，传扁平字段会被
 // ShouldBindJSON 静默丢掉，于是 MaxCommentItems=0；而 0 以前表示「无上限」，
-// 一次详情请求就会滚满 defaultMaxAttempts(500) 轮——正是要避免的给平台刷日志。
-// 放在 action 层而不是某个 handler 里，两条路径和以后新增的调用方都能覆盖到。
+// 一次详情请求就会滚满 defaultMaxAttempts(500) 轮。放在 action 层而不是某个
+// handler 里，两条路径和以后新增的调用方都能覆盖到。
 //
 // 真要拉更多评论，显式传一个大的 MaxCommentItems。
 func (c CommentLoadConfig) normalize() CommentLoadConfig {
@@ -493,9 +493,9 @@ func humanScroll(ctx context.Context, page *rod.Page, speed string, largeMode bo
 		}
 	}
 
-	// 兜底：常规幅度没推动，加大力度再滚一次，仍走真实滚轮。
-	// 不能用 window.scrollTo：详情页评论是在容器内滚动的，window 的 scrollTop 恒为 0
-	// （见 getScrollTop），滚 window 既滚错对象、又是一次 JS 注入。
+	// 兜底：常规幅度没推动，加大力度再滚一次。
+	// 不用 window.scrollTo：详情页评论在容器内滚动，window 的 scrollTop 恒为 0
+	// （见 getScrollTop）。实测滚 window 推不动评论容器，读回来的位移也不是它的。
 	if !scrolled && pushCount > 0 {
 		smartScroll(page, float64(viewportHeight)*3)
 		time.Sleep(400 * time.Millisecond) // 技术 settle：等滚动落位

--- a/xiaohongshu/feed_detail_test.go
+++ b/xiaohongshu/feed_detail_test.go
@@ -1,0 +1,54 @@
+package xiaohongshu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCommentLoadConfig_normalize 零值一律按「未设置」处理，回落到默认上限。
+//
+// 回归的是这个坑：HTTP 详情接口要的是嵌套的 comment_config，调用方传扁平字段
+// 会被 ShouldBindJSON 静默丢掉 → MaxCommentItems=0 → 以前 0 表示无上限 →
+// 一次请求滚满 defaultMaxAttempts(500) 轮。
+func TestCommentLoadConfig_normalize(t *testing.T) {
+	t.Run("空配置回落到默认", func(t *testing.T) {
+		got := CommentLoadConfig{}.normalize()
+		assert.Equal(t, defaultMaxCommentItems, got.MaxCommentItems)
+		assert.Equal(t, defaultMaxRepliesThreshold, got.MaxRepliesThreshold)
+		assert.Equal(t, defaultScrollSpeed, got.ScrollSpeed)
+	})
+
+	t.Run("负值同样按未设置处理", func(t *testing.T) {
+		got := CommentLoadConfig{MaxCommentItems: -1, MaxRepliesThreshold: -5}.normalize()
+		assert.Equal(t, defaultMaxCommentItems, got.MaxCommentItems)
+		assert.Equal(t, defaultMaxRepliesThreshold, got.MaxRepliesThreshold)
+	})
+
+	t.Run("显式值不被覆盖", func(t *testing.T) {
+		got := CommentLoadConfig{
+			MaxCommentItems:     200,
+			MaxRepliesThreshold: 3,
+			ScrollSpeed:         "slow",
+			ClickMoreReplies:    true,
+		}.normalize()
+		assert.Equal(t, 200, got.MaxCommentItems)
+		assert.Equal(t, 3, got.MaxRepliesThreshold)
+		assert.Equal(t, "slow", got.ScrollSpeed)
+		assert.True(t, got.ClickMoreReplies)
+	})
+
+	t.Run("默认配置本身已规范化且有上限", func(t *testing.T) {
+		d := DefaultCommentLoadConfig()
+		assert.Equal(t, d, d.normalize())
+		assert.Greater(t, d.MaxCommentItems, 0, "默认配置不能是无上限")
+	})
+}
+
+// TestCalculateMaxAttempts 规范化之后不该再落到 500 轮那条兜底上。
+func TestCalculateMaxAttempts(t *testing.T) {
+	cl := &commentLoader{config: CommentLoadConfig{}.normalize()}
+	assert.Equal(t, defaultMaxCommentItems*3, cl.calculateMaxAttempts())
+	assert.Less(t, cl.calculateMaxAttempts(), defaultMaxAttempts,
+		"默认配置的滚动轮数应远小于无上限时的 %d", defaultMaxAttempts)
+}

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -97,19 +97,45 @@ func (p *PublishAction) Publish(ctx context.Context, content PublishImageContent
 	return nil
 }
 
-func removePopCover(page *rod.Page) {
+// hasPopCover 当前页面是否还有挡人的浮层。
+func hasPopCover(page *rod.Page) bool {
+	has, _, err := page.Has("div.d-popover")
+	return err == nil && has
+}
 
-	// 先移除弹窗封面
-	has, elem, err := page.Has("div.d-popover")
-	if err != nil {
+// dismissPopCover 关掉挡住发布 TAB 的浮层，逐级降级。
+//
+// 顺序：Esc → 点空白 → JS 摘节点。前两步是真实手势，优先用；最后一步是
+// Eval("this.remove()")，是注入，但它只要节点在就必定生效。
+//
+// 为什么保留最后这一步：真机探针实测发布页 d-popover 数量为 0，说明这条
+// 路径本就极少触发——真实收益接近零。而 Esc 关不关得掉取决于小红书自己
+// 有没有写这个监听器，无从预判。拿"可能有效"换掉"必定有效"，赌上的是
+// 发布直接失败（mustClickPublishTab 空转 15s）。不值得。
+func dismissPopCover(page *rod.Page) {
+	if err := page.Keyboard.Press(input.Escape); err != nil {
+		logrus.Debugf("按 Esc 关闭浮层失败: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond) // 技术等待：等浮层收起动画
+	if !hasPopCover(page) {
 		return
 	}
-	if has {
-		elem.MustRemove()
+
+	clickEmptyPosition(page)
+	time.Sleep(200 * time.Millisecond)
+	if !hasPopCover(page) {
+		return
 	}
 
-	// 兜底：点击一下空位置吧
-	clickEmptyPosition(page)
+	// 真实手势都无效，退回摘节点，保证发布能继续。
+	has, elem, err := page.Has("div.d-popover")
+	if err != nil || !has {
+		return
+	}
+	logrus.Warn("Esc 与点击空白都未能关闭浮层，退回 JS 移除节点")
+	if err := elem.Remove(); err != nil {
+		logrus.Warnf("移除浮层失败: %v", err)
+	}
 }
 
 func clickEmptyPosition(page *rod.Page) {
@@ -127,6 +153,8 @@ func mustClickPublishTab(page *rod.Page, tabname string) error {
 	page.MustElement(`div.upload-content`).MustWaitVisible()
 
 	deadline := time.Now().Add(15 * time.Second)
+	blockedAtLeastOnce := false
+
 	for time.Now().Before(deadline) {
 		tab, blocked, err := getTabElement(page, tabname)
 		if err != nil {
@@ -141,8 +169,9 @@ func mustClickPublishTab(page *rod.Page, tabname string) error {
 		}
 
 		if blocked {
-			logrus.Info("发布 TAB 被遮挡，尝试移除遮挡")
-			removePopCover(page)
+			blockedAtLeastOnce = true
+			logrus.Info("发布 TAB 被遮挡，尝试关闭浮层")
+			dismissPopCover(page)
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
@@ -156,6 +185,12 @@ func mustClickPublishTab(page *rod.Page, tabname string) error {
 		return nil
 	}
 
+	// 区分两种失败：找不到 TAB，和找到了但一直关不掉挡在上面的浮层。
+	// 后者是 dismissPopCover（Esc + 点空白）没奏效——真机上没能复现出浮层，
+	// 这条路径未经走查验证，所以把原因写进错误里，真踩到时一眼可辨。
+	if blockedAtLeastOnce {
+		return errors.Errorf("发布 TAB %s 一直被浮层遮挡，Esc 与点击空白都未能关闭", tabname)
+	}
 	return errors.Errorf("没有找到发布 TAB - %s", tabname)
 }
 
@@ -321,7 +356,7 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 
 	// 处理定时发布
 	if scheduleTime != nil {
-		if err := setSchedulePublish(page, *scheduleTime); err != nil {
+		if err := setSchedulePublish(ctx, page, *scheduleTime); err != nil {
 			return errors.Wrap(err, "设置定时发布失败")
 		}
 		slog.Info("定时发布设置完成", "schedule_time", scheduleTime.Format("2006-01-02 15:04"))
@@ -341,7 +376,7 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 	}
 
 	// 绑定商品
-	if err := bindProducts(page, products); err != nil {
+	if err := bindProducts(ctx, page, products); err != nil {
 		return errors.Wrap(err, "绑定商品失败")
 	}
 
@@ -654,8 +689,9 @@ func inputTags(ctx context.Context, contentElem *rod.Element, tags []string) err
 }
 
 func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
-	// 输入 # 触发话题联想（控制字符，直接 Input）
-	if err := contentElem.Input("#"); err != nil {
+	// 输入 # 触发话题联想。必须走 humanize.Type：rod 的 elem.Input 会在 CDP 插入后
+	// 再补一次 JS dispatchEvent(new Event('input'/'change'))，isTrusted=false。
+	if err := humanize.Type(ctx, contentElem, "#"); err != nil {
 		return errors.Wrap(err, "输入#失败")
 	}
 	time.Sleep(200 * time.Millisecond) // 技术等待：等联想下拉框弹出
@@ -670,13 +706,13 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 	topicContainer, err := page.Element("#creator-editor-topic-container")
 	if err != nil || topicContainer == nil {
 		slog.Warn("未找到标签联想下拉框，直接输入空格", "tag", tag)
-		return contentElem.Input(" ")
+		return humanize.Type(ctx, contentElem, " ")
 	}
 
 	firstItem, err := topicContainer.Element(".item")
 	if err != nil || firstItem == nil {
 		slog.Warn("未找到标签联想选项，直接输入空格", "tag", tag)
-		return contentElem.Input(" ")
+		return humanize.Type(ctx, contentElem, " ")
 	}
 
 	if err := humanize.Click(firstItem); err != nil {
@@ -852,7 +888,7 @@ func setVisibility(page *rod.Page, visibility string) error {
 }
 
 // setSchedulePublish 设置定时发布时间
-func setSchedulePublish(page *rod.Page, t time.Time) error {
+func setSchedulePublish(ctx context.Context, page *rod.Page, t time.Time) error {
 	// 1. 点击定时发布开关
 	if err := clickScheduleSwitch(page); err != nil {
 		return err
@@ -860,7 +896,7 @@ func setSchedulePublish(page *rod.Page, t time.Time) error {
 	time.Sleep(800 * time.Millisecond)
 
 	// 2. 设置日期时间
-	if err := setDateTime(page, t); err != nil {
+	if err := setDateTime(ctx, page, t); err != nil {
 		return err
 	}
 	time.Sleep(500 * time.Millisecond)
@@ -883,18 +919,20 @@ func clickScheduleSwitch(page *rod.Page) error {
 }
 
 // setDateTime 设置日期时间
-func setDateTime(page *rod.Page, t time.Time) error {
+func setDateTime(ctx context.Context, page *rod.Page, t time.Time) error {
 	dateTimeStr := t.Format("2006-01-02 15:04")
 
-	input, err := page.Element(".date-picker-container input")
+	elem, err := page.Element(".date-picker-container input")
 	if err != nil {
 		return errors.Wrap(err, "查找日期时间输入框失败")
 	}
 
-	if err := input.SelectAllText(); err != nil {
+	// SelectAllText 走 Eval(this.select())：JS 驱动的选中，不派发伪造事件，
+	// 信号弱于 elem.Input，本轮不动（改法需平台相关的 Ctrl/Cmd+A 或三击）。
+	if err := elem.SelectAllText(); err != nil {
 		return errors.Wrap(err, "选择日期时间文本失败")
 	}
-	if err := input.Input(dateTimeStr); err != nil {
+	if err := humanize.Type(ctx, elem, dateTimeStr); err != nil {
 		return errors.Wrap(err, "输入日期时间失败")
 	}
 	slog.Info("已设置日期时间", "datetime", dateTimeStr)
@@ -1056,7 +1094,7 @@ func isButtonDisabled(btn *rod.Element) bool {
 }
 
 // bindProducts 绑定商品到发布内容
-func bindProducts(page *rod.Page, products []string) error {
+func bindProducts(ctx context.Context, page *rod.Page, products []string) error {
 	if len(products) == 0 {
 		return nil
 	}
@@ -1079,7 +1117,7 @@ func bindProducts(page *rod.Page, products []string) error {
 	// 遍历搜索并选择商品
 	var failedProducts []string
 	for _, keyword := range products {
-		if err := searchAndSelectProduct(page, modal, keyword); err != nil {
+		if err := searchAndSelectProduct(ctx, page, modal, keyword); err != nil {
 			slog.Warn("搜索选择商品失败", "keyword", keyword, "error", err)
 			failedProducts = append(failedProducts, keyword)
 		}
@@ -1187,7 +1225,7 @@ func waitForProductModal(page *rod.Page) (*rod.Element, error) {
 }
 
 // searchAndSelectProduct 搜索并选择商品
-func searchAndSelectProduct(page *rod.Page, modal *rod.Element, keyword string) error {
+func searchAndSelectProduct(ctx context.Context, page *rod.Page, modal *rod.Element, keyword string) error {
 	slog.Info("搜索商品", "keyword", keyword)
 
 	// 1. 获取搜索框
@@ -1196,14 +1234,14 @@ func searchAndSelectProduct(page *rod.Page, modal *rod.Element, keyword string) 
 		return errors.Wrap(err, "未找到商品搜索框")
 	}
 
-	// 2. 清空并输入关键词（使用原生 JS setter + 完整事件）
+	// 2. 清空并输入关键词。SelectAllText 走 Eval(this.select())：JS 驱动的选中，不派发伪造事件，
+	// 信号弱于 elem.Input，本轮不动（改法需平台相关的 Ctrl/Cmd+A 或三击）。
 	if err := searchInput.SelectAllText(); err != nil {
 		slog.Warn("选择搜索框文本失败", "error", err)
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	// 使用 rod Input 输入关键词
-	if err := searchInput.Input(keyword); err != nil {
+	if err := humanize.Type(ctx, searchInput, keyword); err != nil {
 		return errors.Wrap(err, "输入搜索关键词失败")
 	}
 	time.Sleep(300 * time.Millisecond)

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -105,13 +105,12 @@ func hasPopCover(page *rod.Page) bool {
 
 // dismissPopCover 关掉挡住发布 TAB 的浮层，逐级降级。
 //
-// 顺序：Esc → 点空白 → JS 摘节点。前两步是真实手势，优先用；最后一步是
-// Eval("this.remove()")，是注入，但它只要节点在就必定生效。
+// 顺序：Esc → 点空白 → 摘节点。前两步走正常交互，多数浮层这样就关掉了；
+// 都无效才落到最后一步。
 //
-// 为什么保留最后这一步：真机探针实测发布页 d-popover 数量为 0，说明这条
-// 路径本就极少触发——真实收益接近零。而 Esc 关不关得掉取决于小红书自己
-// 有没有写这个监听器，无从预判。拿"可能有效"换掉"必定有效"，赌上的是
-// 发布直接失败（mustClickPublishTab 空转 15s）。不值得。
+// 保留最后一步是因为它只要节点还在就必定生效：Esc 和点空白关不关得掉取决于
+// 页面自己有没有写对应的处理，无从预判，不该拿发布失败去赌（关不掉会让
+// mustClickPublishTab 空转满 15 秒）。
 func dismissPopCover(page *rod.Page) {
 	if err := page.Keyboard.Press(input.Escape); err != nil {
 		logrus.Debugf("按 Esc 关闭浮层失败: %v", err)
@@ -127,12 +126,12 @@ func dismissPopCover(page *rod.Page) {
 		return
 	}
 
-	// 真实手势都无效，退回摘节点，保证发布能继续。
+	// 前两步都无效，退回摘节点，保证发布能继续。
 	has, elem, err := page.Has("div.d-popover")
 	if err != nil || !has {
 		return
 	}
-	logrus.Warn("Esc 与点击空白都未能关闭浮层，退回 JS 移除节点")
+	logrus.Warn("Esc 与点击空白都未能关闭浮层，改为移除该节点")
 	if err := elem.Remove(); err != nil {
 		logrus.Warnf("移除浮层失败: %v", err)
 	}
@@ -689,8 +688,8 @@ func inputTags(ctx context.Context, contentElem *rod.Element, tags []string) err
 }
 
 func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
-	// 输入 # 触发话题联想。必须走 humanize.Type：rod 的 elem.Input 会在 CDP 插入后
-	// 再补一次 JS dispatchEvent(new Event('input'/'change'))，isTrusted=false。
+	// 输入 # 触发话题联想。统一走 humanize.Type，不用 elem.Input——后者除了
+	// CDP 插入还会额外派发一轮 input/change，与逐字符输入的事件序列对不上。
 	if err := humanize.Type(ctx, contentElem, "#"); err != nil {
 		return errors.Wrap(err, "输入#失败")
 	}
@@ -927,8 +926,8 @@ func setDateTime(ctx context.Context, page *rod.Page, t time.Time) error {
 		return errors.Wrap(err, "查找日期时间输入框失败")
 	}
 
-	// SelectAllText 走 Eval(this.select())：JS 驱动的选中，不派发伪造事件，
-	// 信号弱于 elem.Input，本轮不动（改法需平台相关的 Ctrl/Cmd+A 或三击）。
+	// SelectAllText 走 Eval(this.select())，只改选区、不额外派发事件，暂时保留。
+	// 换成键盘全选要区分 Ctrl/Cmd，换成三击又可能触发日期控件的其他行为。
 	if err := elem.SelectAllText(); err != nil {
 		return errors.Wrap(err, "选择日期时间文本失败")
 	}
@@ -1234,8 +1233,8 @@ func searchAndSelectProduct(ctx context.Context, page *rod.Page, modal *rod.Elem
 		return errors.Wrap(err, "未找到商品搜索框")
 	}
 
-	// 2. 清空并输入关键词。SelectAllText 走 Eval(this.select())：JS 驱动的选中，不派发伪造事件，
-	// 信号弱于 elem.Input，本轮不动（改法需平台相关的 Ctrl/Cmd+A 或三击）。
+	// 2. 清空并输入关键词。SelectAllText 走 Eval(this.select())，只改选区、不额外
+	// 派发事件，暂时保留（换键盘全选要区分 Ctrl/Cmd）。
 	if err := searchInput.SelectAllText(); err != nil {
 		slog.Warn("选择搜索框文本失败", "error", err)
 	}

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -131,7 +131,7 @@ func submitPublishVideo(ctx context.Context, page *rod.Page, title, content stri
 
 	// 处理定时发布
 	if scheduleTime != nil {
-		if err := setSchedulePublish(page, *scheduleTime); err != nil {
+		if err := setSchedulePublish(ctx, page, *scheduleTime); err != nil {
 			return errors.Wrap(err, "设置定时发布失败")
 		}
 		slog.Info("定时发布设置完成", "schedule_time", scheduleTime.Format("2006-01-02 15:04"))
@@ -143,7 +143,7 @@ func submitPublishVideo(ctx context.Context, page *rod.Page, title, content stri
 	}
 
 	// 绑定商品
-	if err := bindProducts(page, products); err != nil {
+	if err := bindProducts(ctx, page, products); err != nil {
 		return errors.Wrap(err, "绑定商品失败")
 	}
 


### PR DESCRIPTION
一组交互层的收敛与两个默认值/兜底的修正。

## humanize：点击补上按下停留与落点抖动

rod 的 `Mouse.Click` 是 `Down` 紧接着 `Up`、中间无间隔；且它对同一元素返回的可点位置是常量，于是每次点击落点完全一致。

- 新增 `Action ClickHold`（median ~85ms），`Click` / `ClickNoWait` / `ClickAt` 统一走 `pressAndRelease`
- `Click` / `ClickNoWait` 的落点在元素框内小幅抖动，幅度 `±min(边长 15%, 8px)`：按比例是为了小元素不偏出去，封顶 8px 是因为宽元素里真正可点的常常只是中间一小块
- `ClickAt` 只补停留、不抖动 —— 落点是调用方算出来的

## publish：输入统一走 humanize.Type

链路里还剩 5 处 `elem.Input`（标签的 `#` 触发词、联想失败时的空格兜底、定时发布时间、商品关键词）。`elem.Input` 在 CDP 插入之外还会多派发一轮 `input`/`change`，与 `humanize.Type` 的逐字符事件序列对不上。

后两处需要 ctx，顺带把 ctx 穿到 `setSchedulePublish` / `setDateTime` / `bindProducts` / `searchAndSelectProduct`。

## publish：浮层关闭改逐级降级

`removePopCover` 原本直接摘节点，改名 `dismissPopCover` 并改成 `Esc → 点空白 → 摘节点`，每步后检查浮层是否已消失。前两步走正常交互，都无效才落到最后一步 —— 它只要节点还在就必定生效，不该拿发布失败去赌。

`mustClickPublishTab` 的失败信息也区分开了「找不到 TAB」和「浮层一直关不掉」，原来都报前者，会把人往错方向带。

## feed：评论加载上限的零值按「未设置」处理

HTTP 详情接口传 `load_all_comments=true` 而不带 `comment_config` 时，会滚满 `defaultMaxAttempts`(500) 轮。两层叠加：HTTP 侧要的是嵌套的 `comment_config`，按内部字段名传扁平的 `max_comment_items` 会被 `ShouldBindJSON` 静默丢掉、得到 `MaxCommentItems=0`；而 `0` 以前表示「无上限」。MCP 侧 `limit` 默认 20（README 也是这么写的），两个接口不一致。

`normalize()` 放在 action 层的 `GetFeedDetailWithConfig`，不是放在某个 handler —— MCP、HTTP 和以后新增的调用方都覆盖得到。

**行为变化**：HTTP 侧不带 config 时从「加载全部」变成「最多 20 条」，与 MCP 和 README 的既有约定对齐。要更多就显式传 `comment_config.max_comment_items`。

## feed：滚动兜底改用滚轮

`humanScroll` 的兜底分支原本调 `window.scrollTo`。详情页评论在容器内滚动、window 的 `scrollTop` 恒为 0（见 `getScrollTop`），实测滚 window 推不动评论容器、读回来的位移也不是它的，等于空转。改成加大幅度再走一次滚轮。这个兜底只在常规幅度没推动时才进。

## 验证

- 单测：抖动幅度上下界、抖动后仍在框内、多次抖动确实分散；`CommentLoadConfig.normalize` 的零值/负值/显式值分支
- 集成测试（本地页面，不联网不登录）：输入的事件序列、点击的停留时长与落点分散；退化实现会让它们变红
- 真机走查：发布一篇图文（两个标签均正常触发联想）、详情页加载 330 条评论、点赞与取消点赞