### PR TITLE
refactor(interact): 发布与导航的点击统一走交互原语

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ test_*.sh
 cookies.json
 docker/data/
 docker/images/
+docker/docker-compose.override.yml
 
 # 本地分析/调试产物，不进仓库
 debug/

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,7 +58,7 @@ docker build -t xpzouying/xiaohongshu-mcp .
 docker compose up -d
 
 # 查看日志
-docker logs -f xpzouying/xiaohongshu-mcp
+docker logs -f xiaohongshu-mcp
 
 # 或者
 docker compose logs -f
@@ -74,7 +74,7 @@ docker compose logs -f
 docker compose stop
 
 # 查看实时日志
-docker logs -f xpzouying/xiaohongshu-mcp
+docker logs -f xiaohongshu-mcp
 
 # 进入容器
 docker exec -it xiaohongshu-mcp bash

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/xpzouying/xiaohongshu-mcp/humanize"
 )
 
 type NavigateAction struct {
@@ -37,7 +38,10 @@ func (n *NavigateAction) ToProfilePage(ctx context.Context) error {
 
 	// Find and click the "我" channel link in sidebar
 	profileLink := page.MustElement(`div.main-container li.user.side-bar-component a.link-wrapper span.channel`)
-	profileLink.MustClick()
+	humanize.Delay(ctx, humanize.BeforeClick)
+	if err := humanize.Click(profileLink); err != nil {
+		return err
+	}
 
 	// Wait for navigation to complete
 	page.MustWaitLoad()

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -167,7 +167,7 @@ func mustClickPublishTab(page *rod.Page, tabname string) error {
 			continue
 		}
 
-		if err := tab.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		if err := humanize.Click(tab); err != nil {
 			logrus.Warnf("点击发布 TAB 失败: %v", err)
 			time.Sleep(200 * time.Millisecond)
 			continue
@@ -402,7 +402,7 @@ func clickPublishButton(page *rod.Page) error {
 		return clickPublishWidget(page, btn.elem)
 	}
 
-	if err := btn.elem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+	if err := humanize.Click(btn.elem); err != nil {
 		return errors.Wrap(err, "点击发布按钮失败")
 	}
 	return nil
@@ -548,7 +548,7 @@ func clickPublishWidget(page *rod.Page, widget *rod.Element) error {
 func waitAndClickTitleInput(titleElem *rod.Element) error {
 	slog.Info("正文填写完成，准备等待后回点标题输入框")
 	time.Sleep(1 * time.Second)
-	if err := titleElem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+	if err := humanize.Click(titleElem); err != nil {
 		return errors.Wrap(err, "回点标题输入框失败")
 	}
 	slog.Info("已回点标题输入框，继续后续发布流程")
@@ -831,7 +831,7 @@ func setVisibility(page *rod.Page, visibility string) error {
 	if err != nil {
 		return errors.Wrap(err, "查找可见范围下拉框失败")
 	}
-	if err := dropdown.Click(proto.InputMouseButtonLeft, 1); err != nil {
+	if err := humanize.Click(dropdown); err != nil {
 		return errors.Wrap(err, "点击可见范围下拉框失败")
 	}
 	time.Sleep(500 * time.Millisecond)
@@ -847,7 +847,7 @@ func setVisibility(page *rod.Page, visibility string) error {
 			continue
 		}
 		if strings.Contains(text, visibility) {
-			if err := opt.Click(proto.InputMouseButtonLeft, 1); err != nil {
+			if err := humanize.Click(opt); err != nil {
 				return errors.Wrap(err, "选择可见范围失败")
 			}
 			slog.Info("已设置可见范围", "visibility", visibility)
@@ -882,7 +882,7 @@ func clickScheduleSwitch(page *rod.Page) error {
 		return errors.Wrap(err, "查找定时发布开关失败")
 	}
 
-	if err := switchElem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+	if err := humanize.Click(switchElem); err != nil {
 		return errors.Wrap(err, "点击定时发布开关失败")
 	}
 	slog.Info("已点击定时发布开关")
@@ -955,7 +955,7 @@ func setOriginal(page *rod.Page) error {
 		}
 
 		// 点击开关
-		if err := switchElem.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		if err := humanize.Click(switchElem); err != nil {
 			return errors.Wrap(err, "点击原创声明开关失败")
 		}
 
@@ -1152,7 +1152,7 @@ func clickAddProductButton(page *rod.Page) error {
 
 				// 检查是否为 button 或含 d-button class
 				if tag == "button" {
-					if err := parent.Click(proto.InputMouseButtonLeft, 1); err != nil {
+					if err := humanize.Click(parent); err != nil {
 						return errors.Wrap(err, "点击添加商品按钮失败")
 					}
 					slog.Info("已点击添加商品按钮")
@@ -1162,7 +1162,7 @@ func clickAddProductButton(page *rod.Page) error {
 
 				cls, _ := parent.Attribute("class")
 				if cls != nil && strings.Contains(*cls, "d-button") {
-					if err := parent.Click(proto.InputMouseButtonLeft, 1); err != nil {
+					if err := humanize.Click(parent); err != nil {
 						return errors.Wrap(err, "点击添加商品按钮失败")
 					}
 					slog.Info("已点击添加商品按钮")
@@ -1265,7 +1265,7 @@ func searchAndSelectProduct(ctx context.Context, page *rod.Page, modal *rod.Elem
 		return nil
 	}
 
-	if err := checkbox.Click(proto.InputMouseButtonLeft, 1); err != nil {
+	if err := humanize.Click(checkbox); err != nil {
 		return errors.Wrap(err, "点击商品选择框失败")
 	}
 
@@ -1281,7 +1281,7 @@ func clickModalSaveButton(modal *rod.Element) error {
 	// 查找保存按钮（参考工作代码：直接查找并点击，不强制要求找到）
 	btn, err := modal.Element(".goods-selected-footer button")
 	if err == nil && btn != nil {
-		if err := btn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		if err := humanize.Click(btn); err != nil {
 			slog.Warn("点击保存按钮失败", "error", err)
 		} else {
 			slog.Info("已点击保存按钮")
@@ -1292,7 +1292,7 @@ func clickModalSaveButton(modal *rod.Element) error {
 	// 尝试点击主按钮
 	primaryBtn, err := modal.Element(".goods-selected-footer .d-button--primary")
 	if err == nil && primaryBtn != nil {
-		if err := primaryBtn.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		if err := humanize.Click(primaryBtn); err != nil {
 			slog.Warn("点击主按钮失败", "error", err)
 		} else {
 			slog.Info("已点击主按钮")


### PR DESCRIPTION
## 改动

`publish.go` 与 `navigate.go` 中部分点击未走项目统一的交互封装，与文件内
其余调用点写法不一致（该文件已有 5 处使用封装）。

- `publish.go`：12 处统一替换为 `humanize.Click`
- `navigate.go`：1 处统一替换为 `humanize.Click`

封装内部同样执行 `WaitInteractable` 与 `WaitEnabled`，调用语义一致。
`publish_video.go` 复用同一批共享函数，一并覆盖。

顺带：

- `.gitignore` 忽略 `docker/docker-compose.override.yml`，该文件用于本机覆盖
- `docker/README.md` 修正查看日志的命令，原文误用镜像名，`docker logs` 接收
  的是容器名

## 验证

已本地走查：完整发布一篇图文笔记，覆盖发布 Tab 切换、标题输入框、原创声明
开关、发布按钮，以及个人主页导航，全部正常。

可见范围、定时发布、商品绑定三条分支需特定参数才会触发，本次未覆盖。

`go build` / `go vet` / `go test ./...` 均通过。