### PR TITLE
feat(notification): 支持通知的读取、回复与点赞

### DIFF
--- a/handlers_api.go
+++ b/handlers_api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
 	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
@@ -326,4 +327,81 @@ func (s *AppServer) myProfileHandler(c *gin.Context) {
 	}
 
 	respondSuccess(c, map[string]any{"data": result}, "获取我的主页成功")
+}
+
+// getUnreadCountHandler 获取通知未读数
+func (s *AppServer) getUnreadCountHandler(c *gin.Context) {
+	result, err := s.xiaohongshuService.GetUnreadCount(c.Request.Context())
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "GET_UNREAD_COUNT_FAILED",
+			"获取未读数失败", err.Error())
+		return
+	}
+
+	respondSuccess(c, map[string]any{"data": result}, "获取未读数成功")
+}
+
+// listNotificationsHandler 获取通知列表。两个参数都可选，因此 GET 走 query、POST 走 JSON。
+func (s *AppServer) listNotificationsHandler(c *gin.Context) {
+	var req ListNotificationsRequest
+
+	if c.Request.Method == http.MethodPost {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+				"请求参数错误", err.Error())
+			return
+		}
+	} else {
+		req.Tab = c.Query("tab")
+		if limit, err := strconv.Atoi(c.Query("limit")); err == nil {
+			req.Limit = limit
+		}
+	}
+
+	result, err := s.xiaohongshuService.ListNotifications(c.Request.Context(), req.Tab, req.Limit)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "LIST_NOTIFICATIONS_FAILED",
+			"获取通知列表失败", err.Error())
+		return
+	}
+
+	respondSuccess(c, map[string]any{"data": result}, "获取通知列表成功")
+}
+
+// replyNotificationHandler 回复通知里的评论
+func (s *AppServer) replyNotificationHandler(c *gin.Context) {
+	var req ReplyNotificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	result, err := s.xiaohongshuService.ReplyNotification(c.Request.Context(), req.CommentID, req.Content)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "REPLY_NOTIFICATION_FAILED",
+			"回复通知失败", err.Error())
+		return
+	}
+
+	respondSuccess(c, map[string]any{"data": result}, "回复成功")
+}
+
+// likeNotificationHandler 给通知里的评论点赞/取消点赞
+func (s *AppServer) likeNotificationHandler(c *gin.Context) {
+	var req LikeNotificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "INVALID_REQUEST",
+			"请求参数错误", err.Error())
+		return
+	}
+
+	result, err := s.xiaohongshuService.LikeNotification(c.Request.Context(), req.CommentID, req.Unlike)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "LIKE_NOTIFICATION_FAILED",
+			"点赞失败", err.Error())
+		return
+	}
+
+	respondSuccess(c, map[string]any{"data": result}, "操作成功")
 }

--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -34,7 +34,7 @@ func TestLogNormal_noMax(t *testing.T) {
 func TestDefaultProvider_Timing(t *testing.T) {
 	tp := DefaultProvider{}.Timing()
 
-	for _, action := range []Action{AfterClick, AfterType, AfterNavigate, BetweenScroll, BeforeSubmit, BeforeClick, Reading, Keystroke, ClickHold} {
+	for _, action := range []Action{AfterClick, AfterType, AfterNavigate, BetweenScroll, BeforeSubmit, BeforeClick, Reading, Keystroke, ClickHold, AfterInteract, PointerSettle} {
 		dist, ok := tp[action]
 		assert.True(t, ok, "缺少动作 %s 的时延分布", action)
 		assert.Greater(t, dist.Max, dist.Min, "%s: Max 应大于 Min", action)
@@ -114,4 +114,16 @@ func TestDelay_UnknownActionFallback(t *testing.T) {
 	assert.NotPanics(t, func() {
 		Delay(ctx, Action("nonexistent"))
 	})
+}
+
+// TestPointerSettle_HasSufficientFloor 钉住 PointerSettle 的下限。
+func TestPointerSettle_HasSufficientFloor(t *testing.T) {
+	dist := DefaultProvider{}.Timing()[PointerSettle]
+
+	assert.GreaterOrEqual(t, dist.Min, 200*time.Millisecond,
+		"PointerSettle 的下限不应低于 200ms")
+
+	// Min 是 clamp 下限，等价于最坏情况的采样
+	assert.GreaterOrEqual(t, dist.sample(-5), 200*time.Millisecond,
+		"极端偏小的采样也应被 clamp 到 200ms 以上")
 }

--- a/humanize/humanize_test.go
+++ b/humanize/humanize_test.go
@@ -116,14 +116,12 @@ func TestDelay_UnknownActionFallback(t *testing.T) {
 	})
 }
 
-// TestPointerSettle_HasSufficientFloor 钉住 PointerSettle 的下限。
 func TestPointerSettle_HasSufficientFloor(t *testing.T) {
 	dist := DefaultProvider{}.Timing()[PointerSettle]
 
 	assert.GreaterOrEqual(t, dist.Min, 200*time.Millisecond,
 		"PointerSettle 的下限不应低于 200ms")
 
-	// Min 是 clamp 下限，等价于最坏情况的采样
 	assert.GreaterOrEqual(t, dist.sample(-5), 200*time.Millisecond,
 		"极端偏小的采样也应被 clamp 到 200ms 以上")
 }

--- a/humanize/input.go
+++ b/humanize/input.go
@@ -92,6 +92,8 @@ func Click(elem *rod.Element) error {
 		return err
 	}
 
+	Delay(elem.Page().GetContext(), PointerSettle)
+
 	if err := elem.WaitEnabled(); err != nil {
 		return err
 	}

--- a/humanize/provider.go
+++ b/humanize/provider.go
@@ -19,6 +19,7 @@ const (
 	Keystroke     Action = "keystroke"
 	ClickHold     Action = "click_hold"
 	AfterInteract Action = "after_interact"
+	PointerSettle Action = "pointer_settle"
 )
 
 type LogNormal struct {
@@ -63,6 +64,7 @@ func (DefaultProvider) Timing() TimingProfile {
 		Keystroke:     {Mu: -2.12, Sigma: 0.50, Min: 30 * time.Millisecond, Max: 400 * time.Millisecond},
 		ClickHold:     {Mu: -2.47, Sigma: 0.33, Min: 45 * time.Millisecond, Max: 250 * time.Millisecond},
 		AfterInteract: {Mu: 0.88, Sigma: 0.30, Min: 2 * time.Second, Max: 3 * time.Second},
+		PointerSettle: {Mu: -1.20, Sigma: 0.35, Min: 200 * time.Millisecond, Max: 1200 * time.Millisecond},
 	}
 }
 

--- a/mcp_handlers.go
+++ b/mcp_handlers.go
@@ -754,3 +754,81 @@ func (s *AppServer) handleGetMyProfile(ctx context.Context) *MCPToolResult {
 		}},
 	}
 }
+
+// handleGetUnreadCount 获取通知未读数
+func (s *AppServer) handleGetUnreadCount(ctx context.Context) *MCPToolResult {
+	logrus.Info("MCP: 获取通知未读数")
+
+	result, err := s.xiaohongshuService.GetUnreadCount(ctx)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取未读数失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	return marshalMCPResult(result, "获取未读数")
+}
+
+// handleListNotifications 获取通知列表
+func (s *AppServer) handleListNotifications(ctx context.Context, tab string, limit int) *MCPToolResult {
+	logrus.Infof("MCP: 获取通知列表 tab=%s limit=%d", tab, limit)
+
+	result, err := s.xiaohongshuService.ListNotifications(ctx, tab, limit)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "获取通知列表失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	return marshalMCPResult(result, "获取通知列表")
+}
+
+// handleReplyNotification 回复通知里的评论
+func (s *AppServer) handleReplyNotification(ctx context.Context, commentID, content string) *MCPToolResult {
+	logrus.Infof("MCP: 回复通知评论 comment=%s", commentID)
+
+	result, err := s.xiaohongshuService.ReplyNotification(ctx, commentID, content)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "回复失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	return marshalMCPResult(result, "回复")
+}
+
+// marshalMCPResult 把结果序列化成 MCP 文本内容。
+func marshalMCPResult(result any, action string) *MCPToolResult {
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{
+				Type: "text",
+				Text: fmt.Sprintf("%s成功，但序列化失败: %v", action, err),
+			}},
+			IsError: true,
+		}
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContent{{Type: "text", Text: string(jsonData)}},
+	}
+}
+
+// handleLikeNotification 给通知里的评论点赞/取消点赞
+func (s *AppServer) handleLikeNotification(ctx context.Context, commentID string, unlike bool) *MCPToolResult {
+	logrus.Infof("MCP: 通知点赞 comment=%s unlike=%v", commentID, unlike)
+
+	result, err := s.xiaohongshuService.LikeNotification(ctx, commentID, unlike)
+	if err != nil {
+		return &MCPToolResult{
+			Content: []MCPContent{{Type: "text", Text: "点赞失败: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	return marshalMCPResult(result, "点赞")
+}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -100,6 +100,24 @@ type FavoriteFeedArgs struct {
 	Unfavorite bool   `json:"unfavorite,omitempty" jsonschema:"是否取消收藏，true为取消收藏，false或未设置则为收藏"`
 }
 
+// ListNotificationsArgs 通知列表参数
+type ListNotificationsArgs struct {
+	Tab   string `json:"tab,omitempty" jsonschema:"通知分区: mentions(评论和@,默认)|likes(赞和收藏)|connections(新增关注)"`
+	Limit int    `json:"limit,omitempty" jsonschema:"返回条数上限，默认20"`
+}
+
+// LikeNotificationArgs 通知点赞参数
+type LikeNotificationArgs struct {
+	CommentID string `json:"comment_id" jsonschema:"目标评论ID，从 list_notifications 的 comment_id 字段获取"`
+	Unlike    bool   `json:"unlike,omitempty" jsonschema:"是否取消点赞，true为取消点赞，false或未设置则为点赞"`
+}
+
+// ReplyNotificationArgs 通知回复参数
+type ReplyNotificationArgs struct {
+	CommentID string `json:"comment_id" jsonschema:"目标评论ID，从 list_notifications 的 comment_id 字段获取"`
+	Content   string `json:"content" jsonschema:"回复内容"`
+}
+
 // InitMCPServer 初始化 MCP Server
 func InitMCPServer(appServer *AppServer) *mcp.Server {
 	// 创建 MCP Server
@@ -459,7 +477,71 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 		}),
 	)
 
-	logrus.Infof("Registered %d MCP tools", 14)
+	// 工具 15: 通知未读数
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "get_unread_count",
+			Description: "获取通知未读数，返回「评论和@」「赞和收藏」「新增关注」三个分区各自的未读条数。不会清除未读标记。查看具体内容用 list_notifications。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Unread Count",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("get_unread_count", func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleGetUnreadCount(ctx)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 16: 通知列表
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "list_notifications",
+			Description: "获取通知列表。返回评论内容、评论者、以及对应笔记的 feed_id 和 xsec_token（可用于 get_feed_detail 读原帖）。已删除或不可见的条目会被过滤，过滤数量见 filtered 字段。注意：会清除该分区的未读标记，只需要未读数时用 get_unread_count。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Notifications",
+				ReadOnlyHint: true,
+			},
+		},
+		withPanicRecovery("list_notifications", func(ctx context.Context, req *mcp.CallToolRequest, args ListNotificationsArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleListNotifications(ctx, args.Tab, args.Limit)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 17: 回复通知里的评论
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "reply_notification",
+			Description: "回复「评论和@」里的一条评论。comment_id 从 list_notifications 获取。适合处理收到的评论，无需先定位笔记。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Reply Notification",
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		withPanicRecovery("reply_notification", func(ctx context.Context, req *mcp.CallToolRequest, args ReplyNotificationArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleReplyNotification(ctx, args.CommentID, args.Content)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	// 工具 18: 给通知里的评论点赞
+	mcp.AddTool(server,
+		&mcp.Tool{
+			Name:        "like_notification",
+			Description: "给「评论和@」里的一条评论点赞或取消点赞。comment_id 从 list_notifications 获取（其 liked 字段是当前状态）。已是目标状态时跳过。",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Like Notification",
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		withPanicRecovery("like_notification", func(ctx context.Context, req *mcp.CallToolRequest, args LikeNotificationArgs) (*mcp.CallToolResult, any, error) {
+			result := appServer.handleLikeNotification(ctx, args.CommentID, args.Unlike)
+			return convertToMCPResult(result), nil, nil
+		}),
+	)
+
+	logrus.Infof("Registered %d MCP tools", 18)
 }
 
 // convertToMCPResult 将自定义的 MCPToolResult 转换为官方 SDK 的格式

--- a/routes.go
+++ b/routes.go
@@ -57,6 +57,11 @@ func setupRoutes(appServer *AppServer) *gin.Engine {
 		api.POST("/feeds/like", appServer.likeFeedHandler)
 		api.POST("/feeds/favorite", appServer.favoriteFeedHandler)
 		api.GET("/user/me", appServer.myProfileHandler)
+		api.GET("/notifications/unread", appServer.getUnreadCountHandler)
+		api.GET("/notifications/list", appServer.listNotificationsHandler)
+		api.POST("/notifications/list", appServer.listNotificationsHandler)
+		api.POST("/notifications/reply", appServer.replyNotificationHandler)
+		api.POST("/notifications/like", appServer.likeNotificationHandler)
 	}
 
 	return router

--- a/routes_test.go
+++ b/routes_test.go
@@ -52,3 +52,65 @@ func TestMCPStatelessSinglePost(t *testing.T) {
 	require.Nil(t, result.Error, "无握手的 tools/list 不应报错")
 	assert.NotEmpty(t, result.Result.Tools, "应返回已注册的工具")
 }
+
+// TestNotificationToolsRegistered 固定通知相关工具已注册到 MCP。
+//
+// 三个工具的注册各是 registerTools 里一段独立代码，漏掉任何一个编译都不会报错，
+// 只有真正调用时才会发现工具不存在。
+func TestNotificationToolsRegistered(t *testing.T) {
+	router := setupRoutes(NewAppServer(NewXiaohongshuService()))
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var result struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+
+	names := make(map[string]bool, len(result.Result.Tools))
+	for _, tool := range result.Result.Tools {
+		names[tool.Name] = true
+	}
+
+	for _, want := range []string{"get_unread_count", "list_notifications", "reply_notification", "like_notification"} {
+		assert.True(t, names[want], "工具 %s 应已注册", want)
+	}
+}
+
+// TestNotificationRoutesRegistered 固定通知的 HTTP 路由存在。
+//
+// 读路由表而不是发请求：这些 handler 会真的起浏览器访问小红书，
+// 单测里不能碰。
+func TestNotificationRoutesRegistered(t *testing.T) {
+	router := setupRoutes(NewAppServer(NewXiaohongshuService()))
+
+	registered := make(map[string]bool)
+	for _, r := range router.Routes() {
+		registered[r.Method+" "+r.Path] = true
+	}
+
+	// 列表接口两个参数都可选，GET 也要能进
+	for _, want := range []string{
+		"GET /api/v1/notifications/unread",
+		"GET /api/v1/notifications/list",
+		"POST /api/v1/notifications/list",
+		"POST /api/v1/notifications/reply",
+		"POST /api/v1/notifications/like",
+	} {
+		assert.True(t, registered[want], "路由 %s 应已注册", want)
+	}
+}

--- a/service.go
+++ b/service.go
@@ -565,6 +565,55 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 	}, nil
 }
 
+// GetUnreadCount 获取通知未读数
+func (s *XiaohongshuService) GetUnreadCount(ctx context.Context) (*xiaohongshu.NotificationCount, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	return xiaohongshu.NewNotificationAction(page).UnreadCount(ctx)
+}
+
+// ListNotifications 获取指定分区的通知列表
+func (s *XiaohongshuService) ListNotifications(ctx context.Context, tab string, limit int) (*xiaohongshu.NotificationList, error) {
+	parsed, err := xiaohongshu.ParseNotificationTab(tab)
+	if err != nil {
+		return nil, err
+	}
+
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	return xiaohongshu.NewNotificationAction(page).List(ctx, parsed, limit)
+}
+
+// LikeNotification 给通知里的评论点赞或取消点赞
+func (s *XiaohongshuService) LikeNotification(ctx context.Context, commentID string, unlike bool) (*xiaohongshu.NotificationLikeResult, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	return xiaohongshu.NewNotificationAction(page).Like(ctx, commentID, unlike)
+}
+
+// ReplyNotification 在通知页就地回复评论
+func (s *XiaohongshuService) ReplyNotification(ctx context.Context, commentID, content string) (*xiaohongshu.NotificationReplyResult, error) {
+	b := newBrowser()
+	defer b.Close()
+
+	page := b.NewPage()
+	defer page.Close()
+
+	return xiaohongshu.NewNotificationAction(page).Reply(ctx, commentID, content)
+}
+
 func newBrowser() *headless_browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(),
 		browser.WithFingerprintSeed(configs.FingerprintSeed()),

--- a/types.go
+++ b/types.go
@@ -123,3 +123,21 @@ type ActionResult struct {
 	Success bool   `json:"success"`
 	Message string `json:"message"`
 }
+
+// ListNotificationsRequest 通知列表请求
+type ListNotificationsRequest struct {
+	Tab   string `json:"tab,omitempty"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// ReplyNotificationRequest 通知回复请求
+type ReplyNotificationRequest struct {
+	CommentID string `json:"comment_id" binding:"required"`
+	Content   string `json:"content" binding:"required"`
+}
+
+// LikeNotificationRequest 通知点赞请求
+type LikeNotificationRequest struct {
+	CommentID string `json:"comment_id" binding:"required"`
+	Unlike    bool   `json:"unlike,omitempty"`
+}

--- a/xiaohongshu/notification.go
+++ b/xiaohongshu/notification.go
@@ -1,0 +1,356 @@
+package xiaohongshu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/humanize"
+)
+
+// NotificationTab 通知页的三个分区。
+type NotificationTab string
+
+const (
+	TabMentions    NotificationTab = "mentions"    // 评论和@
+	TabLikes       NotificationTab = "likes"       // 赞和收藏
+	TabConnections NotificationTab = "connections" // 新增关注
+)
+
+// tabLabels 分区对应的页面标签文字，用于切换分区时定位。
+var tabLabels = map[NotificationTab]string{
+	TabMentions:    "评论和@",
+	TabLikes:       "赞和收藏",
+	TabConnections: "新增关注",
+}
+
+// ParseNotificationTab 解析分区名，空值默认为「评论和@」。
+func ParseNotificationTab(s string) (NotificationTab, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case "", string(TabMentions):
+		return TabMentions, nil
+	case string(TabLikes):
+		return TabLikes, nil
+	case string(TabConnections):
+		return TabConnections, nil
+	}
+	return "", fmt.Errorf("未知的通知分区 %q，可选：mentions / likes / connections", s)
+}
+
+// statusNormal 是内容状态里表示「正常可见」的取值，未知取值按不可见处理。
+const statusNormal = "NORMAL"
+
+// NotificationCount 三个分区各自的未读数。
+type NotificationCount struct {
+	Mentions    int `json:"mentions"`
+	Likes       int `json:"likes"`
+	Connections int `json:"connections"`
+	Unread      int `json:"unread"`
+}
+
+// NotificationUser 通知里涉及的用户。
+type NotificationUser struct {
+	UserID    string `json:"user_id"`
+	Nickname  string `json:"nickname"`
+	XsecToken string `json:"xsec_token,omitempty"`
+}
+
+// NotificationItem 一条通知。
+//
+// FeedID / FeedXsecToken 取自笔记信息，与 get_feed_detail、reply_comment_in_feed
+// 所需的参数一致，调用方可以直接拿去读原帖或走笔记页回复。
+type NotificationItem struct {
+	ID            string           `json:"id"`
+	Type          string           `json:"type"`
+	Title         string           `json:"title"`
+	Time          int64            `json:"time"`
+	From          NotificationUser `json:"from"`
+	CommentID     string           `json:"comment_id,omitempty"`
+	CommentText   string           `json:"comment_text,omitempty"`
+	Liked         bool             `json:"liked"`
+	FeedID        string           `json:"feed_id,omitempty"`
+	FeedXsecToken string           `json:"feed_xsec_token,omitempty"`
+	FeedTitle     string           `json:"feed_title,omitempty"`
+}
+
+// NotificationList 一个分区的通知列表。
+type NotificationList struct {
+	Tab NotificationTab `json:"tab"`
+	// Filtered 是被过滤掉的条目数：评论已删除、或笔记/评论处于非正常状态。
+	// 单独计数是为了让调用方知道「列表比实际条目少」，而不是以为一条不少。
+	Filtered int                `json:"filtered"`
+	Items    []NotificationItem `json:"items"`
+}
+
+// NotificationAction 通知中心相关动作。
+type NotificationAction struct {
+	page *rod.Page
+}
+
+func NewNotificationAction(page *rod.Page) *NotificationAction {
+	return &NotificationAction{page: page}
+}
+
+// UnreadCount 读取三个分区的未读数。
+func (n *NotificationAction) UnreadCount(ctx context.Context) (*NotificationCount, error) {
+	page := n.page.Timeout(60 * time.Second)
+
+	page.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	humanize.Delay(ctx, humanize.AfterNavigate)
+
+	if err := page.WaitStable(time.Second); err != nil {
+		logrus.Warnf("explore 页未稳定，继续读取未读数: %v", err)
+	}
+
+	res, err := page.Eval(`() => {
+		const s = window.__INITIAL_STATE__;
+		const c = s && s.notification && s.notification.notificationCount;
+		return c ? JSON.stringify(c) : "";
+	}`)
+	if err != nil {
+		return nil, fmt.Errorf("读取未读数失败: %w", err)
+	}
+
+	raw := res.Value.String()
+	if raw == "" {
+		return nil, fmt.Errorf("页面状态里没有未读数，可能未登录或页面结构已变化")
+	}
+
+	var count rawCount
+	if err := json.Unmarshal([]byte(raw), &count); err != nil {
+		return nil, fmt.Errorf("解析未读数失败: %w", err)
+	}
+	return &NotificationCount{
+		Mentions:    count.Mentions,
+		Likes:       count.Likes,
+		Connections: count.Connections,
+		Unread:      count.Unread,
+	}, nil
+}
+
+// rawCount 是未读数在页面状态里的原始结构。
+type rawCount struct {
+	Mentions    int `json:"mentions"`
+	Likes       int `json:"likes"`
+	Connections int `json:"connections"`
+	Unread      int `json:"unreadCount"`
+}
+
+// List 读取指定分区的通知列表。
+func (n *NotificationAction) List(ctx context.Context, tab NotificationTab, limit int) (*NotificationList, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	page := n.page.Timeout(3 * time.Minute)
+
+	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	humanize.Delay(ctx, humanize.AfterNavigate)
+
+	if err := n.switchTab(ctx, page, tab); err != nil {
+		return nil, err
+	}
+
+	if err := n.loadUntil(ctx, page, tab, limit); err != nil {
+		return nil, err
+	}
+
+	payload, err := n.readTab(page, tab)
+	if err != nil {
+		return nil, err
+	}
+
+	items, filtered := convertNotifications(payload.MessageList, limit)
+	return &NotificationList{Tab: tab, Filtered: filtered, Items: items}, nil
+}
+
+// switchTab 切到目标分区。「评论和@」是默认分区，无需点击。
+func (n *NotificationAction) switchTab(ctx context.Context, page *rod.Page, tab NotificationTab) error {
+	if tab == TabMentions {
+		return nil
+	}
+
+	label := tabLabels[tab]
+	elems, err := page.Elements(`.reds-tab-item`)
+	if err != nil {
+		return fmt.Errorf("未找到通知分区标签: %w", err)
+	}
+
+	for _, elem := range elems {
+		text, err := elem.Text()
+		if err != nil || strings.TrimSpace(text) != label {
+			continue
+		}
+		humanize.Delay(ctx, humanize.BeforeClick)
+		if err := humanize.Click(elem); err != nil {
+			return fmt.Errorf("切换到分区 %s 失败: %w", label, err)
+		}
+		humanize.Delay(ctx, humanize.AfterClick)
+		return nil
+	}
+	return fmt.Errorf("未找到分区标签 %q", label)
+}
+
+// loadUntil 滚动加载，直到条目数够用或没有更多。
+func (n *NotificationAction) loadUntil(ctx context.Context, page *rod.Page, tab NotificationTab, limit int) error {
+	const maxRounds = 20
+
+	for range maxRounds {
+		payload, err := n.readTab(page, tab)
+		if err != nil {
+			return err
+		}
+		loaded := len(payload.MessageList)
+		if loaded >= limit || !payload.HasMore {
+			return nil
+		}
+
+		if err := page.Mouse.Scroll(0, 800, 5); err != nil {
+			return fmt.Errorf("滚动加载失败: %w", err)
+		}
+		humanize.Delay(ctx, humanize.BetweenScroll)
+
+		if after, err := n.readTab(page, tab); err == nil && len(after.MessageList) == loaded {
+			humanize.Delay(ctx, humanize.Reading)
+		}
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// 页面状态里通知列表的原始结构。字段名与状态一致，解析交给 encoding/json。
+type (
+	notificationPayload struct {
+		HasMore     bool              `json:"hasMore"`
+		MessageList []rawNotification `json:"messageList"`
+	}
+
+	rawNotification struct {
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		Title string `json:"title"`
+		Time  int64  `json:"time"`
+
+		UserInfo rawUser `json:"userInfo"`
+		User     rawUser `json:"user"`
+
+		Comment rawComment `json:"commentInfo"`
+		Item    rawItem    `json:"itemInfo"`
+	}
+
+	rawUser struct {
+		UserID    string `json:"userid"`
+		Nickname  string `json:"nickname"`
+		XsecToken string `json:"xsecToken"`
+	}
+
+	rawIllegal struct {
+		Status string `json:"illegalStatus"`
+	}
+
+	rawComment struct {
+		ID      string     `json:"id"`
+		Content string     `json:"content"`
+		Liked   bool       `json:"liked"`
+		Illegal rawIllegal `json:"illegalInfo"`
+	}
+
+	rawItem struct {
+		ID        string     `json:"id"`
+		Type      string     `json:"type"`
+		Content   string     `json:"content"`
+		XsecToken string     `json:"xsecToken"`
+		Illegal   rawIllegal `json:"illegalInfo"`
+	}
+)
+
+// itemTypeNote 标记关联对象是一篇笔记；其他类型的 id 与笔记 id 不通用。
+const itemTypeNote = "note_info"
+
+// from 返回发起这条通知的用户。
+func (r rawNotification) from() rawUser {
+	if r.UserInfo.UserID != "" || r.UserInfo.Nickname != "" {
+		return r.UserInfo
+	}
+	return r.User
+}
+
+// readTab 读取指定分区的原始数据，字段映射由结构体承担。
+func (n *NotificationAction) readTab(page *rod.Page, tab NotificationTab) (*notificationPayload, error) {
+	res, err := page.Eval(`(tab) => {
+		const s = window.__INITIAL_STATE__;
+		const m = s && s.notification && s.notification.notificationMap;
+		return m && m[tab] ? JSON.stringify(m[tab]) : "";
+	}`, string(tab))
+	if err != nil {
+		return nil, fmt.Errorf("读取通知列表失败: %w", err)
+	}
+
+	raw := res.Value.String()
+	if raw == "" {
+		return nil, fmt.Errorf("页面状态里没有分区 %s，可能未登录或页面结构已变化", tab)
+	}
+
+	var payload notificationPayload
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, fmt.Errorf("解析通知列表失败: %w", err)
+	}
+	return &payload, nil
+}
+
+// visible 判断一条通知的内容是否仍然正常可见。
+func (r rawNotification) visible() bool {
+	if r.Comment.ID != "" && r.Comment.Illegal.Status != "" && r.Comment.Illegal.Status != statusNormal {
+		return false
+	}
+	if r.Item.ID != "" && r.Item.Illegal.Status != "" && r.Item.Illegal.Status != statusNormal {
+		return false
+	}
+	return true
+}
+
+// convertNotifications 过滤掉不可见条目并转成对外结构，返回条目和被过滤的数量。
+func convertNotifications(raw []rawNotification, limit int) ([]NotificationItem, int) {
+	items := make([]NotificationItem, 0, len(raw))
+	filtered := 0
+
+	for _, r := range raw {
+		if len(items) >= limit {
+			break
+		}
+		if !r.visible() {
+			filtered++
+			continue
+		}
+
+		u := r.from()
+		item := NotificationItem{
+			ID:    r.ID,
+			Type:  r.Type,
+			Title: r.Title,
+			Time:  r.Time,
+			From: NotificationUser{
+				UserID:    u.UserID,
+				Nickname:  u.Nickname,
+				XsecToken: u.XsecToken,
+			},
+			CommentID:   r.Comment.ID,
+			CommentText: r.Comment.Content,
+			Liked:       r.Comment.Liked,
+			FeedTitle:   r.Item.Content,
+		}
+		if r.Item.Type == itemTypeNote {
+			item.FeedID = r.Item.ID
+			item.FeedXsecToken = r.Item.XsecToken
+		}
+		items = append(items, item)
+	}
+	return items, filtered
+}

--- a/xiaohongshu/notification_like.go
+++ b/xiaohongshu/notification_like.go
@@ -1,0 +1,112 @@
+package xiaohongshu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/humanize"
+)
+
+// NotificationLikeResult 通知点赞的结果。
+type NotificationLikeResult struct {
+	CommentID string `json:"comment_id"`
+	Nickname  string `json:"nickname"`
+	Liked     bool   `json:"liked"`
+	// Skipped 表示调用前已是目标状态，本次未操作。
+	Skipped bool `json:"skipped"`
+}
+
+// likeSettleTimeout 是等待点赞状态生效的上限。
+const likeSettleTimeout = 15 * time.Second
+
+// Like 给一条评论点赞或取消点赞；已是目标状态时直接返回。
+func (n *NotificationAction) Like(ctx context.Context, commentID string, unlike bool) (*NotificationLikeResult, error) {
+	if strings.TrimSpace(commentID) == "" {
+		return nil, fmt.Errorf("缺少 comment_id")
+	}
+
+	want := !unlike
+	page := n.page.Timeout(3 * time.Minute)
+
+	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	humanize.Delay(ctx, humanize.AfterNavigate)
+
+	target, index, err := n.locate(ctx, page, commentID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &NotificationLikeResult{
+		CommentID: commentID,
+		Nickname:  target.from().Nickname,
+		Liked:     want,
+	}
+
+	if target.Comment.Liked == want {
+		result.Skipped = true
+		logrus.Infof("通知点赞跳过（已是目标状态）: comment=%s liked=%v", commentID, want)
+		return result, nil
+	}
+
+	items, err := page.Elements(`.tabs-content-container > .container`)
+	if err != nil {
+		return nil, fmt.Errorf("未找到通知条目: %w", err)
+	}
+	if index >= len(items) {
+		return nil, fmt.Errorf("通知条目渲染数(%d)少于目标位置(%d)，页面可能未加载完", len(items), index)
+	}
+
+	humanize.Delay(ctx, humanize.Reading)
+
+	btn, err := items[index].Element(`.action-like .like-wrapper`)
+	if err != nil {
+		return nil, fmt.Errorf("该通知没有点赞入口（评论可能已删除或不可点赞）: %w", err)
+	}
+
+	humanize.Delay(ctx, humanize.BeforeClick)
+	if err := humanize.Click(btn); err != nil {
+		return nil, fmt.Errorf("无法点击点赞: %w", err)
+	}
+
+	if err := n.waitLikeSettled(page, commentID, want); err != nil {
+		return nil, err
+	}
+
+	humanize.Delay(ctx, humanize.AfterInteract)
+
+	logrus.Infof("通知点赞成功: comment=%s liked=%v", commentID, want)
+	return result, nil
+}
+
+// waitLikeSettled 等待点赞状态变成目标值；判不出来直接报错，不自动重试。
+func (n *NotificationAction) waitLikeSettled(page *rod.Page, commentID string, want bool) error {
+	if n.likedMatches(page, commentID, want, likeSettleTimeout) {
+		return nil
+	}
+	return fmt.Errorf("点赞未确认成功：%s 内状态未变成 %v。点赞可能已生效但同步慢，"+
+		"请先用 list_notifications 读一次当前状态再决定是否重试", likeSettleTimeout, want)
+}
+
+// likedMatches 轮询状态，直到目标评论的 liked 等于 want 或超时。
+func (n *NotificationAction) likedMatches(page *rod.Page, commentID string, want bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		payload, err := n.readTab(page, TabMentions)
+		if err == nil {
+			for _, r := range payload.MessageList {
+				if r.Comment.ID == commentID {
+					if r.Comment.Liked == want {
+						return true
+					}
+					break
+				}
+			}
+		}
+		time.Sleep(700 * time.Millisecond)
+	}
+	return false
+}

--- a/xiaohongshu/notification_reply.go
+++ b/xiaohongshu/notification_reply.go
@@ -1,0 +1,161 @@
+package xiaohongshu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/xiaohongshu-mcp/humanize"
+)
+
+// NotificationReplyResult 通知回复的结果。
+type NotificationReplyResult struct {
+	CommentID string `json:"comment_id"`
+	Nickname  string `json:"nickname"`
+	FeedID    string `json:"feed_id,omitempty"`
+	Content   string `json:"content"`
+}
+
+// Reply 回复一条评论。
+func (n *NotificationAction) Reply(ctx context.Context, commentID, content string) (*NotificationReplyResult, error) {
+	if strings.TrimSpace(commentID) == "" {
+		return nil, fmt.Errorf("缺少 comment_id")
+	}
+	if strings.TrimSpace(content) == "" {
+		return nil, fmt.Errorf("回复内容不能为空")
+	}
+
+	page := n.page.Timeout(3 * time.Minute)
+
+	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	humanize.Delay(ctx, humanize.AfterNavigate)
+
+	target, index, err := n.locate(ctx, page, commentID)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := page.Elements(`.tabs-content-container > .container`)
+	if err != nil {
+		return nil, fmt.Errorf("未找到通知条目: %w", err)
+	}
+	if index >= len(items) {
+		return nil, fmt.Errorf("通知条目渲染数(%d)少于目标位置(%d)，页面可能未加载完", len(items), index)
+	}
+	item := items[index]
+
+	humanize.Delay(ctx, humanize.Reading)
+
+	replyBtn, err := item.Element(`.action-reply`)
+	if err != nil {
+		return nil, fmt.Errorf("该通知没有回复入口（评论可能已删除或不可回复）: %w", err)
+	}
+
+	humanize.Delay(ctx, humanize.BeforeClick)
+	if err := humanize.Click(replyBtn); err != nil {
+		return nil, fmt.Errorf("无法点击回复: %w", err)
+	}
+	humanize.Delay(ctx, humanize.AfterClick)
+
+	input, err := item.Element(`textarea.comment-input`)
+	if err != nil {
+		return nil, fmt.Errorf("回复输入框未出现: %w", err)
+	}
+
+	if err := verifyReplyTarget(input, target.from().Nickname); err != nil {
+		return nil, err
+	}
+
+	if err := humanize.Type(ctx, input, content); err != nil {
+		return nil, fmt.Errorf("无法输入回复内容: %w", err)
+	}
+	humanize.Delay(ctx, humanize.AfterType)
+
+	submit, err := item.Element(`button.submit`)
+	if err != nil {
+		return nil, fmt.Errorf("未找到发送按钮: %w", err)
+	}
+
+	humanize.Delay(ctx, humanize.BeforeSubmit)
+	if err := humanize.Click(submit); err != nil {
+		return nil, fmt.Errorf("无法点击发送: %w", err)
+	}
+
+	if err := waitReplyAccepted(item, 8*time.Second); err != nil {
+		return nil, err
+	}
+
+	humanize.Delay(ctx, humanize.AfterInteract)
+
+	logrus.Infof("通知回复成功: comment=%s", commentID)
+	return &NotificationReplyResult{
+		CommentID: commentID,
+		Nickname:  target.from().Nickname,
+		FeedID:    target.Item.ID,
+		Content:   content,
+	}, nil
+}
+
+// locate 找到目标评论在当前分区里的位置，必要时滚动加载。
+func (n *NotificationAction) locate(ctx context.Context, page *rod.Page, commentID string) (*rawNotification, int, error) {
+	const maxRounds = 20
+
+	for range maxRounds {
+		payload, err := n.readTab(page, TabMentions)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		for i, r := range payload.MessageList {
+			if r.Comment.ID != commentID {
+				continue
+			}
+			if !r.visible() {
+				return nil, 0, fmt.Errorf("该评论已删除或不可见，不能回复: %s", commentID)
+			}
+			return &r, i, nil
+		}
+
+		if !payload.HasMore {
+			return nil, 0, fmt.Errorf("未找到评论 %s，它可能不在「评论和@」里或已被清理", commentID)
+		}
+
+		if err := page.Mouse.Scroll(0, 800, 5); err != nil {
+			return nil, 0, fmt.Errorf("滚动查找失败: %w", err)
+		}
+		humanize.Delay(ctx, humanize.BetweenScroll)
+
+		if err := ctx.Err(); err != nil {
+			return nil, 0, err
+		}
+	}
+	return nil, 0, fmt.Errorf("翻找 %d 轮仍未定位到评论 %s", maxRounds, commentID)
+}
+
+// verifyReplyTarget 用输入框的 placeholder 核对回复对象。
+func verifyReplyTarget(input *rod.Element, nickname string) error {
+	placeholder, err := input.Attribute("placeholder")
+	if err != nil || placeholder == nil {
+		return fmt.Errorf("读不到回复框提示文字，无法确认回复对象，已中止")
+	}
+	if nickname != "" && !strings.Contains(*placeholder, nickname) {
+		return fmt.Errorf("回复对象不符：期望 %q，实际提示为 %q，已中止", nickname, *placeholder)
+	}
+	return nil
+}
+
+// waitReplyAccepted 等待回复提交完成。
+func waitReplyAccepted(item *rod.Element, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		has, _, err := item.Has(`textarea.comment-input`)
+		if err == nil && !has {
+			return nil
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return fmt.Errorf("回复未确认成功：发送后输入框仍未收起（可能被限制或发送失败）")
+}

--- a/xiaohongshu/notification_test.go
+++ b/xiaohongshu/notification_test.go
@@ -1,0 +1,200 @@
+package xiaohongshu
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNotificationTab(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    NotificationTab
+		wantErr bool
+	}{
+		{"", TabMentions, false},
+		{"mentions", TabMentions, false},
+		{"LIKES", TabLikes, false},
+		{"  connections  ", TabConnections, false},
+		{"评论和@", "", true},
+		{"unknown", "", true},
+	}
+
+	for _, c := range cases {
+		got, err := ParseNotificationTab(c.in)
+		if c.wantErr {
+			assert.Error(t, err, "input=%q", c.in)
+			continue
+		}
+		require.NoError(t, err, "input=%q", c.in)
+		assert.Equal(t, c.want, got, "input=%q", c.in)
+	}
+}
+
+// comment 构造一条带评论的通知。
+func comment(id, nick, text, status string) rawNotification {
+	return rawNotification{
+		ID:       "n-" + id,
+		Title:    "评论了你的笔记",
+		UserInfo: rawUser{UserID: "u-" + id, Nickname: nick, XsecToken: "ut-" + id},
+		Comment: rawComment{
+			ID:      id,
+			Content: text,
+			Illegal: rawIllegal{Status: status},
+		},
+		Item: rawItem{
+			ID:        "f-" + id,
+			Type:      itemTypeNote,
+			Content:   "笔记标题",
+			XsecToken: "ft-" + id,
+			Illegal:   rawIllegal{Status: statusNormal},
+		},
+	}
+}
+
+// 状态非正常的条目要被过滤掉，且其正文不能出现在结果里。
+func TestConvertNotifications_FiltersInvisible(t *testing.T) {
+	raw := []rawNotification{
+		comment("c1", "甲", "正常评论", statusNormal),
+		comment("c2", "乙", "不可见条目的正文", "NOT_NORMAL"),
+		comment("c3", "丙", "另一条正常", statusNormal),
+	}
+
+	items, filtered := convertNotifications(raw, 20)
+
+	require.Len(t, items, 2)
+	assert.Equal(t, 1, filtered)
+	assert.Equal(t, "c1", items[0].CommentID)
+	assert.Equal(t, "c3", items[1].CommentID)
+
+	for _, it := range items {
+		assert.NotEqual(t, "不可见条目的正文", it.CommentText)
+	}
+}
+
+// 白名单：未知状态一律按不可见处理，而不是放行。
+func TestConvertNotifications_UnknownStatusIsFiltered(t *testing.T) {
+	a := comment("c1", "甲", "x", "UNSEEN_A")
+	b := comment("c2", "乙", "y", statusNormal)
+	b.Item.Illegal.Status = "UNSEEN_B"
+
+	items, filtered := convertNotifications([]rawNotification{a, b}, 20)
+
+	assert.Empty(t, items)
+	assert.Equal(t, 2, filtered)
+}
+
+// 状态字段为空时（例如「新增关注」没有评论/笔记）不应被误判为不可见。
+func TestConvertNotifications_KeepsItemsWithoutStatus(t *testing.T) {
+	raw := []rawNotification{
+		{ID: "1", Title: "关注了你", User: rawUser{UserID: "u1", Nickname: "甲"}},
+		{ID: "2", Title: "赞了你的笔记", Item: rawItem{ID: "f1", Type: itemTypeNote, Illegal: rawIllegal{Status: statusNormal}}},
+	}
+
+	items, filtered := convertNotifications(raw, 20)
+
+	assert.Len(t, items, 2)
+	assert.Zero(t, filtered)
+}
+
+// limit 只截正常条目，被过滤的不占名额。
+func TestConvertNotifications_LimitCountsVisibleOnly(t *testing.T) {
+	raw := []rawNotification{
+		comment("c1", "甲", "x", "NOT_NORMAL"),
+		comment("c2", "乙", "x", statusNormal),
+		comment("c3", "丙", "x", statusNormal),
+		comment("c4", "丁", "x", statusNormal),
+	}
+
+	items, filtered := convertNotifications(raw, 2)
+
+	require.Len(t, items, 2)
+	assert.Equal(t, "c2", items[0].CommentID)
+	assert.Equal(t, "c3", items[1].CommentID)
+	assert.Equal(t, 1, filtered)
+}
+
+// 非笔记类型的关联对象也带 id 和 token，但与笔记 id 不通用，不能给出去。
+func TestConvertNotifications_OmitsFeedIDForNonNote(t *testing.T) {
+	r := comment("c1", "甲", "x", statusNormal)
+	r.Title = "收藏了你的笔记"
+	r.Item.Type = "board_info"
+	r.Item.Content = "某专辑"
+
+	items, _ := convertNotifications([]rawNotification{r}, 20)
+
+	require.Len(t, items, 1)
+	assert.Empty(t, items[0].FeedID)
+	assert.Empty(t, items[0].FeedXsecToken)
+	// 标题仍要保留，调用方还得知道发生了什么
+	assert.Equal(t, "某专辑", items[0].FeedTitle)
+	assert.Equal(t, "收藏了你的笔记", items[0].Title)
+}
+
+// TestNotificationPayload_Unmarshal 固定页面状态到结构体的字段映射。
+//
+// 字段名一旦对不上，解析出来的是零值而不是报错——列表会静默变成一堆空条目，
+// 因此用一份同形报文钉住。
+func TestNotificationPayload_Unmarshal(t *testing.T) {
+	const fixture = `{
+		"cursor": "1",
+		"hasMore": true,
+		"messageList": [{
+			"id": "7000000000000000001",
+			"type": "comment/item",
+			"title": "评论了你的笔记",
+			"time": 1700000000,
+			"userInfo": {"userid": "u1", "nickname": "甲", "xsecToken": "ut1"},
+			"commentInfo": {
+				"id": "c1", "content": "评论正文", "liked": true,
+				"illegalInfo": {"illegalStatus": "NORMAL"}
+			},
+			"itemInfo": {
+				"id": "f1", "type": "note_info", "content": "笔记标题", "xsecToken": "ft1",
+				"illegalInfo": {"illegalStatus": "NORMAL"}
+			}
+		}]
+	}`
+
+	var payload notificationPayload
+	require.NoError(t, json.Unmarshal([]byte(fixture), &payload))
+
+	assert.True(t, payload.HasMore)
+	require.Len(t, payload.MessageList, 1)
+
+	r := payload.MessageList[0]
+	assert.Equal(t, "评论了你的笔记", r.Title)
+	assert.Equal(t, int64(1700000000), r.Time)
+	assert.Equal(t, "甲", r.from().Nickname)
+	assert.Equal(t, "ut1", r.from().XsecToken)
+	assert.Equal(t, "c1", r.Comment.ID)
+	assert.True(t, r.Comment.Liked)
+	assert.Equal(t, statusNormal, r.Comment.Illegal.Status)
+	assert.Equal(t, itemTypeNote, r.Item.Type)
+	assert.Equal(t, "ft1", r.Item.XsecToken)
+	assert.True(t, r.visible())
+
+	items, filtered := convertNotifications(payload.MessageList, 20)
+	require.Len(t, items, 1)
+	assert.Zero(t, filtered)
+	assert.Equal(t, "f1", items[0].FeedID)
+	assert.Equal(t, "ft1", items[0].FeedXsecToken)
+}
+
+// 「新增关注」分区的用户字段名与其他分区不同，两者都要能取到。
+func TestRawNotification_From(t *testing.T) {
+	const fixture = `{"messageList": [
+		{"id": "1", "title": "关注了你", "user": {"userid": "u9", "nickname": "丙", "xsecToken": "ut9"}},
+		{"id": "2", "title": "评论了你的笔记", "userInfo": {"userid": "u8", "nickname": "丁"}}
+	]}`
+
+	var payload notificationPayload
+	require.NoError(t, json.Unmarshal([]byte(fixture), &payload))
+	require.Len(t, payload.MessageList, 2)
+
+	assert.Equal(t, "丙", payload.MessageList[0].from().Nickname)
+	assert.Equal(t, "u9", payload.MessageList[0].from().UserID)
+	assert.Equal(t, "丁", payload.MessageList[1].from().Nickname)
+}


### PR DESCRIPTION
新增四个能力，MCP 工具与 HTTP 接口同步提供：

| 工具 | 路由 |
|---|---|
| `get_unread_count` | `GET /api/v1/notifications/unread` |
| `list_notifications` | `GET`/`POST /api/v1/notifications/list` |
| `reply_notification` | `POST /api/v1/notifications/reply` |
| `like_notification` | `POST /api/v1/notifications/like` |

`list_notifications` 返回评论者、内容，以及关联笔记的 `feed_id` / `xsec_token`，可接 `get_feed_detail`。状态非正常的条目会被过滤，数量计入 `filtered`；关联对象不是笔记时不给出 `feed_id`。

另含两处改动：

- `humanize.Click` 的一处参数调整，**影响所有点击路径**
- 通知页取数改由 Go 结构体解析，页面内脚本相应精简，并补充了报文解析的单测

`go build` / `go vet` / `go test ./...` 均通过，各接口功能已验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)