### PR TITLE
fix(docker): tini 注册为 child subreaper，消除误导性告警

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,8 @@ ENV XDG_CONFIG_HOME=/app/data/config
 
 EXPOSE 18060
 
-# 用 tini 当 PID 1，回收浏览器退出后被过继过来的子进程，避免堆积僵尸进程
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# 用 tini 回收浏览器退出后被过继过来的子进程，避免堆积僵尸进程。
+# -s 注册为 child subreaper，容器另外带了 init 进程（如 compose 的 init: true）时同样生效
+ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
 
 CMD ["./app"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     # image: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp
     container_name: xiaohongshu-mcp
     restart: unless-stopped
-    init: true
     tty: true
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
## 问题

#793 给镜像加了 tini 作为 ENTRYPOINT，但 `docker-compose.yml` 里原本就有 `init: true`，两者叠加成了两层 init：

```
docker-init  ← PID 1
  └─ tini    ← 不是 PID 1
       └─ ./app
```

tini 因此在启动时打印：

```
[WARN  tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
```

实际回收由外层 `docker-init` 完成、功能正常，但这条告警会让使用者误以为回收失效。对本来就走 compose 的用户来说，#793 没有带来功能收益，只带来了这条噪音。

## 改动

1. ENTRYPOINT 加 `-s`，tini 注册为 child subreaper——用户若自行额外加了 `--init`，也不会再出告警。
2. `docker-compose.yml` 去掉 `init: true`，消除冗余，tini 回到 PID 1。

## 验证

以 v2.4.2 镜像为基础加 `-s` 后实测：

| 场景 | PID 1 | 僵尸数 | tini 告警 |
|---|---|---|---|
| 复刻本仓库 compose 配置（已去掉 `init: true`） | `tini` | 0 | 无 |
| `docker run --init`（用户自带 init） | `docker-init` | 0 | 无 |
| `docker run`（不带 init） | `tini` | 0 | 无 |

三种场景下 `/health` 均返回 200，`docker stop` 均 0 秒退出、退出码 0（SIGTERM 正常转发）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)