### PR TITLE
chore(test): 精简测试注释

### DIFF
--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -28,9 +28,7 @@ func TestGetCookiesFilePath(t *testing.T) {
 		t.Setenv("TMPDIR", tmp)
 		t.Setenv("COOKIES_PATH", "")
 
-		// /tmp 下有旧文件
 		assert.NoError(t, os.WriteFile(filepath.Join(tmp, "cookies.json"), []byte("[]"), 0644))
-		// 本地目录也有
 		cwd := t.TempDir()
 		t.Chdir(cwd)
 		assert.NoError(t, os.WriteFile(filepath.Join(cwd, "cookies.json"), []byte("[]"), 0644))

--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -122,8 +122,7 @@ func TestJitterInQuad_StaysInside(t *testing.T) {
 	}
 }
 
-// TestJitterInQuad_Scatters 同一元素多次抖动应产生不同落点，
-// 否则等于没抖动（rod 返回的可点位置本身是常量）。
+// TestJitterInQuad_Scatters 同一元素多次抖动应产生不同落点。
 func TestJitterInQuad_Scatters(t *testing.T) {
 	q := proto.DOMQuad{0, 0, 200, 0, 200, 60, 0, 60}
 	center := proto.Point{X: 100, Y: 30}

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -127,9 +127,8 @@ type clickRecord struct {
 	Y  float64 `json:"y"`
 }
 
-// TestClickPressAndScatter 校验 Click 的两条约定：
-//   - 按下与抬起之间有停留（rod 原生 Mouse.Click 是 Down 紧接 Up，没有间隔）
-//   - 同一元素多次点击的落点不固定（rod 返回的可点位置是常量）
+// TestClickPressAndScatter 校验 Click 的两条约定：按下与抬起之间有停留，
+// 且同一元素多次点击的落点不固定。
 func TestClickPressAndScatter(t *testing.T) {
 	bin, err := browser.EnsureBrowser()
 	if err != nil {
@@ -201,10 +200,8 @@ document.querySelectorAll('[data-n]').forEach(el =>
   el.addEventListener('click', () => window.HIT.push(el.dataset.n), true));
 </script></body>`
 
-// TestClickGuards 校验点击前的落点检查：够不到的目标必须报错，而不是静默落空。
-//
-// 反过来同样重要：opacity:0 和 pointer-events:none 的元素必须放行——鼠标点在
-// 那个坐标上本来就是这个结果，拦下来反而与页面的真实行为不符。
+// TestClickGuards 校验点击前的落点检查：够不到的目标必须报错，而不是静默落空；
+// opacity:0 和 pointer-events:none 则必须放行。
 func TestClickGuards(t *testing.T) {
 	bin, err := browser.EnsureBrowser()
 	if err != nil {

--- a/pkg/downloader/images_test.go
+++ b/pkg/downloader/images_test.go
@@ -48,7 +48,6 @@ func TestNewImageDownloader(t *testing.T) {
 		t.Errorf("savePath = %q, expected %q", downloader.savePath, testPath)
 	}
 
-	// 验证目录是否创建
 	if _, err := os.Stat(testPath); os.IsNotExist(err) {
 		t.Errorf("save path directory was not created: %s", testPath)
 	}
@@ -86,17 +85,14 @@ func TestImageDownloader_generateFileName(t *testing.T) {
 
 	fileName1 := downloader.generateFileName(url, extension)
 
-	// 文件名应该包含扩展名
 	if filepath.Ext(fileName1) != "."+extension {
 		t.Errorf("fileName should end with .%s, got %s", extension, fileName1)
 	}
 
-	// 文件名应该包含img_前缀
 	if !strings.HasPrefix(filepath.Base(fileName1), "img_") {
 		t.Errorf("fileName should start with img_, got %s", fileName1)
 	}
 
-	// 不同URL应该生成不同的文件名
 	url2 := "https://example.com/different.jpg"
 	fileName2 := downloader.generateFileName(url2, extension)
 	if fileName1 == fileName2 {

--- a/xiaohongshu/feeds_test.go
+++ b/xiaohongshu/feeds_test.go
@@ -21,7 +21,6 @@ func TestGetFeedsList(t *testing.T) {
 	page := b.NewPage()
 	defer page.Close()
 
-	// NewFeedsListAction 内部已经处理导航
 	action := NewFeedsListAction(page)
 
 	feeds, err := action.GetFeedsList(context.Background())
@@ -30,9 +29,7 @@ func TestGetFeedsList(t *testing.T) {
 
 	fmt.Printf("成功获取到 %d 个 Feed\n", len(feeds))
 
-	// 验证 JSON 结构完整性
 	for i, feed := range feeds {
-		// 验证必填字段
 		require.NotEmpty(t, feed.ID, "Feed ID should not be empty")
 		require.NotEmpty(t, feed.ModelType, "ModelType should not be empty")
 		require.NotEmpty(t, feed.XsecToken, "XsecToken should not be empty")
@@ -41,7 +38,6 @@ func TestGetFeedsList(t *testing.T) {
 		require.NotEmpty(t, feed.NoteCard.User.UserID, "User ID should not be empty")
 		require.NotEmpty(t, feed.NoteCard.User.Nickname, "User nickname should not be empty")
 
-		// 如果是视频类型，检查视频信息
 		if feed.NoteCard.Type == "video" {
 			require.NotNil(t, feed.NoteCard.Video, "Video info should not be nil for video type")
 			if feed.NoteCard.Video != nil {
@@ -51,24 +47,20 @@ func TestGetFeedsList(t *testing.T) {
 
 		// 只对第一个 Feed 进行完整 JSON 序列化检查
 		if i == 0 {
-			// 序列化为 JSON
 			jsonData, err := json.MarshalIndent(feed, "", "  ")
 			require.NoError(t, err, "Failed to marshal feed")
 
 			fmt.Printf("\n第一个 Feed 的完整 JSON 结构:\n%s\n", string(jsonData))
 
-			// 反序列化检查
 			var checkFeed Feed
 			err = json.Unmarshal(jsonData, &checkFeed)
 			require.NoError(t, err, "Failed to unmarshal feed")
 
-			// 比较序列化前后是否一致
 			require.Equal(t, feed.ID, checkFeed.ID)
 			require.Equal(t, feed.ModelType, checkFeed.ModelType)
 			require.Equal(t, feed.NoteCard.Type, checkFeed.NoteCard.Type)
 		}
 
-		// 打印前3个 Feed 的信息
 		if i < 3 {
 			fmt.Printf("\nFeed %d 基本信息:\n", i+1)
 			fmt.Printf("  ID: %s\n", feed.ID)


### PR DESCRIPTION
延续 #765 #766，把同样的标准套到测试代码。

删掉：
- 复述断言的注释（`// 验证目录是否创建`、`// 文件名应该包含扩展名`、`// 序列化为 JSON` 这种，下一行就是对应的断言）
- 描述第三方库默认行为、把测试意图讲穿的段落

保留：预期值怎么算出来的（如 `norm=0 → exp(0)=1s`）、测试环境为什么这么搭（hermetic 的做法、为什么比语义不比字节）。

断言本身一个没动，无逻辑变更。`go vet ./...`、`go vet -tags integration ./...`、`go test ./...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)