### PR TITLE
chore: 精简全仓注释

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -26,8 +26,7 @@ func WithProxy(proxy string) Option {
 	}
 }
 
-// WithFingerprintSeed 固定指纹 seed（同账号绑定一套稳定指纹）。
-// seed<=0 视为未设，回退每次随机。
+// WithFingerprintSeed 设置 seed，seed<=0 视为未设，回退每次随机。
 func WithFingerprintSeed(seed int) Option {
 	return func(c *browserConfig) {
 		c.fingerprintSeed = seed

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -89,7 +89,6 @@ func (s *AppServer) publishHandler(c *gin.Context) {
 		return
 	}
 
-	// 执行发布
 	result, err := s.xiaohongshuService.PublishContent(c.Request.Context(), &req)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "PUBLISH_FAILED",
@@ -109,7 +108,6 @@ func (s *AppServer) publishVideoHandler(c *gin.Context) {
 		return
 	}
 
-	// 执行视频发布
 	result, err := s.xiaohongshuService.PublishVideo(c.Request.Context(), &req)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "PUBLISH_VIDEO_FAILED",
@@ -122,7 +120,6 @@ func (s *AppServer) publishVideoHandler(c *gin.Context) {
 
 // listFeedsHandler 获取Feeds列表
 func (s *AppServer) listFeedsHandler(c *gin.Context) {
-	// 获取 Feeds 列表
 	result, err := s.xiaohongshuService.ListFeeds(c.Request.Context())
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "LIST_FEEDS_FAILED",
@@ -160,7 +157,6 @@ func (s *AppServer) searchFeedsHandler(c *gin.Context) {
 		return
 	}
 
-	// 搜索 Feeds
 	result, err := s.xiaohongshuService.SearchFeeds(c.Request.Context(), keyword, filters)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "SEARCH_FEEDS_FAILED",
@@ -185,7 +181,6 @@ func (s *AppServer) getFeedDetailHandler(c *gin.Context) {
 	var err error
 
 	if req.CommentConfig != nil {
-		// 使用配置参数
 		config := xiaohongshu.CommentLoadConfig{
 			ClickMoreReplies:    req.CommentConfig.ClickMoreReplies,
 			MaxRepliesThreshold: req.CommentConfig.MaxRepliesThreshold,
@@ -194,7 +189,6 @@ func (s *AppServer) getFeedDetailHandler(c *gin.Context) {
 		}
 		result, err = s.xiaohongshuService.GetFeedDetailWithConfig(c.Request.Context(), req.FeedID, req.XsecToken, req.LoadAllComments, config)
 	} else {
-		// 使用默认配置
 		result, err = s.xiaohongshuService.GetFeedDetail(c.Request.Context(), req.FeedID, req.XsecToken, req.LoadAllComments)
 	}
 
@@ -217,7 +211,6 @@ func (s *AppServer) userProfileHandler(c *gin.Context) {
 		return
 	}
 
-	// 获取用户信息
 	result, err := s.xiaohongshuService.UserProfile(c.Request.Context(), req.UserID, req.XsecToken)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "GET_USER_PROFILE_FAILED",

--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -63,7 +63,6 @@ func TestDelay_RespectsContextCancel(t *testing.T) {
 	assert.Less(t, time.Since(start), 100*time.Millisecond, "已取消的 ctx 应让 Delay 立即返回")
 }
 
-// TestCubicBezier_Endpoints 贝塞尔曲线两端点应精确落在 p0/p3。
 func TestCubicBezier_Endpoints(t *testing.T) {
 	p0 := proto.Point{X: 0, Y: 0}
 	p1 := proto.Point{X: 10, Y: 50}

--- a/humanize/input.go
+++ b/humanize/input.go
@@ -13,10 +13,7 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 )
 
-// pressAndRelease 按下、停留一段采样出的时长、再抬起。
-//
-// rod 的 Mouse.Click 是 Down 紧接着 Up，中间没有间隔；这里按 ClickHold 的
-// 分布补上停留时间。
+// pressAndRelease 按下、停留一段按 ClickHold 采样出的时长、再抬起。
 func pressAndRelease(mouse *rod.Mouse) error {
 	if err := mouse.Down(proto.InputMouseButtonLeft, 1); err != nil {
 		return err
@@ -28,16 +25,14 @@ func pressAndRelease(mouse *rod.Mouse) error {
 }
 
 // jitterOffset 给定边长，返回 ±min(边长的 15%, 8px) 内的随机偏移。
-//
-// 两个上限缺一不可：按比例是为了小元素上不至于偏出去；封顶 8px 是因为宽元素
-// 里真正可点的常常只是中间一小块（比如一整行里只有个图标可点），偏太远会落空。
+// 两个上限缺一不可：按比例保证小元素上不会偏出边界；封顶 8px 是因为宽元素里
+// 可点区域常常只有中间一小块（比如一整行里只有个图标可点），偏太远会落空。
 func jitterOffset(size float64) float64 {
 	limit := math.Min(math.Abs(size)*0.15, 8)
 	return (rand.Float64() - 0.5) * 2 * limit
 }
 
-// jitterInQuad 在元素框内围绕 pt 取一个带小幅随机偏移的落点。
-// rod 对同一元素返回的可点位置是常量，这里让它在元素内有些变化。
+// jitterInQuad 在元素框内围绕 pt 取一个带小幅偏移的落点。
 func jitterInQuad(pt proto.Point, q proto.DOMQuad) proto.Point {
 	return proto.Point{
 		X: pt.X + jitterOffset(q[4]-q[0]),
@@ -75,20 +70,13 @@ func ensurePointInViewport(page *rod.Page, pt proto.Point) error {
 	return nil
 }
 
-// ensureClickable 落点必须真的能被鼠标打到。
+// ensureClickable 落点必须真的能被鼠标打到：坐标在视口内，且元素的 visibility
+// 不是 hidden——后者有布局盒子、坐标也在视口里，但按规范不参与命中测试，
+// 点下去会落到下层元素上，属于静默落空。
 //
-// 只查两件事，都便宜且与页面的瞬时状态无关：
-//   - 落点在视口内（见 ensurePointInViewport）
-//   - 元素的 visibility 不是 hidden：这类元素有布局盒子、坐标也在视口里，
-//     但按规范不参与命中测试，点下去会落到它下面的元素上，同样是静默落空
-//
-// 刻意不查的三件事：
-//   - 不用 document.elementFromPoint 做命中校验：悬停浮层的状态在程序化移动
-//     指针时并不稳定，实测会把当时可见可点的选项判成不可点，拦错了更糟
-//   - 不查 opacity：opacity:0 的元素真人点下去照样命中，拦了反而不一致
-//   - 不查 pointer-events：设了 none 的元素真人点下去也是穿透到下层，同上
-//
-// display:none 和零象限不用查——它们在 Shape() 那一步就拿不到可点区域了。
+// 不用 document.elementFromPoint 做命中校验：悬停浮层的状态在程序化移动指针时
+// 并不稳定，实测会把当时可见可点的选项判成不可点，拦错了更糟。
+// display:none 和零象限不用查，它们在 Shape() 那一步就拿不到可点区域。
 func ensureClickable(elem *rod.Element, pt proto.Point) error {
 	if err := ensurePointInViewport(elem.Page(), pt); err != nil {
 		return err

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -53,9 +53,6 @@ func countEvents(t *testing.T, page *rod.Page, target string) map[string]int {
 }
 
 // assertOneInputPerRune 每个字符应恰好产生一次 input，且不应产生 change。
-//
-// 这两条一起把输入的事件序列钉死：任何人把 Type 换成一次性写入、或换成
-// elem.Input（它在 CDP 插入之外还会多派发一轮 input/change），这里都会红。
 func assertOneInputPerRune(t *testing.T, label string, counts map[string]int, text string) {
 	t.Helper()
 

--- a/humanize/provider.go
+++ b/humanize/provider.go
@@ -33,8 +33,7 @@ type LogNormal struct {
 	Min, Max  time.Duration // clamp 边界（Max<=0 表示不设上限）
 }
 
-// sample 是纯函数核心：给定一个标准正态样本 norm，返回 clamp 后的时延。
-// 拆出来是为了可确定性单测（喂已知 norm 值）。
+// sample 给定样本 norm，返回 clamp 后的时延。拆成纯函数是为了可确定性单测。
 func (l LogNormal) sample(norm float64) time.Duration {
 	secs := math.Exp(l.Mu + l.Sigma*norm)
 	// 先在"秒"量级上处理上限：secs 极大时直接 float64→Duration 会溢出成负值、

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -42,7 +42,6 @@ func (s *AppServer) handleCheckLoginStatus(ctx context.Context) *MCPToolResult {
 		}
 	}
 
-	// 根据 IsLoggedIn 判断并返回友好的提示
 	var resultText string
 	if status.IsLoggedIn {
 		resultText = fmt.Sprintf("✅ 已登录\n用户名: %s\n\n你可以使用其他功能了。", status.Username)
@@ -124,7 +123,6 @@ func (s *AppServer) handleDeleteCookies(ctx context.Context) *MCPToolResult {
 func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 发布内容")
 
-	// 解析参数
 	title, _ := args["title"].(string)
 	content, _ := args["content"].(string)
 	imagePathsInterface, _ := args["images"].([]interface{})
@@ -152,16 +150,13 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 		}
 	}
 
-	// 解析定时发布参数
 	scheduleAt, _ := args["schedule_at"].(string)
 	visibility := parseVisibility(args)
 
-	// 解析原创参数
 	isOriginal, _ := args["is_original"].(bool)
 
 	logrus.Infof("MCP: 发布内容 - 标题: %s, 图片数量: %d, 标签数量: %d, 定时: %s, 原创: %v, visibility: %s, 商品: %v", title, len(imagePaths), len(tags), scheduleAt, isOriginal, visibility, products)
 
-	// 构建发布请求
 	req := &PublishRequest{
 		Title:      title,
 		Content:    content,
@@ -173,7 +168,6 @@ func (s *AppServer) handlePublishContent(ctx context.Context, args map[string]in
 		Products:   products,
 	}
 
-	// 执行发布
 	result, err := s.xiaohongshuService.PublishContent(ctx, req)
 	if err != nil {
 		return &MCPToolResult{
@@ -228,13 +222,11 @@ func (s *AppServer) handlePublishVideo(ctx context.Context, args map[string]inte
 		}
 	}
 
-	// 解析定时发布参数
 	scheduleAt, _ := args["schedule_at"].(string)
 	visibility := parseVisibility(args)
 
 	logrus.Infof("MCP: 发布视频 - 标题: %s, 标签数量: %d, 定时: %s, visibility: %s, 商品: %v", title, len(tags), scheduleAt, visibility, products)
 
-	// 构建发布请求
 	req := &PublishVideoRequest{
 		Title:      title,
 		Content:    content,
@@ -245,7 +237,6 @@ func (s *AppServer) handlePublishVideo(ctx context.Context, args map[string]inte
 		Products:   products,
 	}
 
-	// 执行发布
 	result, err := s.xiaohongshuService.PublishVideo(ctx, req)
 	if err != nil {
 		return &MCPToolResult{
@@ -281,7 +272,6 @@ func (s *AppServer) handleListFeeds(ctx context.Context) *MCPToolResult {
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
 	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return &MCPToolResult{
@@ -317,7 +307,6 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 
 	logrus.Infof("MCP: 搜索Feeds - 关键词: %s", args.Keyword)
 
-	// 将 MCP 的 FilterOption 转换为 xiaohongshu.FilterOption
 	filter := xiaohongshu.FilterOption{
 		SortBy:      args.Filters.SortBy,
 		NoteType:    args.Filters.NoteType,
@@ -337,7 +326,6 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
 	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return &MCPToolResult{
@@ -361,7 +349,6 @@ func (s *AppServer) handleSearchFeeds(ctx context.Context, args SearchFeedsArgs)
 func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取Feed详情")
 
-	// 解析参数
 	feedID, ok := args["feed_id"].(string)
 	if !ok || feedID == "" {
 		return &MCPToolResult{
@@ -455,7 +442,6 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
 	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return &MCPToolResult{
@@ -479,7 +465,6 @@ func (s *AppServer) handleGetFeedDetail(ctx context.Context, args map[string]any
 func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) *MCPToolResult {
 	logrus.Info("MCP: 获取用户主页")
 
-	// 解析参数
 	userID, ok := args["user_id"].(string)
 	if !ok || userID == "" {
 		return &MCPToolResult{
@@ -515,7 +500,6 @@ func (s *AppServer) handleUserProfile(ctx context.Context, args map[string]any) 
 		}
 	}
 
-	// 格式化输出，转换为JSON字符串
 	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return &MCPToolResult{
@@ -611,7 +595,6 @@ func (s *AppServer) handleFavoriteFeed(ctx context.Context, args map[string]inte
 func (s *AppServer) handlePostComment(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 发表评论到Feed")
 
-	// 解析参数
 	feedID, ok := args["feed_id"].(string)
 	if !ok || feedID == "" {
 		return &MCPToolResult{
@@ -647,7 +630,6 @@ func (s *AppServer) handlePostComment(ctx context.Context, args map[string]inter
 
 	logrus.Infof("MCP: 发表评论 - Feed ID: %s, 内容长度: %d", feedID, len(content))
 
-	// 发表评论
 	result, err := s.xiaohongshuService.PostCommentToFeed(ctx, feedID, xsecToken, content)
 	if err != nil {
 		return &MCPToolResult{
@@ -659,7 +641,6 @@ func (s *AppServer) handlePostComment(ctx context.Context, args map[string]inter
 		}
 	}
 
-	// 返回成功结果，只包含feed_id
 	resultText := fmt.Sprintf("评论发表成功 - Feed ID: %s", result.FeedID)
 	return &MCPToolResult{
 		Content: []MCPContent{{
@@ -673,7 +654,6 @@ func (s *AppServer) handlePostComment(ctx context.Context, args map[string]inter
 func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]interface{}) *MCPToolResult {
 	logrus.Info("MCP: 回复评论")
 
-	// 解析参数
 	feedID, ok := args["feed_id"].(string)
 	if !ok || feedID == "" {
 		return &MCPToolResult{
@@ -721,7 +701,6 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 
 	logrus.Infof("MCP: 回复评论 - Feed ID: %s, Comment ID: %s, User ID: %s, 内容长度: %d", feedID, commentID, userID, len(content))
 
-	// 回复评论
 	result, err := s.xiaohongshuService.ReplyCommentToFeed(ctx, feedID, xsecToken, commentID, userID, content)
 	if err != nil {
 		return &MCPToolResult{
@@ -733,7 +712,6 @@ func (s *AppServer) handleReplyComment(ctx context.Context, args map[string]inte
 		}
 	}
 
-	// 返回成功结果
 	responseText := fmt.Sprintf("评论回复成功 - Feed ID: %s, Comment ID: %s, User ID: %s", result.FeedID, result.TargetCommentID, result.TargetUserID)
 	return &MCPToolResult{
 		Content: []MCPContent{{

--- a/service.go
+++ b/service.go
@@ -188,13 +188,11 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 		return nil, fmt.Errorf("标题长度超过限制")
 	}
 
-	// 处理图片：下载URL图片或使用本地路径
 	imagePaths, err := s.processImages(req.Images)
 	if err != nil {
 		return nil, err
 	}
 
-	// 解析定时发布时间
 	var scheduleTime *time.Time
 	if req.ScheduleAt != "" {
 		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
@@ -220,7 +218,6 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 		logrus.Infof("设置定时发布时间: %s", t.Format("2006-01-02 15:04"))
 	}
 
-	// 构建发布内容
 	content := xiaohongshu.PublishImageContent{
 		Title:        req.Title,
 		Content:      req.Content,
@@ -232,7 +229,6 @@ func (s *XiaohongshuService) PublishContent(ctx context.Context, req *PublishReq
 		Products:     req.Products,
 	}
 
-	// 执行发布
 	if err := s.publishContent(ctx, content); err != nil {
 		logrus.Errorf("发布内容失败: title=%s %v", content.Title, err)
 		return nil, err
@@ -267,7 +263,6 @@ func (s *XiaohongshuService) publishContent(ctx context.Context, content xiaohon
 		return err
 	}
 
-	// 执行发布
 	return action.Publish(ctx, content)
 }
 
@@ -286,7 +281,6 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 		return nil, fmt.Errorf("视频文件不存在或不可访问: %v", err)
 	}
 
-	// 解析定时发布时间
 	var scheduleTime *time.Time
 	if req.ScheduleAt != "" {
 		t, err := time.Parse(time.RFC3339, req.ScheduleAt)
@@ -312,7 +306,6 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 		logrus.Infof("设置定时发布时间: %s", t.Format("2006-01-02 15:04"))
 	}
 
-	// 构建发布内容
 	content := xiaohongshu.PublishVideoContent{
 		Title:        req.Title,
 		Content:      req.Content,
@@ -323,7 +316,6 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 		Products:     req.Products,
 	}
 
-	// 执行发布
 	if err := s.publishVideo(ctx, content); err != nil {
 		return nil, err
 	}
@@ -361,10 +353,8 @@ func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse,
 	page := b.NewPage()
 	defer page.Close()
 
-	// 创建 Feeds 列表 action
 	action := xiaohongshu.NewFeedsListAction(page)
 
-	// 获取 Feeds 列表
 	feeds, err := action.GetFeedsList(ctx)
 	if err != nil {
 		logrus.Errorf("获取 Feeds 列表失败: %v", err)
@@ -414,10 +404,8 @@ func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID
 	page := b.NewPage()
 	defer page.Close()
 
-	// 创建 Feed 详情 action
 	action := xiaohongshu.NewFeedDetailAction(page)
 
-	// 获取 Feed 详情
 	result, err := action.GetFeedDetailWithConfig(ctx, feedID, xsecToken, loadAllComments, config)
 	if err != nil {
 		return nil, err

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -20,7 +20,6 @@ type ActionResult struct {
 	Message string `json:"message"`
 }
 
-// 选择器常量
 const (
 	SelectorLikeButton    = ".interact-container .left .like-lottie"
 	SelectorCollectButton = ".interact-container .left .reds-icon.collect-icon"
@@ -216,7 +215,6 @@ func (a *interactAction) getInteractState(page *rod.Page, feedID string) (liked 
 		return false, false, myerrors.ErrNoFeedDetail
 	}
 
-	// 直接解析为 noteDetailMap
 	var noteDetailMap map[string]struct {
 		Note struct {
 			InteractInfo struct {

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -76,17 +76,12 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	// 导航到小红书首页，这会触发二维码弹窗
 	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
 
-	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
 
-	// 检查是否已经登录
 	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
-		// 已经登录，直接返回
 		return nil
 	}
 
-	// 等待扫码成功提示或者登录完成
-	// 这里我们等待登录成功的元素出现，这样更简单可靠
 	pp.MustElement(".main-container .user .link-wrapper .channel")
 
 	return nil
@@ -98,15 +93,12 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 	// 导航到小红书首页，这会触发二维码弹窗
 	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
 
-	// 等待一小段时间让页面完全加载
 	time.Sleep(2 * time.Second)
 
-	// 检查是否已经登录
 	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
 		return "", true, nil
 	}
 
-	// 获取二维码图片
 	src, err := pp.MustElement(".login-container .qrcode-img").Attribute("src")
 	if err != nil {
 		return "", false, errors.Wrap(err, "get qrcode src failed")

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -41,18 +41,15 @@ func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 
 	pp := page.Timeout(300 * time.Second)
 
-	// 使用更稳健的导航和等待策略
 	if err := pp.Navigate(urlOfPublic); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 
-	// 等待页面加载，使用 WaitLoad 代替 WaitIdle（更宽松）
 	if err := pp.WaitLoad(); err != nil {
 		logrus.Warnf("等待页面加载出现问题: %v，继续尝试", err)
 	}
 	time.Sleep(2 * time.Second)
 
-	// 等待页面稳定
 	if err := pp.WaitDOMStable(time.Second, 0.1); err != nil {
 		logrus.Warnf("等待 DOM 稳定出现问题: %v，继续尝试", err)
 	}
@@ -103,14 +100,9 @@ func hasPopCover(page *rod.Page) bool {
 	return err == nil && has
 }
 
-// dismissPopCover 关掉挡住发布 TAB 的浮层，逐级降级。
-//
-// 顺序：Esc → 点空白 → 摘节点。前两步走正常交互，多数浮层这样就关掉了；
-// 都无效才落到最后一步。
-//
-// 保留最后一步是因为它只要节点还在就必定生效：Esc 和点空白关不关得掉取决于
-// 页面自己有没有写对应的处理，无从预判，不该拿发布失败去赌（关不掉会让
-// mustClickPublishTab 空转满 15 秒）。
+// dismissPopCover 关掉挡住发布 TAB 的浮层，按 Esc → 点空白 → 摘节点逐级降级。
+// 保留摘节点这一步是因为它只要节点还在就必定生效，前两步是否奏效取决于页面
+// 自己有没有写对应的处理，无从预判。
 func dismissPopCover(page *rod.Page) {
 	if err := page.Keyboard.Press(input.Escape); err != nil {
 		logrus.Debugf("按 Esc 关闭浮层失败: %v", err)
@@ -184,9 +176,7 @@ func mustClickPublishTab(page *rod.Page, tabname string) error {
 		return nil
 	}
 
-	// 区分两种失败：找不到 TAB，和找到了但一直关不掉挡在上面的浮层。
-	// 后者是 dismissPopCover（Esc + 点空白）没奏效——真机上没能复现出浮层，
-	// 这条路径未经走查验证，所以把原因写进错误里，真踩到时一眼可辨。
+	// 区分两种失败：找不到 TAB，和找到了但浮层一直关不掉
 	if blockedAtLeastOnce {
 		return errors.Errorf("发布 TAB %s 一直被浮层遮挡，Esc 与点击空白都未能关闭", tabname)
 	}
@@ -244,7 +234,6 @@ func isElementBlocked(elem *rod.Element) (bool, error) {
 }
 
 func uploadImages(page *rod.Page, imagesPaths []string) error {
-	// 验证文件路径有效性
 	validPaths := make([]string, 0, len(imagesPaths))
 	for _, path := range imagesPaths {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -297,7 +286,6 @@ func waitForUploadComplete(page *rod.Page, expectedCount int) error {
 		}
 
 		currentCount := len(uploadedImages)
-		// 数量变化时才打印，避免刷屏
 		if currentCount != lastLogCount {
 			slog.Info("等待图片上传", "current", currentCount, "expected", expectedCount)
 			lastLogCount = currentCount
@@ -322,7 +310,6 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 		return errors.Wrap(err, "输入标题失败")
 	}
 
-	// 检查标题长度
 	humanize.Delay(ctx, humanize.AfterType)
 	if err := checkTitleMaxLength(page); err != nil {
 		return err
@@ -347,13 +334,11 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 
 	humanize.Delay(ctx, humanize.AfterType)
 
-	// 检查正文长度
 	if err := checkContentMaxLength(page); err != nil {
 		return err
 	}
 	slog.Info("检查正文长度：通过")
 
-	// 处理定时发布
 	if scheduleTime != nil {
 		if err := setSchedulePublish(ctx, page, *scheduleTime); err != nil {
 			return errors.Wrap(err, "设置定时发布失败")
@@ -361,7 +346,6 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 		slog.Info("定时发布设置完成", "schedule_time", scheduleTime.Format("2006-01-02 15:04"))
 	}
 
-	// 设置可见范围
 	if err := setVisibility(page, visibility); err != nil {
 		return errors.Wrap(err, "设置可见范围失败")
 	}
@@ -374,7 +358,6 @@ func submitPublish(ctx context.Context, page *rod.Page, title, content string, t
 		slog.Info("已声明原创")
 	}
 
-	// 绑定商品
 	if err := bindProducts(ctx, page, products); err != nil {
 		return errors.Wrap(err, "绑定商品失败")
 	}
@@ -579,12 +562,10 @@ func checkTitleMaxLength(page *rod.Page) error {
 		return errors.Wrap(err, "检查标题长度元素失败")
 	}
 
-	// 元素不存在，说明标题没超长
 	if !has {
 		return nil
 	}
 
-	// 元素存在，说明标题超长
 	titleLength, err := elem.Text()
 	if err != nil {
 		return errors.Wrap(err, "获取标题长度文本失败")
@@ -599,12 +580,10 @@ func checkContentMaxLength(page *rod.Page) error {
 		return errors.Wrap(err, "检查正文长度元素失败")
 	}
 
-	// 元素不存在，说明正文没超长
 	if !has {
 		return nil
 	}
 
-	// 元素存在，说明正文超长
 	contentLength, err := elem.Text()
 	if err != nil {
 		return errors.Wrap(err, "获取正文长度文本失败")
@@ -688,8 +667,7 @@ func inputTags(ctx context.Context, contentElem *rod.Element, tags []string) err
 }
 
 func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
-	// 输入 # 触发话题联想。统一走 humanize.Type，不用 elem.Input——后者除了
-	// CDP 插入还会额外派发一轮 input/change，与逐字符输入的事件序列对不上。
+	// 输入 # 触发话题联想
 	if err := humanize.Type(ctx, contentElem, "#"); err != nil {
 		return errors.Wrap(err, "输入#失败")
 	}
@@ -728,13 +706,11 @@ func findTextboxByPlaceholder(page *rod.Page) (*rod.Element, error) {
 		return nil, errors.New("no p elements found")
 	}
 
-	// 查找包含指定placeholder的元素
 	placeholderElem := findPlaceholderElement(elements, "输入正文描述")
 	if placeholderElem == nil {
 		return nil, errors.New("no placeholder element found")
 	}
 
-	// 向上查找textbox父元素
 	textboxElem := findTextboxParent(placeholderElem)
 	if textboxElem == nil {
 		return nil, errors.New("no textbox parent found")
@@ -783,7 +759,6 @@ func findTextboxParent(elem *rod.Element) *rod.Element {
 // isElementVisible 检查元素是否可见
 func isElementVisible(elem *rod.Element) bool {
 
-	// 检查是否有隐藏样式
 	style, err := elem.Attribute("style")
 	if err == nil && style != nil {
 		styleStr := *style
@@ -806,7 +781,6 @@ func isElementVisible(elem *rod.Element) bool {
 		}
 	}
 
-	// 检查 aria-hidden 属性
 	ariaHidden, err := elem.Attribute("aria-hidden")
 	if err == nil && ariaHidden != nil && *ariaHidden == "true" {
 		return false
@@ -848,13 +822,11 @@ func setVisibility(page *rod.Page, visibility string) error {
 		return nil
 	}
 
-	// 支持的选项校验
 	supported := map[string]bool{"仅自己可见": true, "仅互关好友可见": true}
 	if !supported[visibility] {
 		return errors.Errorf("不支持的可见范围: %s，支持: 公开可见、仅自己可见、仅互关好友可见", visibility)
 	}
 
-	// 点击可见范围下拉框
 	dropdown, err := page.Element("div.permission-card-wrapper div.d-select-content")
 	if err != nil {
 		return errors.Wrap(err, "查找可见范围下拉框失败")


### PR DESCRIPTION
延续 #765，把同样的标准套到其余业务代码上。

删掉两类：
- 复述代码的（`// 解析参数`、`// 执行发布`、`// 获取 Feeds 列表` 这种，下一行就写着）
- 把推导过程当注释写的长段落

保留代码本身说明不了的信息：平台侧的长度与时间限制、DOM 结构、选择器与降级顺序的取舍、某个函数为什么要拆出来。

净减 97 行注释，无逻辑变更。`go build` / `go vet` / `go test ./...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)