### PR TITLE
chore(search): 搜索导航后补上与其他路径一致的停顿

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -108,6 +108,7 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	page.MustNavigate(searchURL)
 	page.MustWaitStable()
 	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	if len(pending) > 0 {
 		// 悬停在筛选按钮上展开面板


### PR DESCRIPTION
## 改动

搜索是唯一一条导航后没有调用 `humanize.Delay` 的路径。收藏、评论、笔记详情
等路径在导航后均有此调用，此处补齐，保持一致。

一行改动。

## 验证

已本地走查两条路径：

- 不带筛选：返回 20 条结果
- 带筛选（排序「最新」+ 类型「图文」）：返回 20 条，类型全部为图文，筛选生效

`go build` / `go vet` / `go test ./...` 均通过。