### PR TITLE
fix(login): 取二维码不再堆积浏览器实例

### DIFF
--- a/login_session.go
+++ b/login_session.go
@@ -1,0 +1,42 @@
+package main
+
+import "sync"
+
+// loginSessions 管理「已发出二维码、还在等扫码」的登录会话。
+//
+// 取一次二维码就要留一个浏览器活着等扫码，否则检测不到登录、也存不了 cookie。
+// 但没有任何东西拦着重复调用，于是每调一次就多一个浏览器活到超时为止。
+// 这里的约束是：同一时刻只保留一个待扫码会话，开新的就把旧的关掉。
+type loginSessions struct {
+	mu     sync.Mutex
+	seq    uint64
+	cancel func()
+}
+
+// start 结束上一个待扫码会话（如果有），登记新的，返回本次会话的序号。
+// 序号用于 finish 判断自己是不是仍然是当前会话。
+func (l *loginSessions) start(cancel func()) uint64 {
+	l.mu.Lock()
+	prev := l.cancel
+	l.seq++
+	seq := l.seq
+	l.cancel = cancel
+	l.mu.Unlock()
+
+	// 放到锁外调用：取消动作会触发对方 goroutine 的收尾，避免相互等待
+	if prev != nil {
+		prev()
+	}
+	return seq
+}
+
+// finish 会话自己结束时清理登记。仅当它仍是当前会话才清，
+// 否则会把后来者的登记抹掉，导致后来者永远不会被 start 关闭。
+func (l *loginSessions) finish(seq uint64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.seq == seq {
+		l.cancel = nil
+	}
+}

--- a/login_session_test.go
+++ b/login_session_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLoginSessions 固定「同一时刻只保留一个待扫码会话」这条约束。
+//
+// 这是浏览器不再堆积的依据：每个待扫码会话都占着一个浏览器活到超时为止，
+// 只要新会话没能关掉旧的，进程就会累积。
+func TestLoginSessions(t *testing.T) {
+	t.Run("开新会话会关掉上一个", func(t *testing.T) {
+		var l loginSessions
+		closed := 0
+
+		l.start(func() { closed++ })
+		assert.Equal(t, 0, closed, "第一个会话不该被关")
+
+		l.start(func() {})
+		assert.Equal(t, 1, closed, "开第二个时应关掉第一个")
+	})
+
+	t.Run("第一个会话无需关闭任何东西", func(t *testing.T) {
+		var l loginSessions
+		assert.NotPanics(t, func() { l.start(func() {}) })
+	})
+
+	t.Run("会话结束后不会再被关第二次", func(t *testing.T) {
+		var l loginSessions
+		closed := 0
+
+		seq := l.start(func() { closed++ })
+		l.finish(seq)
+
+		l.start(func() {})
+		assert.Equal(t, 0, closed, "已结束的会话不该再被关闭")
+	})
+
+	t.Run("旧会话的收尾不会顶掉新会话", func(t *testing.T) {
+		var l loginSessions
+		newClosed := 0
+
+		oldSeq := l.start(func() {})
+		l.start(func() { newClosed++ }) // 新会话上位
+
+		// 旧会话此时才走完收尾，它必须认出自己已不是当前会话
+		l.finish(oldSeq)
+
+		// 再开一个：如果上一步误清了登记，新会话就永远关不掉了
+		l.start(func() {})
+		assert.Equal(t, 1, newClosed, "新会话仍应被后来者关闭")
+	})
+
+	t.Run("并发开会话时每个序号唯一", func(t *testing.T) {
+		var l loginSessions
+		const n = 50
+
+		var mu sync.Mutex
+		seen := make(map[uint64]bool, n)
+
+		var wg sync.WaitGroup
+		for range n {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				seq := l.start(func() {})
+				mu.Lock()
+				seen[seq] = true
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		assert.Len(t, seen, n, "序号必须唯一，否则 finish 会误清别人的登记")
+	})
+}

--- a/service.go
+++ b/service.go
@@ -19,7 +19,9 @@ import (
 )
 
 // XiaohongshuService 小红书业务服务
-type XiaohongshuService struct{}
+type XiaohongshuService struct {
+	logins loginSessions
+}
 
 // NewXiaohongshuService 创建小红书服务实例
 func NewXiaohongshuService() *XiaohongshuService {
@@ -156,17 +158,7 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 	timeout := 4 * time.Minute
 
 	if !loggedIn {
-		go func() {
-			ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			defer deferFunc()
-
-			if loginAction.WaitForLogin(ctxTimeout) {
-				if er := saveCookies(page); er != nil {
-					logrus.Errorf("failed to save cookies: %v", er)
-				}
-			}
-		}()
+		s.waitScanInBackground(loginAction, page, deferFunc, timeout)
 	}
 
 	return &LoginQrcodeResponse{
@@ -179,6 +171,36 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 		Img:        img,
 		IsLoggedIn: loggedIn,
 	}, nil
+}
+
+// waitScanInBackground 在后台等用户扫码，扫上了就存 cookie。
+//
+// 浏览器必须一直活着才检测得到扫码，所以这里不能提前关；但也不能任由它堆积——
+// 再取一次二维码就会把上一个还在等的会话关掉，同一时刻只留一个。
+func (s *XiaohongshuService) waitScanInBackground(
+	loginAction *xiaohongshu.LoginAction, page *rod.Page, closeBrowser func(), timeout time.Duration,
+) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout)
+	seq := s.logins.start(cancel)
+	logrus.Infof("等待扫码登录，会话 #%d，超时 %s", seq, timeout)
+
+	go func() {
+		defer closeBrowser()
+		defer cancel()
+		defer s.logins.finish(seq)
+
+		if loginAction.WaitForLogin(ctxTimeout) {
+			if err := saveCookies(page); err != nil {
+				logrus.Errorf("扫码成功但保存 cookies 失败，会话 #%d: %v", seq, err)
+				return
+			}
+			logrus.Infof("扫码登录成功，cookies 已保存，会话 #%d", seq)
+			return
+		}
+
+		// 没等到扫码：要么超时，要么被新取的二维码取代
+		logrus.Infof("登录会话 #%d 结束，未检测到扫码（超时或已被新的二维码取代）", seq)
+	}()
 }
 
 // PublishContent 发布内容


### PR DESCRIPTION
Closes #470

## 问题

`get_login_qrcode` 每调用一次就新建一个浏览器，并让它活到 4 分钟超时为止。

浏览器必须活着才检测得到扫码、才能存 cookie，**这部分是有意的**。问题是没有任何东西拦着重复调用——用户没扫码、或者反复点几次「获取二维码」，浏览器就一直堆。

实测连续调用三次（`main` 分支）：

| 调用次数 | 浏览器相关进程数 |
|---|---|
| 起始 | 0 |
| 第 1 次 | 8 |
| 第 2 次 | **16** |
| 第 3 次 | **24** |

线性累积，与 #470 的描述一致。

## 关于 #599

#599 报的是「二维码返回后浏览器立刻关闭，导致 cookie 存不下」。**这个根因不成立**——正常路径下浏览器会活 4 分钟等扫码。

但它描述的现象可能确实发生过：用户重复取二维码时，扫的可能是已经被取代的那一张，cookie 自然存不下，而过程中没有任何提示。本 PR 把会话的开始与结束都打进日志后，这种情况可以从日志直接看出来。因此 #599 不作为「已修复」关闭，留待报告人在新版本上复测。

## 改动

新增 `loginSessions`：同一时刻只保留一个待扫码会话，开新的就取消旧的。

一个实现细节值得说明：会话登记用**序号**而不是函数值。Go 的函数不可比较，会话收尾时无法用 `==` 判断自己是否仍是当前会话；若不加判断，旧会话的收尾会抹掉后来者的登记，后来者便再也关不掉——测试里专门覆盖了这一条。

## 验证

**真机走查**（本 PR 的主要依据）：同一场景下修复后稳定维持 8 个进程，不再累积。日志按预期输出：

```
等待扫码登录，会话 #1，超时 4m0s
等待扫码登录，会话 #2，超时 4m0s
登录会话 #1 结束，未检测到扫码（超时或已被新的二维码取代）
```

**单元测试** `TestLoginSessions`：覆盖 5 种情形——新会话关掉旧的、首个会话无需关闭、已结束的会话不被重复关闭、旧会话收尾不顶掉新会话、并发下序号唯一。不碰浏览器，`-race` 通过。

`go build` / `go vet` / `go test ./...` / `gofmt -l` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)