### PR TITLE
fix(search): 筛选项按文本匹配，修正选错项的问题

### DIFF
--- a/humanize/input.go
+++ b/humanize/input.go
@@ -101,6 +101,24 @@ func MoveTo(page *rod.Page, pt proto.Point) error {
 	return moveMouseCurved(page.Mouse, pt)
 }
 
+// Hover 沿曲线把指针移到元素上，不点击。
+// 用于靠悬停触发的交互（如展开 hover 浮层）。
+// 不用 rod 的 elem.Hover：它是一次 MoveTo，指针会直接瞬移过去。
+func Hover(elem *rod.Element) error {
+	shape, err := elem.Shape()
+	if err != nil {
+		return err
+	}
+	if len(shape.Quads) == 0 {
+		return errors.New("元素无可悬停区域")
+	}
+
+	q := shape.Quads[0]
+	center := proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2}
+
+	return moveMouseCurved(elem.Page().Mouse, jitterInQuad(center, q))
+}
+
 // ClickAt 沿曲线移到指定坐标再点击。
 // 用于点不到元素、只能算坐标的场景（如取元素区域内的偏移点、点击空白处）；
 // 有元素可点时用 Click。

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -71,7 +71,10 @@ var filterOptionsMap = map[int][]internalFilterOption{
 	},
 }
 
-// convertToInternalFilters 将 FilterOption 转换为内部的 internalFilterOption 列表
+// convertToInternalFilters 把用户传的 FilterOption 转成内部筛选项列表。
+//
+// 这里同时是唯一的校验入口：选项只能从 filterOptionsMap 里取，取不到就报错，
+// 所以拿到的每一项按构造就是合法的，后续无需再校验一遍。
 func convertToInternalFilters(filter FilterOption) ([]internalFilterOption, error) {
 	var internalFilters []internalFilterOption
 
@@ -139,27 +142,6 @@ func findInternalOption(filtersIndex int, text string) (internalFilterOption, er
 	return internalFilterOption{}, fmt.Errorf("在筛选组 %d 中未找到文本 '%s'", filtersIndex, text)
 }
 
-// validateInternalFilterOption 验证内部筛选选项是否在有效范围内
-func validateInternalFilterOption(filter internalFilterOption) error {
-	// 检查筛选组索引是否有效
-	if filter.FiltersIndex < 1 || filter.FiltersIndex > 5 {
-		return fmt.Errorf("无效的筛选组索引 %d，有效范围为 1-5", filter.FiltersIndex)
-	}
-
-	// 检查标签索引是否在对应筛选组的有效范围内
-	options, exists := filterOptionsMap[filter.FiltersIndex]
-	if !exists {
-		return fmt.Errorf("筛选组 %d 不存在", filter.FiltersIndex)
-	}
-
-	for _, o := range options {
-		if o.Text == filter.Text {
-			return nil
-		}
-	}
-	return fmt.Errorf("筛选组 %d 中没有选项 %q", filter.FiltersIndex, filter.Text)
-}
-
 type SearchAction struct {
 	page *rod.Page
 }
@@ -193,16 +175,11 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 			allInternalFilters = append(allInternalFilters, internalFilters...)
 		}
 
-		// 验证所有内部筛选选项
-		for _, filter := range allInternalFilters {
-			if err := validateInternalFilterOption(filter); err != nil {
-				return nil, fmt.Errorf("筛选选项验证失败: %w", err)
-			}
-		}
-
-		// 悬停在筛选按钮上
+		// 悬停在筛选按钮上展开面板
 		filterButton := page.MustElement(`div.filter`)
-		filterButton.MustHover()
+		if err := humanize.Hover(filterButton); err != nil {
+			return nil, fmt.Errorf("悬停筛选按钮失败: %w", err)
+		}
 		humanize.Delay(ctx, humanize.BeforeClick)
 
 		// 等待筛选面板出现

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-rod/rod"
@@ -27,43 +28,46 @@ type FilterOption struct {
 	Location    string `json:"location,omitempty" jsonschema:"位置距离: 不限|同城|附近,默认为'不限'"`
 }
 
-// internalFilterOption 内部使用的筛选选项(基于索引)
+// internalFilterOption 一个待应用的筛选项：落在哪个筛选组、选项文本是什么。
+//
+// 只记组序号不记标签序号：面板里每个选项会渲染成两个 div.tags，
+// 且首项是否重复各组不一致（排序依据/位置距离重复，其余不重复），
+// 下标对不上，只能按文本找。
 type internalFilterOption struct {
-	FiltersIndex int    // 筛选组索引
-	TagsIndex    int    // 标签索引
-	Text         string // 标签文本描述
+	FiltersIndex int    // 筛选组序号（组之间无重复，可用序号定位）
+	Text         string // 选项文本，用于在组内匹配
 }
 
 // 预定义的筛选选项映射表（内部使用）
 var filterOptionsMap = map[int][]internalFilterOption{
 	1: { // 排序依据
-		{FiltersIndex: 1, TagsIndex: 1, Text: "综合"},
-		{FiltersIndex: 1, TagsIndex: 2, Text: "最新"},
-		{FiltersIndex: 1, TagsIndex: 3, Text: "最多点赞"},
-		{FiltersIndex: 1, TagsIndex: 4, Text: "最多评论"},
-		{FiltersIndex: 1, TagsIndex: 5, Text: "最多收藏"},
+		{FiltersIndex: 1, Text: "综合"},
+		{FiltersIndex: 1, Text: "最新"},
+		{FiltersIndex: 1, Text: "最多点赞"},
+		{FiltersIndex: 1, Text: "最多评论"},
+		{FiltersIndex: 1, Text: "最多收藏"},
 	},
 	2: { // 笔记类型
-		{FiltersIndex: 2, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 2, TagsIndex: 2, Text: "视频"},
-		{FiltersIndex: 2, TagsIndex: 3, Text: "图文"},
+		{FiltersIndex: 2, Text: "不限"},
+		{FiltersIndex: 2, Text: "视频"},
+		{FiltersIndex: 2, Text: "图文"},
 	},
 	3: { // 发布时间
-		{FiltersIndex: 3, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 3, TagsIndex: 2, Text: "一天内"},
-		{FiltersIndex: 3, TagsIndex: 3, Text: "一周内"},
-		{FiltersIndex: 3, TagsIndex: 4, Text: "半年内"},
+		{FiltersIndex: 3, Text: "不限"},
+		{FiltersIndex: 3, Text: "一天内"},
+		{FiltersIndex: 3, Text: "一周内"},
+		{FiltersIndex: 3, Text: "半年内"},
 	},
 	4: { // 搜索范围
-		{FiltersIndex: 4, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 4, TagsIndex: 2, Text: "已看过"},
-		{FiltersIndex: 4, TagsIndex: 3, Text: "未看过"},
-		{FiltersIndex: 4, TagsIndex: 4, Text: "已关注"},
+		{FiltersIndex: 4, Text: "不限"},
+		{FiltersIndex: 4, Text: "已看过"},
+		{FiltersIndex: 4, Text: "未看过"},
+		{FiltersIndex: 4, Text: "已关注"},
 	},
 	5: { // 位置距离
-		{FiltersIndex: 5, TagsIndex: 1, Text: "不限"},
-		{FiltersIndex: 5, TagsIndex: 2, Text: "同城"},
-		{FiltersIndex: 5, TagsIndex: 3, Text: "附近"},
+		{FiltersIndex: 5, Text: "不限"},
+		{FiltersIndex: 5, Text: "同城"},
+		{FiltersIndex: 5, Text: "附近"},
 	},
 }
 
@@ -148,12 +152,12 @@ func validateInternalFilterOption(filter internalFilterOption) error {
 		return fmt.Errorf("筛选组 %d 不存在", filter.FiltersIndex)
 	}
 
-	if filter.TagsIndex < 1 || filter.TagsIndex > len(options) {
-		return fmt.Errorf("筛选组 %d 的标签索引 %d 超出范围，有效范围为 1-%d",
-			filter.FiltersIndex, filter.TagsIndex, len(options))
+	for _, o := range options {
+		if o.Text == filter.Text {
+			return nil
+		}
 	}
-
-	return nil
+	return fmt.Errorf("筛选组 %d 中没有选项 %q", filter.FiltersIndex, filter.Text)
 }
 
 type SearchAction struct {
@@ -207,12 +211,13 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 		// 用 ClickNoWait：筛选面板是 hover 浮层，rod 的 WaitInteractable 会误判被遮挡而死等；
 		// ClickNoWait 移进面板内选项（维持 hover、面板不关）再点。
 		for _, filter := range allInternalFilters {
-			selector := fmt.Sprintf(`div.filter-panel div.filters:nth-child(%d) div.tags:nth-child(%d)`,
-				filter.FiltersIndex, filter.TagsIndex)
-			option := page.MustElement(selector)
+			option, err := findFilterOption(page, filter)
+			if err != nil {
+				return nil, err
+			}
 			humanize.Delay(ctx, humanize.BeforeClick)
 			if err := humanize.ClickNoWait(option); err != nil {
-				return nil, fmt.Errorf("点击筛选选项失败: %w", err)
+				return nil, fmt.Errorf("点击筛选选项 %q 失败: %w", filter.Text, err)
 			}
 		}
 
@@ -245,6 +250,39 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	}
 
 	return feeds, nil
+}
+
+// findFilterOption 在筛选面板里定位一个选项。
+//
+// 组用序号定位：各组之间没有重复，`:nth-of-type` 稳定。
+// 组内的选项只能按文本找，不能用序号——面板里每个选项会渲染成两个
+// div.tags（两份的位置尺寸完全相同，点哪个都落在同一处），而且首项
+// 是否重复各组并不一致：排序依据、位置距离的首项重复，笔记类型、
+// 发布时间、搜索范围的首项不重复。所以任何下标算术都对不齐，
+// 早前用 div.tags:nth-child(N) 会选错项（如要"最多点赞"点到"最新"）。
+func findFilterOption(page *rod.Page, filter internalFilterOption) (*rod.Element, error) {
+	group, err := page.Element(fmt.Sprintf(
+		`div.filter-panel div.filters:nth-of-type(%d)`, filter.FiltersIndex))
+	if err != nil {
+		return nil, fmt.Errorf("未找到筛选组 %d（%s）: %w", filter.FiltersIndex, filter.Text, err)
+	}
+
+	options, err := group.Elements("div.tags")
+	if err != nil {
+		return nil, fmt.Errorf("筛选组 %d 内没有可选项: %w", filter.FiltersIndex, err)
+	}
+
+	for _, opt := range options {
+		text, err := opt.Text()
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(text) == filter.Text {
+			return opt, nil
+		}
+	}
+
+	return nil, fmt.Errorf("筛选组 %d 内未找到选项 %q", filter.FiltersIndex, filter.Text)
 }
 
 func makeSearchURL(keyword string) string {

--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -16,11 +16,11 @@ func TestFilterValidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, internalFilters, 2)
 
-	// 验证转换后的内部筛选选项
-	for _, filter := range internalFilters {
-		err := validateInternalFilterOption(filter)
-		require.NoError(t, err)
-	}
+	// 转换结果应带上正确的组号与原文本
+	require.Equal(t, 2, internalFilters[0].FiltersIndex)
+	require.Equal(t, "图文", internalFilters[0].Text)
+	require.Equal(t, 3, internalFilters[1].FiltersIndex)
+	require.Equal(t, "一天内", internalFilters[1].Text)
 
 	// 测试无效的筛选值
 	invalidFilter := FilterOption{


### PR DESCRIPTION
`search_feeds` 带 filter 时会点错选项：要「最多点赞」实际点到「最新」，要「图文」点到「视频」。

closes #661 closes #657 closes #640

## 原因

筛选面板里**每个选项会渲染成两个 `div.tags`**，而且首项是否重复各组并不一致。实测「排序依据」组 5 个逻辑选项对应 10 个 `div.tags`：

| nth-child | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|---|---|---|---|---|---|---|---|---|---|---|
| 文本 | 综合 | 综合 | 最新 | 最新 | 最多点赞 | 最多点赞 | 最多评论 | 最多评论 | 最多收藏 | 最多收藏 |

各组的重复情况：

| 组 | 逻辑选项数 | `div.tags` 数 | 首项是否重复 |
|---|---|---|---|
| 排序依据 | 5 | 10 | 是 |
| 笔记类型 | 3 | 5 | 否 |
| 发布时间 | 4 | 7 | 否 |
| 搜索范围 | 4 | 7 | 否 |
| 位置距离 | 3 | 6 | 是 |

原来的 `div.tags:nth-child(N)` 把逻辑序号当成节点序号，从第二项起就错位；而且各组偏移量不同，**任何下标算术都补不回来**。

## 改动

- 组用 `:nth-of-type` 定位（组之间没有重复，序号稳定），组内按文本匹配
- 两份重复项的位置尺寸完全相同，取第一个点下去落在同一处
- `internalFilterOption` 的 `TagsIndex` 字段删除 —— 它的唯一用途就是拼那个出错的选择器，留着会误导后来的人；校验相应改为「组内存在该文本」

## 验证

真机搜「咖啡」+ 排序「最多点赞」：

- **修复后**：299680 / 242417 / 21308 / 9546 / 8998 / 7256 —— 按点赞降序
- **修复前**：2 / 17 / 0 / 2 —— 即按「最新」排的

## 致谢

思路取自 @drstrangerujn 的 #671。实现上改用 `humanize.ClickNoWait`：筛选面板是 hover 浮层，rod 的 `Click` 会先 `Hover` + `WaitInteractable`，在浮层上会误判被遮挡、死等到超时（该 PR 提交时 `ClickNoWait` 还不存在）。