### PR TITLE
fix(docker): 镜像内置 tini 作为 PID 1，回收浏览器子进程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxss1 \
     libxtst6 \
     lsb-release \
+    tini \
     wget \
     xdg-utils \
     xz-utils \
@@ -111,5 +112,8 @@ ENV HOME=/app/data/home
 ENV XDG_CONFIG_HOME=/app/data/config
 
 EXPOSE 18060
+
+# 用 tini 当 PID 1，回收浏览器退出后被过继过来的子进程，避免堆积僵尸进程
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 CMD ["./app"]


### PR DESCRIPTION
## 问题

`docker/docker-compose.yml` 里设了 `init: true`，用 compose 启动的容器有 `docker-init` 当 PID 1，不会有僵尸进程。

但这个保证只覆盖 compose 这一条路径。镜像本身 `CMD ["./app"]`，PID 1 就是 Go 程序，不会 `wait()` 被过继过来的孤儿进程。直接 `docker run`（不加 `--init`）或自写编排的用户，Chrome 退出后其子进程会堆积成 `[defunct]`。

## 改动

镜像内置 tini 并设为 ENTRYPOINT，与启动方式无关。`docker-compose.yml` 里的 `init: true` 保留作冗余。

## 验证

| 场景 | PID 1 | 僵尸数 |
|---|---|---|
| 现镜像 + `docker run` | `./app` | 5 |
| 现镜像 + `docker run --init` | `docker-init` | 0 |
| 改后镜像 + `docker run`（不加 `--init`） | `tini` | 0 |

副作用检查：进程树为 `tini -- ./app`，`/health` 返回 200，`docker stop` 0 秒退出、退出码 0（SIGTERM 正常转发，非强杀）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)