### PR TITLE
fix(comment): 支持回复楼中楼，并给评论查找加上边界

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -191,26 +191,59 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 }
 
 // findCommentElement 滚动查找指定评论：优先按 commentID 命中，否则按 userID 匹配。
-// 每轮先在已渲染的评论里查一次，再判断是否到底，最后滚动加载更多。
+// 每轮先在已渲染的评论里查一次，再展开视野里的楼中楼，然后判断是否到底，最后滚动加载更多。
+//
+// 展开这一步是楼中楼回复的前提：二级评论默认折叠在「展开 N 条回复」后面，不点开
+// 就压根不在 DOM 里，此时哪怕 commentID 完全正确也只会得到「未找到评论」。
 func findCommentElement(ctx context.Context, page *rod.Page, commentID, userID string) (*rod.Element, error) {
 	logrus.Infof("开始查找评论 - commentID: %s, userID: %s", commentID, userID)
-
-	const maxAttempts = 100
 
 	scrollToCommentsArea(page)
 	humanize.Delay(ctx, humanize.BetweenScroll)
 
 	lastCommentCount := 0
 	stagnantChecks := 0
+	expandRounds := 0
+	deadline := time.Now().Add(maxSearchDuration)
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	// maxSearchScrolls 数的是「下滚」的次数，也就是这次查找能往下走多远。
+	// 展开楼中楼不计入：它是在当前位置就地把内容摊开，不消耗向下的行程；
+	// 让它占用预算的话，楼中楼多的热帖反而扫不到几条一级评论。
+	// 展开那边由 deadline 兜住总时长。
+	for attempt := 0; attempt < maxSearchScrolls; {
+		// 0. 墙钟兜底。评论区没有固定规模，热帖翻到底可以很久，
+		//    到点就停，别让单次请求无限拖下去。
+		if time.Now().After(deadline) {
+			logrus.Warnf("查找超过 %s，停止", maxSearchDuration)
+			return nil, fmt.Errorf("评论区过大，%s 内未找到目标评论 (commentID: %s, userID: %s)",
+				maxSearchDuration, commentID, userID)
+		}
+
 		// 1. 先查已渲染的评论——目标可能一开始就在页面上
 		if el := lookupComment(page, commentID, userID); el != nil {
-			logrus.Infof("✓ 找到目标评论（尝试 %d 次）", attempt+1)
+			logrus.Infof("✓ 找到目标评论（下滚 %d 次）", attempt)
 			return el, nil
 		}
 
-		// 2. 到底则不再加载
+		// 2. 展开视野里的楼中楼，展开后立刻再查一次
+		if expandRounds < maxExpandRounds {
+			if expanded := expandNearbyReplies(ctx, page); expanded > 0 {
+				expandRounds++
+				humanize.Delay(ctx, humanize.Reading)
+
+				if el := lookupComment(page, commentID, userID); el != nil {
+					logrus.Infof("✓ 展开楼中楼后找到目标评论（下滚 %d 次）", attempt)
+					return el, nil
+				}
+
+				// 眼前还有没展开的，先展开完再往下滚，避免滚过去就漏了
+				continue
+			}
+		}
+		expandRounds = 0
+		attempt++
+
+		// 3. 到底则不再加载
 		if checkEndContainer(page) {
 			logrus.Info("已到达评论底部，未找到目标评论")
 			break
@@ -231,7 +264,7 @@ func findCommentElement(ctx context.Context, page *rod.Page, commentID, userID s
 
 		// 4. 滚到最后一条评论再继续下滚，触发懒加载
 		if currentCount > 0 {
-			if elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment"); err == nil && len(elements) > 0 {
+			if elements, err := page.Timeout(2 * time.Second).Elements(".comment-item"); err == nil && len(elements) > 0 {
 				if err := elements[len(elements)-1].ScrollIntoView(); err != nil {
 					logrus.Debugf("滚动到最后一条评论失败: %v", err)
 				}
@@ -258,7 +291,10 @@ func lookupComment(page *rod.Page, commentID, userID string) *rod.Element {
 		return nil
 	}
 
-	elements, err := page.Timeout(2 * time.Second).Elements(".parent-comment, .comment-item, .comment")
+	// 只认 .comment-item：一级和二级评论都带这个 class，粒度正好是「一条评论」。
+	// 不能带上 .parent-comment——它把整个楼层（含楼中楼）都包在里面，按 userID 找时
+	// 会先命中外层楼层并返回它，结果回复按钮取到的是楼主那条，等于回错了人。
+	elements, err := page.Timeout(2 * time.Second).Elements(".comment-item")
 	if err != nil {
 		return nil
 	}

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -27,6 +27,26 @@ const (
 	largeScrollTrigger   = 5 // 停滞多少次后触发大滚动
 	buttonClickInterval  = 3 // 每隔多少次尝试点击一次按钮
 	finalSprintPushCount = 15
+
+	// 查找一条评论时最多下滚多少轮。normal 档一轮滚 0.7 屏，另加一次「滚到最后
+	// 一条评论」的跳转，25 轮覆盖几十屏，远超 get_feed_detail 默认加载的评论数——
+	// 调用方拿到的 comment_id 基本都落在这个范围内，翻不到多半是参数不对。
+	//
+	// 这个上限只管查找。批量拉评论走 get_feed_detail 的 defaultMaxAttempts，
+	// 两者不共用。
+	maxSearchScrolls = 25
+
+	// 查找评论时，最多连续多少轮只展开楼中楼而不下滚。
+	// 防止一个几百条回复的大楼层把查找预算吃光，导致后面的评论根本没机会加载。
+	maxExpandRounds = 5
+
+	// 查找一条评论的墙钟上限。
+	//
+	// 评论区没有固定规模，热帖翻到底可以很久，只靠轮数和停滞检测兜不住
+	// （实测一条热帖跑满 12 分钟仍未收敛）。用时间兜底而不是评论条数：
+	// 条数换算不出耗时——展开一个 50 条回复的楼层，条数只涨 50，耗时却是几十秒。
+	// 实测正常命中在 18~25 秒，留一倍多余量。
+	maxSearchDuration = 90 * time.Second
 )
 
 // ========== 数据结构 ==========
@@ -376,6 +396,10 @@ func clickShowMoreButtonsSmart(ctx context.Context, page *rod.Page, maxRepliesTh
 			continue
 		}
 
+		if !isSafeExpandButton(el, text) {
+			continue
+		}
+
 		if shouldSkipButton(text, maxRepliesThreshold, replyCountRegex) {
 			skipped++
 			continue
@@ -388,6 +412,104 @@ func clickShowMoreButtonsSmart(ctx context.Context, page *rod.Page, maxRepliesTh
 	}
 
 	return clicked, skipped
+}
+
+// expandNearbyReplies 展开视口附近的「展开 N 条回复」，把楼中楼灌进 DOM，返回本轮点开的个数。
+//
+// 与 clickShowMoreButtonsSmart 的差别有两点，都是为「边滚边找某条评论」这个场景准备的：
+//   - 只点视口附近的。clickElementWithHumanBehavior 会先 ScrollIntoView，若不加过滤，
+//     顶部残留的按钮每轮都会把页面拽回去，和向下滚动来回打架。
+//   - 不按回复数跳过。那个阈值是给批量抓取省时间用的，这里漏掉一个大楼层就等于漏掉目标。
+func expandNearbyReplies(ctx context.Context, page *rod.Page) int {
+	elements, err := page.Elements(".show-more")
+	if err != nil || len(elements) == 0 {
+		return 0
+	}
+
+	maxClick := maxClickPerRound + rand.Intn(maxClickPerRound)
+	clicked := 0
+
+	for _, el := range elements {
+		if clicked >= maxClick {
+			break
+		}
+
+		if !isElementClickable(el) || !isNearViewport(page, el) {
+			continue
+		}
+
+		text, err := el.Text()
+		if err != nil {
+			continue
+		}
+
+		if !isSafeExpandButton(el, text) {
+			continue
+		}
+
+		if clickElementWithHumanBehavior(ctx, page, el, text) {
+			clicked++
+		}
+	}
+
+	return clicked
+}
+
+// isSafeExpandButton 判断这个 .show-more 是不是真的展开回复按钮。
+//
+// 这两处的按钮是按 class 扫出来批量点的，不是调用方指定的元素，因此文案和
+// 尺寸都要核一遍再点，避免同 class 的其它元素被误点。
+func isSafeExpandButton(el *rod.Element, text string) bool {
+	if !isExpandRepliesButton(text) {
+		logrus.Debugf("跳过展开按钮：文案不匹配 %q", text)
+		return false
+	}
+
+	if !hasReadableSize(el) {
+		logrus.Debugf("跳过展开按钮：尺寸过小 %q", text)
+		return false
+	}
+
+	return true
+}
+
+// expandRepliesTextRegex 匹配展开楼中楼按钮的两种文案。
+// 大楼层点开一次后文案会从「展开 49 条回复」变成不带数字的「展开更多回复」，
+// 只认数字那一种会在大楼层上半途停住。
+var expandRepliesTextRegex = regexp.MustCompile(`^展开\s*(\d+\s*条|更多)回复$`)
+
+func isExpandRepliesButton(text string) bool {
+	return expandRepliesTextRegex.MatchString(strings.TrimSpace(text))
+}
+
+// hasReadableSize 判断元素尺寸是否达到正常按钮的量级。
+// 展开按钮实测约 279x32；1x1 之类的元素同样有布局盒子、过得了可见性检查，
+// 靠尺寸把它们排除掉。
+func hasReadableSize(el *rod.Element) bool {
+	const minWidth, minHeight = 24, 10
+
+	shape, err := el.Shape()
+	if err != nil || len(shape.Quads) == 0 {
+		return false
+	}
+
+	q := shape.Quads[0] // 四个角点，左上 (q0,q1) 右下 (q4,q5)
+	return q[4]-q[0] >= minWidth && q[5]-q[1] >= minHeight
+}
+
+// isNearViewport 判断元素是否落在视口上下各一屏的范围内。
+// 放宽到一屏是为了留重叠：滚动后刚被划出去的按钮下一轮还能再被捡起来。
+func isNearViewport(page *rod.Page, el *rod.Element) bool {
+	shape, err := el.Shape()
+	if err != nil || len(shape.Quads) == 0 {
+		return false
+	}
+
+	// CDP 给的 quads 是相对视口的 CSS 像素，取左上角的 y 即可。
+	top := shape.Quads[0][1]
+	height := float64(page.MustEval(`() => window.innerHeight`).Int())
+
+	return top > -height && top < 2*height
 }
 
 func isElementClickable(el *rod.Element) bool {

--- a/xiaohongshu/feed_detail_test.go
+++ b/xiaohongshu/feed_detail_test.go
@@ -6,6 +6,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestIsExpandRepliesButton 只有读得出「展开…回复」的按钮才允许自动点。
+//
+// 两种文案都必须认：大楼层点开一次后，「展开 49 条回复」会变成不带数字的
+// 「展开更多回复」，只匹配数字那一种会在大楼层上半途停住。
+func TestIsExpandRepliesButton(t *testing.T) {
+	accepted := []string{
+		"展开 49 条回复",
+		"展开1条回复",
+		" 展开 2 条回复 ",
+		"展开更多回复",
+	}
+	for _, text := range accepted {
+		assert.True(t, isExpandRepliesButton(text), "应认得: %q", text)
+	}
+
+	rejected := []string{
+		"",
+		"收起",
+		"展开",
+		"查看全部评论",
+		"展开 2 条回复并关注", // 多余后缀，不是这个按钮
+		"点击领取优惠券",     // 同 class 的其它元素
+		"展开 abc 条回复",
+	}
+	for _, text := range rejected {
+		assert.False(t, isExpandRepliesButton(text), "不该认: %q", text)
+	}
+}
+
 // TestCommentLoadConfig_normalize 零值一律按「未设置」处理，回落到默认上限。
 //
 // 回归的是这个坑：HTTP 详情接口要的是嵌套的 comment_config，调用方传扁平字段


### PR DESCRIPTION
## 问题

回复二级评论（楼中楼）始终报「无法找到评论」，即使 `comment_id` 和 `user_id` 都正确。

对应 issue：#707 #598 #503

## 根因

二级评论默认折叠在「展开 N 条回复」后面，不点开就不在 DOM 里。`findCommentElement` 只滚动、不展开，所以哪怕 `comment_id` 完全正确也找不到。

`get_feed_detail` 返回的评论列表里是包含二级评论的，调用方从那里拿到 id 再来回复，就会撞上这个。

另外发现 `lookupComment` 按 `user_id` 匹配时会选错元素：候选集合里的 `.parent-comment` 把整个楼层连同楼中楼一起包着，按 `user_id` 找会先命中外层楼层，回复按钮取到的是楼主那条。

## 改动

- 查找循环补上展开：每轮先查、再展开视野里的楼层、展开后立刻复查，眼前展开完了才继续下滚
- `user_id` 的候选集合只认 `.comment-item`（一级二级都带这个 class，粒度正好是一条评论）
- 给查找加上收敛条件，避免评论区规模很大时单次请求无限拖下去
- 展开按钮按文案和尺寸核对后再点，查找与批量加载两处共用同一判定

## 验证

已本地走查覆盖：

- 回复未折叠的二级评论（按 `comment_id`）
- 回复折叠在「展开 N 条回复」里的二级评论
- 只给 `user_id`、且目标是二级评论作者（此前会选中楼主）
- 目标不存在时正常返回错误，不会误发内容
- 评论区规模很大时能收敛返回
- `get_feed_detail` 批量展开无回归

`go build` / `go vet` / `go test ./xiaohongshu ./humanize` 全部通过。

## 已知问题（本 PR 未处理）

`get_feed_detail` 在评论区一屏放得下的短笔记上，`click_more_replies` 是失效的：`commentLoader.load` 里 `checkComplete` 排在 `shouldClickButtons` 之前，第一轮就命中 `end-container` 直接返回，展开函数没机会执行。表现为页面上有「展开 N 条回复」，但接口返回的 `subComments` 缺失。

这是既有问题，与本次修复无关，调整判断顺序会影响所有详情请求的行为，另开 issue 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
