### PR TITLE
feat(humanize): 点击前校验落点，够不到就报错而不是静默落空

### DIFF
--- a/humanize/input.go
+++ b/humanize/input.go
@@ -2,7 +2,9 @@ package humanize
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"math/rand"
 	"time"
@@ -52,14 +54,69 @@ func jitterOn(elem *rod.Element, pt proto.Point) proto.Point {
 	return jitterInQuad(pt, shape.Quads[0])
 }
 
+// ensurePointInViewport 落点必须在视口内。
+//
+// 视口外的坐标发出去命中不到任何元素，而调用方拿不到任何错误——以为点了，
+// 其实什么也没发生。实测 left:-9999px 和 top:5000px 的元素都是这样静默落空的。
+func ensurePointInViewport(page *rod.Page, pt proto.Point) error {
+	res, err := page.Eval(`() => JSON.stringify([window.innerWidth, window.innerHeight])`)
+	if err != nil {
+		return err // 读不到视口尺寸就不拦，避免误伤
+	}
+
+	var size []float64
+	if json.Unmarshal([]byte(res.Value.Str()), &size) != nil || len(size) != 2 {
+		return nil
+	}
+
+	if pt.X < 0 || pt.Y < 0 || pt.X > size[0] || pt.Y > size[1] {
+		return fmt.Errorf("落点 (%.0f,%.0f) 在视口 %.0fx%.0f 之外", pt.X, pt.Y, size[0], size[1])
+	}
+	return nil
+}
+
+// ensureClickable 落点必须真的能被鼠标打到。
+//
+// 只查两件事，都便宜且与页面的瞬时状态无关：
+//   - 落点在视口内（见 ensurePointInViewport）
+//   - 元素的 visibility 不是 hidden：这类元素有布局盒子、坐标也在视口里，
+//     但按规范不参与命中测试，点下去会落到它下面的元素上，同样是静默落空
+//
+// 刻意不查的三件事：
+//   - 不用 document.elementFromPoint 做命中校验：悬停浮层的状态在程序化移动
+//     指针时并不稳定，实测会把当时可见可点的选项判成不可点，拦错了更糟
+//   - 不查 opacity：opacity:0 的元素真人点下去照样命中，拦了反而不一致
+//   - 不查 pointer-events：设了 none 的元素真人点下去也是穿透到下层，同上
+//
+// display:none 和零象限不用查——它们在 Shape() 那一步就拿不到可点区域了。
+func ensureClickable(elem *rod.Element, pt proto.Point) error {
+	if err := ensurePointInViewport(elem.Page(), pt); err != nil {
+		return err
+	}
+
+	res, err := elem.Eval(`() => getComputedStyle(this).visibility`)
+	if err != nil {
+		return nil // 读不到样式就不拦
+	}
+	if res.Value.Str() == "hidden" {
+		return errors.New("元素 visibility 为 hidden，不参与命中测试")
+	}
+	return nil
+}
+
 func Click(elem *rod.Element) error {
 	pt, err := elem.WaitInteractable()
 	if err != nil {
 		return err
 	}
 
+	target := jitterOn(elem, *pt)
+	if err := ensureClickable(elem, target); err != nil {
+		return err
+	}
+
 	mouse := elem.Page().Mouse
-	if err := moveMouseCurved(mouse, jitterOn(elem, *pt)); err != nil {
+	if err := moveMouseCurved(mouse, target); err != nil {
 		return err
 	}
 
@@ -88,8 +145,13 @@ func ClickNoWait(elem *rod.Element) error {
 	q := shape.Quads[0] // 8 个值 = 4 个角点 (x,y)；对角线中点即中心
 	center := proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2}
 
+	target := jitterInQuad(center, q)
+	if err := ensureClickable(elem, target); err != nil {
+		return err
+	}
+
 	mouse := elem.Page().Mouse
-	if err := moveMouseCurved(mouse, jitterInQuad(center, q)); err != nil {
+	if err := moveMouseCurved(mouse, target); err != nil {
 		return err
 	}
 	return pressAndRelease(mouse)
@@ -116,7 +178,12 @@ func Hover(elem *rod.Element) error {
 	q := shape.Quads[0]
 	center := proto.Point{X: (q[0] + q[4]) / 2, Y: (q[1] + q[5]) / 2}
 
-	return moveMouseCurved(elem.Page().Mouse, jitterInQuad(center, q))
+	target := jitterInQuad(center, q)
+	if err := ensureClickable(elem, target); err != nil {
+		return err
+	}
+
+	return moveMouseCurved(elem.Page().Mouse, target)
 }
 
 // ClickAt 沿曲线移到指定坐标再点击。
@@ -125,6 +192,9 @@ func Hover(elem *rod.Element) error {
 //
 // 落点由调用方决定，这里不抖动——调用方挑那个坐标通常有它的理由。
 func ClickAt(page *rod.Page, pt proto.Point) error {
+	if err := ensurePointInViewport(page, pt); err != nil {
+		return err
+	}
 	if err := moveMouseCurved(page.Mouse, pt); err != nil {
 		return err
 	}

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -189,3 +189,68 @@ func TestClickPressAndScatter(t *testing.T) {
 	}
 	t.Logf("%d 次点击产生 %d 个不同落点", rounds, len(points))
 }
+
+const guardHTML = `<body style="margin:0;width:800px;height:600px">
+<div data-n="normal"      style="position:absolute;left:100px;top:100px;width:96px;height:40px">x</div>
+<div data-n="display"     style="display:none">x</div>
+<div data-n="visibility"  style="position:absolute;left:100px;top:200px;width:96px;height:40px;visibility:hidden">x</div>
+<div data-n="opacity0"    style="position:absolute;left:100px;top:260px;width:96px;height:40px;opacity:0">x</div>
+<div data-n="offleft"     style="position:absolute;left:-9999px;top:100px;width:96px;height:40px">x</div>
+<div data-n="belowfold"   style="position:absolute;left:100px;top:5000px;width:96px;height:40px">x</div>
+<div data-n="pointernone" style="position:absolute;left:300px;top:100px;width:96px;height:40px;pointer-events:none">x</div>
+<script>
+window.HIT = [];
+document.querySelectorAll('[data-n]').forEach(el =>
+  el.addEventListener('click', () => window.HIT.push(el.dataset.n), true));
+</script></body>`
+
+// TestClickGuards 校验点击前的落点检查：够不到的目标必须报错，而不是静默落空。
+//
+// 反过来同样重要：opacity:0 和 pointer-events:none 的元素必须放行——鼠标点在
+// 那个坐标上本来就是这个结果，拦下来反而与页面的真实行为不符。
+func TestClickGuards(t *testing.T) {
+	bin, err := browser.EnsureBrowser()
+	if err != nil {
+		t.Skipf("SKIP: 浏览器不可用: %v", err)
+	}
+
+	u := launcher.New().Bin(bin).Headless(true).MustLaunch()
+	b := rod.New().ControlURL(u).MustConnect()
+	defer b.MustClose()
+
+	page := b.MustPage("about:blank")
+	page.MustWaitLoad()
+	page.MustSetDocumentContent(guardHTML)
+
+	cases := []struct {
+		name    string
+		blocked bool // 是否应当被拦下
+		reason  string
+	}{
+		{"normal", false, "正常元素"},
+		{"display", true, "display:none 拿不到可点区域"},
+		{"visibility", true, "visibility:hidden 不参与命中测试"},
+		{"opacity0", false, "opacity:0 仍可命中，须放行"},
+		{"offleft", true, "落点在视口左侧之外"},
+		{"belowfold", true, "落点在视口下方之外"},
+		{"pointernone", false, "pointer-events:none 会穿透，须放行"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			el := page.MustElement(`[data-n="` + c.name + `"]`)
+			page.MustEval(`() => { window.HIT = [] }`)
+
+			err := ClickNoWait(el)
+			if c.blocked {
+				if err == nil {
+					t.Errorf("%s（%s）应被拦下，实际放行了", c.name, c.reason)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("%s（%s）不应被拦下，实际报错: %v", c.name, c.reason, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
点击走的是「算元素坐标 → 发鼠标事件到那个坐标」，由浏览器决定那一点上是谁。好处是够不到的元素本来就点不到；代价是**够不到的时候我们收不到任何反馈** —— 调用方以为点了，其实什么也没发生。

## 补的两条检查

| 情形 | 改前 | 改后 |
|---|---|---|
| `left:-9999px` | 能算出落点，点下去无命中，**不报错** | 报错「落点在视口之外」 |
| `top:5000px`（视口下方） | 同上 | 同上 |
| `visibility:hidden` | 有盒子、在视口内，点下去**落到下层元素**，不报错 | 报错「不参与命中测试」 |

`display:none` 与零尺寸不用另外查 —— `Shape()` 那一步就拿不到可点区域。

## 刻意不查的三件事

- **不用 `document.elementFromPoint` 做命中校验。** 悬停浮层的状态在程序化移动指针时并不稳定，实测会把当时可见可点的选项判成不可点 —— 拦错了比不拦更糟。
- **不查 `opacity`。** `opacity:0` 的元素点在那个坐标上照样命中，拦了与页面实际行为不符。
- **不查 `pointer-events`。** 设了 `none` 的元素点下去本来就穿透到下层，同上。

## 入口

`Click` / `ClickNoWait` / `Hover` 走完整检查；`ClickAt` 只查视口（落点是调用方给的，没有元素可查）。

## 验证

新增 `TestClickGuards` 覆盖七种情形，**正反两面都断言** —— 该拦的拦下，`opacity:0` 与 `pointer-events:none` 必须放行：

```
normal       放行  命中自己
display      拦下  元素无可点击区域
visibility   拦下  visibility 为 hidden，不参与命中测试
opacity0     放行  命中自己
offleft      拦下  落点 (-9951,116) 在视口 1280x800 之外
belowfold    拦下  落点 (142,5022) 在视口 1280x800 之外
pointernone  放行  穿透到下层
```

真机复核搜索筛选（悬停浮层路径）不受影响：搜「大模型应用」+ 排序「最多收藏」，结果按收藏降序 19627 / 6803 / 5472 / 3404 / 2561 / 2152。