### PR TITLE
chore(test): 删掉无效与冗余的测试

### DIFF
--- a/configs/browser_test.go
+++ b/configs/browser_test.go
@@ -38,15 +38,3 @@ func TestProxyFromEnv(t *testing.T) {
 		assert.Equal(t, "socks5://127.0.0.1:1080", ProxyFromEnv())
 	})
 }
-
-// TestSetGet 校验 seed/proxy 的存取；用后恢复全局状态避免污染其他测试。
-func TestSetGet(t *testing.T) {
-	origSeed, origProxy := FingerprintSeed(), Proxy()
-	t.Cleanup(func() { SetFingerprintSeed(origSeed); SetProxy(origProxy) })
-
-	SetFingerprintSeed(12345)
-	assert.Equal(t, 12345, FingerprintSeed())
-
-	SetProxy("http://proxy:3128")
-	assert.Equal(t, "http://proxy:3128", Proxy())
-}

--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -122,18 +122,6 @@ func TestJitterInQuad_StaysInside(t *testing.T) {
 	}
 }
 
-// TestJitterInQuad_Scatters 同一元素多次抖动应产生不同落点。
-func TestJitterInQuad_Scatters(t *testing.T) {
-	q := proto.DOMQuad{0, 0, 200, 0, 200, 60, 0, 60}
-	center := proto.Point{X: 100, Y: 30}
-
-	seen := map[proto.Point]struct{}{}
-	for i := 0; i < 50; i++ {
-		seen[jitterInQuad(center, q)] = struct{}{}
-	}
-	assert.Greater(t, len(seen), 40, "50 次抖动应产生大量不同落点，实际只有 %d 个", len(seen))
-}
-
 // TestDelay_UnknownActionFallback 未知动作应回退而非 panic 或零等待。
 func TestDelay_UnknownActionFallback(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/humanize/input_integration_test.go
+++ b/humanize/input_integration_test.go
@@ -127,9 +127,8 @@ type clickRecord struct {
 	Y  float64 `json:"y"`
 }
 
-// TestClickPressAndScatter 校验 Click 的两条约定：按下与抬起之间有停留，
-// 且同一元素多次点击的落点不固定。
-func TestClickPressAndScatter(t *testing.T) {
+// TestClickTiming 校验 Click 的按下时长与落点分布符合约定。
+func TestClickTiming(t *testing.T) {
 	bin, err := browser.EnsureBrowser()
 	if err != nil {
 		t.Skipf("SKIP: 浏览器不可用: %v", err)

--- a/pkg/downloader/images_test.go
+++ b/pkg/downloader/images_test.go
@@ -100,9 +100,8 @@ func TestImageDownloader_generateFileName(t *testing.T) {
 	}
 }
 
-// TestDownloadImage_AntiHotlink 测试下载防盗链图片
-// 验证添加 User-Agent 和 Referer 解决 403 问题
-func TestDownloadImage_AntiHotlink(t *testing.T) {
+// TestDownloadImage_SendsUAAndReferer 下载请求应带上 User-Agent 和 Referer。
+func TestDownloadImage_SendsUAAndReferer(t *testing.T) {
 	// 1x1 透明 PNG，避免依赖外部网络资源导致测试不稳定
 	const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7+2X8AAAAASUVORK5CYII="
 	pngData, err := base64.StdEncoding.DecodeString(pngBase64)
@@ -132,32 +131,6 @@ func TestDownloadImage_AntiHotlink(t *testing.T) {
 	downloader := NewImageDownloader(tempDir)
 
 	filePath, err := downloader.DownloadImage(server.URL + "/image.png")
-	if err != nil {
-		t.Fatalf("下载失败: %v", err)
-	}
-
-	info, err := os.Stat(filePath)
-	if err != nil {
-		t.Fatalf("文件不存在: %v", err)
-	}
-	if info.Size() == 0 {
-		t.Fatalf("下载文件为空")
-	}
-}
-
-// TestDownloadImage_AntiHotlink_External 集成测试：真实外网防盗链场景
-// 默认跳过，设置 XHS_RUN_NETWORK_TESTS=1 后执行。
-func TestDownloadImage_AntiHotlink_External(t *testing.T) {
-	if os.Getenv("XHS_RUN_NETWORK_TESTS") != "1" {
-		t.Skip("skip external network test; set XHS_RUN_NETWORK_TESTS=1 to enable")
-	}
-
-	testURL := "https://img1.mydrivers.com/img/20260213/s_fdac2d21214147019e629fa7f2c8802e.png"
-
-	tempDir := t.TempDir()
-	downloader := NewImageDownloader(tempDir)
-
-	filePath, err := downloader.DownloadImage(testURL)
 	if err != nil {
 		t.Fatalf("下载失败: %v", err)
 	}

--- a/xiaohongshu/feeds_test.go
+++ b/xiaohongshu/feeds_test.go
@@ -6,7 +6,6 @@ package xiaohongshu
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -46,21 +45,6 @@ func TestGetFeedsList(t *testing.T) {
 		}
 
 		// 只对第一个 Feed 进行完整 JSON 序列化检查
-		if i == 0 {
-			jsonData, err := json.MarshalIndent(feed, "", "  ")
-			require.NoError(t, err, "Failed to marshal feed")
-
-			fmt.Printf("\n第一个 Feed 的完整 JSON 结构:\n%s\n", string(jsonData))
-
-			var checkFeed Feed
-			err = json.Unmarshal(jsonData, &checkFeed)
-			require.NoError(t, err, "Failed to unmarshal feed")
-
-			require.Equal(t, feed.ID, checkFeed.ID)
-			require.Equal(t, feed.ModelType, checkFeed.ModelType)
-			require.Equal(t, feed.NoteCard.Type, checkFeed.NoteCard.Type)
-		}
-
 		if i < 3 {
 			fmt.Printf("\nFeed %d 基本信息:\n", i+1)
 			fmt.Printf("  ID: %s\n", feed.ID)


### PR DESCRIPTION
接着 #767，这次清的是测试代码本身。

删掉 4 项：

| 测试 | 理由 |
|---|---|
| `TestJitterInQuad_Scatters` | 断言随机数是随机的；幅度约束已被 `_StaysInside` 和 `TestJitterOffset_Bounds` 覆盖，不多挡任何回归，还有概率性 flaky |
| `TestDownloadImage_AntiHotlink_External` | URL 硬编码到第三方站（随时失效）、默认 `t.Skip` ⇒ 几乎从不执行；同逻辑已有 httptest 版覆盖 |
| `feeds_test` 的 JSON 往返段 | `marshal → unmarshal → 比字段`，测的是 `encoding/json`；那几个字段循环里已经断言过 |
| `configs.TestSetGet` | set 完能 get 到，编译器保证 |

另把两个测试改成中性命名，断言逻辑未动。

保留了 `TestCubicBezier_Endpoints`、`TestEaseInOut`、`TestJitterOffset_Bounds` 等——函数虽小，但插值和边界改坏是静默的，测试是廉价保险。

净减 70 行。`go vet ./...`、`go vet -tags integration ./...`、`go test ./...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)