### PR TITLE
fix(interact): 交互写操作确认后补足停留，避免请求未完成

### DIFF
--- a/humanize/provider.go
+++ b/humanize/provider.go
@@ -25,6 +25,7 @@ const (
 	Reading       Action = "reading"        // 浏览内容时的驻留
 	Keystroke     Action = "keystroke"      // 逐字符输入的字间间隔
 	ClickHold     Action = "click_hold"     // 单次点击里按下到抬起的按压时长
+	AfterInteract Action = "after_interact" // 交互写操作点击后的停留
 )
 
 // LogNormal 描述一个右偏时延分布：ln(时延/秒) ~ Normal(Mu, Sigma)，采样后 clamp 到 [Min, Max]。
@@ -73,6 +74,7 @@ func (DefaultProvider) Timing() TimingProfile {
 		Reading:       {Mu: -0.36, Sigma: 0.40, Min: 300 * time.Millisecond, Max: 3 * time.Second},       // ~0.7s
 		Keystroke:     {Mu: -2.12, Sigma: 0.50, Min: 30 * time.Millisecond, Max: 400 * time.Millisecond}, // ~120ms/字
 		ClickHold:     {Mu: -2.47, Sigma: 0.33, Min: 45 * time.Millisecond, Max: 250 * time.Millisecond}, // ~85ms
+		AfterInteract: {Mu: 0.88, Sigma: 0.30, Min: 2 * time.Second, Max: 3 * time.Second},               // ~2.4s
 	}
 }
 

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -68,7 +68,7 @@ type stateOf func(liked, collected bool) bool
 
 // toggleInteract 点击交互按钮并轮询校验状态是否变为 want；最多两次点击。
 // 到达即成功；始终未变或无法读状态则返回 error——消除"点了没报错就算成功"的假阳性。
-func (a *interactAction) toggleInteract(page *rod.Page, feedID, selector string, want bool, actionType interactActionType, pick stateOf) error {
+func (a *interactAction) toggleInteract(ctx context.Context, page *rod.Page, feedID, selector string, want bool, actionType interactActionType, pick stateOf) error {
 	for attempt := 1; attempt <= 2; attempt++ {
 		if err := a.performClick(page, selector); err != nil {
 			return fmt.Errorf("%s点击失败: %w", actionType, err)
@@ -79,6 +79,7 @@ func (a *interactAction) toggleInteract(page *rod.Page, feedID, selector string,
 			return fmt.Errorf("%s后无法确认状态: %w", actionType, err)
 		}
 		if ok {
+			humanize.Delay(ctx, humanize.AfterInteract)
 			logrus.Infof("feed %s %s成功（第%d次点击）", feedID, actionType, attempt)
 			return nil
 		}
@@ -136,7 +137,7 @@ func (a *LikeAction) perform(ctx context.Context, feedID, xsecToken string, targ
 	liked, _, err := a.getInteractState(page, feedID)
 	if err != nil {
 		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
-		return a.toggleInteract(page, feedID, SelectorLikeButton, targetLiked, actionType,
+		return a.toggleInteract(ctx, page, feedID, SelectorLikeButton, targetLiked, actionType,
 			func(liked, collected bool) bool { return liked })
 	}
 
@@ -149,7 +150,7 @@ func (a *LikeAction) perform(ctx context.Context, feedID, xsecToken string, targ
 		return nil
 	}
 
-	return a.toggleInteract(page, feedID, SelectorLikeButton, targetLiked, actionType,
+	return a.toggleInteract(ctx, page, feedID, SelectorLikeButton, targetLiked, actionType,
 		func(liked, collected bool) bool { return liked })
 }
 
@@ -183,7 +184,7 @@ func (a *FavoriteAction) perform(ctx context.Context, feedID, xsecToken string, 
 	_, collected, err := a.getInteractState(page, feedID)
 	if err != nil {
 		logrus.Warnf("failed to read interact state: %v (continue to try clicking)", err)
-		return a.toggleInteract(page, feedID, SelectorCollectButton, targetCollected, actionType,
+		return a.toggleInteract(ctx, page, feedID, SelectorCollectButton, targetCollected, actionType,
 			func(liked, collected bool) bool { return collected })
 	}
 
@@ -196,7 +197,7 @@ func (a *FavoriteAction) perform(ctx context.Context, feedID, xsecToken string, 
 		return nil
 	}
 
-	return a.toggleInteract(page, feedID, SelectorCollectButton, targetCollected, actionType,
+	return a.toggleInteract(ctx, page, feedID, SelectorCollectButton, targetCollected, actionType,
 		func(liked, collected bool) bool { return collected })
 }
 


### PR DESCRIPTION
## 问题

点赞、收藏及其取消操作在确认完成后立即返回，调用方随即关闭页面与浏览器，
此时请求可能尚未完成，改动偶发不生效——接口返回成功但状态并未变更。

## 改动

- `humanize`：新增 `AfterInteract` 时延项
- `xiaohongshu/like_favorite.go`：`toggleInteract` 返回前补一段等待，并接收
  `ctx` 以支持取消

点赞与收藏共用 `toggleInteract`，同一处修复覆盖两者及各自的取消操作。

## 验证

已本地走查：收藏与取消收藏均正确生效，通过重新加载页面读取服务端状态独立
复核，不依赖接口自身的返回值。修复前复核不通过，修复后通过。