### PR TITLE
fix(cookies): 保存时创建缺失的父目录

### DIFF
--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -106,6 +106,12 @@ func (c *localCookie) write(cks []byte, seed int) error {
 		return errors.Wrap(err, "marshal session file failed")
 	}
 
+	if dir := filepath.Dir(c.path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return errors.Wrap(err, "create cookies dir failed")
+		}
+	}
+
 	return os.WriteFile(c.path, data, 0644)
 }
 

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -155,3 +155,20 @@ func decodeJSON(t *testing.T, data []byte) any {
 	assert.NoError(t, json.Unmarshal(data, &v))
 	return v
 }
+
+// TestSaveCookies_CreatesParentDir 保存时父目录不存在也应能落盘。
+//
+// COOKIES_PATH 指向一个还没创建的目录时，原先会直接写失败。
+func TestSaveCookies_CreatesParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "deeper", "cookies.json")
+
+	c := NewLoadCookie(path)
+	assert.NoError(t, c.SaveCookies([]byte(`[{"name":"a","value":"b"}]`)))
+
+	got, err := c.LoadCookies()
+	assert.NoError(t, err)
+
+	var cks []map[string]string
+	assert.NoError(t, json.Unmarshal(got, &cks))
+	assert.Equal(t, "a", cks[0]["name"])
+}


### PR DESCRIPTION
`COOKIES_PATH` 指向尚不存在的目录时，保存 cookies 会直接失败。改为写入前创建父目录。

补充单测覆盖：父目录不存在时保存 + 读回。

思路来自 @wzy31124513 在 #422 中的排查，感谢。

`go build` / `go vet` / `go test ./...` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)