### PR TITLE
fix(comment): 评论区较短时也展开楼中楼

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -237,40 +237,53 @@ func (cl *commentLoader) checkNoComments() bool {
 }
 
 func (cl *commentLoader) checkComplete(ctx context.Context) bool {
-	if checkEndContainer(cl.page) {
-		currentCount := getCommentCount(cl.page)
-		logrus.Infof("✓ 检测到 'THE END' 元素，已滑动到底部")
-		humanize.Delay(ctx, humanize.BetweenScroll)
-		logrus.Infof("✓ 加载完成: %d 条评论, 尝试次数: %d, 点击: %d, 跳过: %d",
-			currentCount, cl.stats.attempts+1, cl.stats.totalClicked, cl.stats.totalSkipped)
-		return true
+	if !checkEndContainer(cl.page) {
+		return false
 	}
-	return false
+
+	// 到底之后再展开一轮：评论区不用怎么滚就能到底时，循环第一轮就走到这里，
+	// 主流程里的展开步骤根本没机会执行。点开了就先不算加载完，让下一轮重新判断
+	// （展开会露出新的按钮）；一个都没点开就收工，避免被阈值跳过的按钮卡住。
+	if cl.config.ClickMoreReplies && cl.clickButtonsWithRetry(ctx) > 0 {
+		return false
+	}
+
+	currentCount := getCommentCount(cl.page)
+	logrus.Infof("✓ 检测到 'THE END' 元素，已滑动到底部")
+	humanize.Delay(ctx, humanize.BetweenScroll)
+	logrus.Infof("✓ 加载完成: %d 条评论, 尝试次数: %d, 点击: %d, 跳过: %d",
+		currentCount, cl.stats.attempts+1, cl.stats.totalClicked, cl.stats.totalSkipped)
+	return true
 }
 
 func (cl *commentLoader) shouldClickButtons() bool {
 	return cl.config.ClickMoreReplies && cl.stats.attempts%buttonClickInterval == 0
 }
 
-func (cl *commentLoader) clickButtonsWithRetry(ctx context.Context) {
+// clickButtonsWithRetry 展开当前页上的回复按钮，返回本次点开的个数。
+func (cl *commentLoader) clickButtonsWithRetry(ctx context.Context) int {
 	clicked, skipped := clickShowMoreButtonsSmart(ctx, cl.page, cl.config.MaxRepliesThreshold)
-	if clicked > 0 || skipped > 0 {
-		cl.stats.totalClicked += clicked
-		cl.stats.totalSkipped += skipped
-		logrus.Infof("点击'更多': %d 个, 跳过: %d 个, 累计点击: %d, 累计跳过: %d",
-			clicked, skipped, cl.stats.totalClicked, cl.stats.totalSkipped)
-
-		humanize.Delay(ctx, humanize.Reading)
-
-		// 重试一轮
-		clicked2, skipped2 := clickShowMoreButtonsSmart(ctx, cl.page, cl.config.MaxRepliesThreshold)
-		if clicked2 > 0 || skipped2 > 0 {
-			cl.stats.totalClicked += clicked2
-			cl.stats.totalSkipped += skipped2
-			logrus.Infof("第 2 轮: 点击 %d, 跳过 %d", clicked2, skipped2)
-			humanize.Delay(ctx, humanize.Reading)
-		}
+	if clicked == 0 && skipped == 0 {
+		return 0
 	}
+
+	cl.stats.totalClicked += clicked
+	cl.stats.totalSkipped += skipped
+	logrus.Infof("点击'更多': %d 个, 跳过: %d 个, 累计点击: %d, 累计跳过: %d",
+		clicked, skipped, cl.stats.totalClicked, cl.stats.totalSkipped)
+
+	humanize.Delay(ctx, humanize.Reading)
+
+	// 重试一轮
+	clicked2, skipped2 := clickShowMoreButtonsSmart(ctx, cl.page, cl.config.MaxRepliesThreshold)
+	if clicked2 > 0 || skipped2 > 0 {
+		cl.stats.totalClicked += clicked2
+		cl.stats.totalSkipped += skipped2
+		logrus.Infof("第 2 轮: 点击 %d, 跳过 %d", clicked2, skipped2)
+		humanize.Delay(ctx, humanize.Reading)
+	}
+
+	return clicked + clicked2
 }
 
 func (cl *commentLoader) updateState(currentCount int) {


### PR DESCRIPTION
修复 #769。

## 根因

`commentLoader.load` 的循环里，判定加载完成排在展开按钮之前：

```go
if cl.checkComplete(ctx) { return nil }   // end-container 已在 DOM → 直接返回
if cl.shouldClickButtons() { ... }        // 到不了这里
```

评论区不用怎么滚就能到底的笔记，`end-container` 第一轮就存在，于是直接返回，展开一次都没执行。调用方传了 `click_more_replies` 却拿到缺二级评论的结果，而且没有任何提示说明数据不完整。

## 改动

到底后先展开一轮再判定：点开了就不算加载完，让下一轮重新判断（展开会露出新的按钮）；一个都没点开才收工——这样被回复数阈值跳过的按钮不会把循环卡死。

## 走查

| 场景 | 结果 |
|---|---|
| 短笔记（原问题） | 二级评论从 4 条变 8 条，正好补上两个楼层里折叠的部分 |
| 阈值跳过全部按钮 | 跳过 2、点开 0，第一轮正常收工，不卡住 |
| 需要滚动的笔记 | 一级评论数与修复前一致；该次走的是「已达目标评论数」退出，未进入本次改动的分支 |

`go build` / `go vet` / `go test ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)