### PR TITLE
chore: 移除从未赋值的 post_id 字段，并修正 API 文档

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -196,8 +196,7 @@ Content-Type: application/json
     "title": "笔记标题",
     "content": "笔记内容",
     "images": 2,
-    "status": "published",
-    "post_id": "64f1a2b3c4d5e6f7a8b9c0d1"
+    "status": "发布完成"
   },
   "message": "发布成功"
 }
@@ -241,8 +240,7 @@ Content-Type: application/json
     "title": "视频标题",
     "content": "视频内容描述",
     "video": "/Users/username/Videos/video.mp4",
-    "status": "发布完成",
-    "post_id": "64f1a2b3c4d5e6f7a8b9c0d1"
+    "status": "发布完成"
   },
   "message": "视频发布成功"
 }

--- a/service.go
+++ b/service.go
@@ -60,7 +60,6 @@ type PublishResponse struct {
 	Content string `json:"content"`
 	Images  int    `json:"images"`
 	Status  string `json:"status"`
-	PostID  string `json:"post_id,omitempty"`
 }
 
 // PublishVideoRequest 发布视频请求（仅支持本地单个视频文件）
@@ -80,7 +79,6 @@ type PublishVideoResponse struct {
 	Content string `json:"content"`
 	Video   string `json:"video"`
 	Status  string `json:"status"`
-	PostID  string `json:"post_id,omitempty"`
 }
 
 // FeedsListResponse Feeds列表响应


### PR DESCRIPTION
## 背景

`PublishResponse` 和 `PublishVideoResponse` 里都声明了 `PostID`，但全仓没有任何一处给它赋值，加上 `omitempty`，它在响应里从来不会出现。

问题不止是死代码：`docs/API.md` 的两个响应示例都把 `post_id` 写成会返回，还给了一个假值。使用者照着文档预期一个不存在的字段，#494 就是这么来的。

发布完成后平台跳转到的是通用成功页，不携带笔记标识，这条链路上拿不到笔记 ID；唯一的补法是发布后额外去主页反查，为一个字段给发布流程增加无关请求和失败点，不划算。#494 已按「无法实现」关闭。

## 改动

- 两个结构体去掉 `PostID`
- `docs/API.md` 两个示例去掉 `post_id`
- 顺带修正图文发布示例里的 `status` 取值，与代码实际返回一致（此前写的是 `published`）

## 验证

`gofmt` 无变更、`go build ./...` 通过、`go test ./...` 全绿；全仓已无 `PostID` / `post_id` 残留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)