### PR TITLE
feat: 支持 rednote.com 海外站(-site 双站点)

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -11,6 +11,7 @@ import (
 )
 
 type browserConfig struct {
+	site string // 站点标识,决定加载哪份 cookies(空值为默认站点)
 	// fingerprintSeed 固定指纹 seed；>0 时钉死，同账号每次同一套指纹。0 = 每次随机。
 	fingerprintSeed int
 	// proxy 代理地址；非空时启用。
@@ -30,6 +31,13 @@ func WithProxy(proxy string) Option {
 func WithFingerprintSeed(seed int) Option {
 	return func(c *browserConfig) {
 		c.fingerprintSeed = seed
+	}
+}
+
+// WithSite 指定站点(xiaohongshu / rednote),不同站点的 cookies 相互隔离。
+func WithSite(site string) Option {
+	return func(c *browserConfig) {
+		c.site = site
 	}
 }
 
@@ -86,8 +94,8 @@ func NewBrowser(headless bool, options ...Option) *headless_browser.Browser {
 		logrus.Infof("fingerprint seed pinned: %d", cfg.fingerprintSeed)
 	}
 
-	// 加载 cookies
-	cookiePath := cookies.GetCookiesFilePath()
+	// 加载 cookies(按站点隔离)
+	cookiePath := cookies.GetCookiesFilePathForSite(cfg.site)
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
 
 	if data, err := cookieLoader.LoadCookies(); err == nil {

--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -14,15 +14,22 @@ import (
 )
 
 func main() {
+	var site string // 站点: xiaohongshu | rednote
+	flag.StringVar(&site, "site", xiaohongshu.SiteXiaohongshu, "站点: xiaohongshu | rednote")
 	flag.Parse()
 
+	if err := xiaohongshu.SetSite(site); err != nil {
+		logrus.Fatalf("站点配置错误: %v", err)
+	}
+
 	// 登录的时候，需要界面，所以不能无头模式。
-	// 登录与后续运行共用同一个 seed：首次登录生成并写入会话文件，之后一直复用。
-	store := cookies.NewLoadCookie(cookies.GetCookiesFilePath())
+	// 登录与后续运行共用同一个 seed：首次登录生成并写入会话文件，之后一直复用(会话文件按站点隔离)。
+	store := cookies.NewLoadCookie(cookies.GetCookiesFilePathForSite(site))
 
 	b := browser.NewBrowser(false,
 		browser.WithFingerprintSeed(configs.ResolveFingerprintSeed(store)),
 		browser.WithProxy(configs.ProxyFromEnv()),
+		browser.WithSite(site),
 	)
 	defer b.Close()
 
@@ -77,6 +84,6 @@ func saveCookies(page *rod.Page) error {
 		return err
 	}
 
-	cookieLoader := cookies.NewLoadCookie(cookies.GetCookiesFilePath())
+	cookieLoader := cookies.NewLoadCookie(cookies.GetCookiesFilePathForSite(xiaohongshu.Site().Name))
 	return cookieLoader.SaveCookies(data)
 }

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -2,6 +2,7 @@ package cookies
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -145,4 +146,15 @@ func GetCookiesFilePath() string {
 	}
 
 	return localCookiesPath
+}
+
+// GetCookiesFilePathForSite 按站点返回 cookies 文件路径。
+// 默认站点(xiaohongshu)沿用 GetCookiesFilePath 的兼容逻辑;
+// 其他站点(如 rednote)在同目录使用 cookies-<site>.json,登录态彼此隔离。
+func GetCookiesFilePathForSite(site string) string {
+	base := GetCookiesFilePath()
+	if site == "" || site == "xiaohongshu" {
+		return base
+	}
+	return filepath.Join(filepath.Dir(base), fmt.Sprintf("cookies-%s.json", site))
 }

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -172,3 +172,17 @@ func TestSaveCookies_CreatesParentDir(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(got, &cks))
 	assert.Equal(t, "a", cks[0]["name"])
 }
+
+// TestGetCookiesFilePathForSite 校验站点隔离：默认站点沿用原路径，其他站点用 cookies-<site>.json。
+func TestGetCookiesFilePathForSite(t *testing.T) {
+	t.Setenv("COOKIES_PATH", "/data/cookies.json")
+
+	t.Run("默认站点与空站点沿用原路径", func(t *testing.T) {
+		assert.Equal(t, "/data/cookies.json", GetCookiesFilePathForSite("xiaohongshu"))
+		assert.Equal(t, "/data/cookies.json", GetCookiesFilePathForSite(""))
+	})
+
+	t.Run("其他站点在同目录使用带站点后缀的文件", func(t *testing.T) {
+		assert.Equal(t, "/data/cookies-rednote.json", GetCookiesFilePathForSite("rednote"))
+	})
+}

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -71,7 +71,7 @@ func (s *AppServer) deleteCookiesHandler(c *gin.Context) {
 		return
 	}
 
-	cookiePath := cookies.GetCookiesFilePath()
+	cookiePath := cookies.GetCookiesFilePathForSite(xiaohongshu.Site().Name)
 	respondSuccess(c, map[string]interface{}{
 		"cookie_path": cookiePath,
 		"message":     "Cookies 已成功删除，登录状态已重置。下次操作时需要重新登录。",

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
 	"github.com/xpzouying/xiaohongshu-mcp/cookies"
+	"github.com/xpzouying/xiaohongshu-mcp/xiaohongshu"
 )
 
 // version 构建版本号，发布时通过 -ldflags "-X main.version=vX.Y.Z" 注入。
@@ -16,10 +17,16 @@ func main() {
 	var (
 		headless bool
 		port     string
+		site     string // 站点: xiaohongshu | rednote
 	)
 	flag.BoolVar(&headless, "headless", true, "是否无头模式")
 	flag.StringVar(&port, "port", ":18060", "端口")
+	flag.StringVar(&site, "site", xiaohongshu.SiteXiaohongshu, "站点: xiaohongshu | rednote")
 	flag.Parse()
+
+	if err := xiaohongshu.SetSite(site); err != nil {
+		logrus.Fatalf("站点配置错误: %v", err)
+	}
 
 	logrus.Infof("xiaohongshu-mcp version: %s", version)
 
@@ -32,9 +39,9 @@ func main() {
 
 	configs.InitHeadless(headless)
 	// 入口层解析出 seed 和代理，经 configs 透传给浏览器工厂。
-	// seed 取值：环境变量 > 会话文件 > 新生成并写回，保证同一账号每次启动一致。
+	// seed 取值：环境变量 > 会话文件 > 新生成并写回，保证同一账号每次启动一致(会话文件按站点隔离)。
 	configs.SetFingerprintSeed(configs.ResolveFingerprintSeed(
-		cookies.NewLoadCookie(cookies.GetCookiesFilePath())))
+		cookies.NewLoadCookie(cookies.GetCookiesFilePathForSite(site))))
 	configs.SetProxy(configs.ProxyFromEnv())
 
 	// 初始化服务

--- a/service.go
+++ b/service.go
@@ -96,7 +96,7 @@ type UserProfileResponse struct {
 
 // DeleteCookies 删除 cookies 文件，用于登录重置
 func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
-	cookiePath := cookies.GetCookiesFilePath()
+	cookiePath := cookies.GetCookiesFilePathForSite(xiaohongshu.Site().Name)
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
 	return cookieLoader.DeleteCookies()
 }
@@ -465,7 +465,6 @@ func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken,
 	}
 
 	return response, nil
-
 }
 
 // PostCommentToFeed 发表评论到Feed
@@ -621,6 +620,7 @@ func newBrowser() *headless_browser.Browser {
 	return browser.NewBrowser(configs.IsHeadless(),
 		browser.WithFingerprintSeed(configs.FingerprintSeed()),
 		browser.WithProxy(configs.Proxy()),
+		browser.WithSite(xiaohongshu.Site().Name),
 	)
 }
 
@@ -635,7 +635,7 @@ func saveCookies(page *rod.Page) error {
 		return err
 	}
 
-	cookieLoader := cookies.NewLoadCookie(cookies.GetCookiesFilePath())
+	cookieLoader := cookies.NewLoadCookie(cookies.GetCookiesFilePathForSite(xiaohongshu.Site().Name))
 	return cookieLoader.SaveCookies(data)
 }
 

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -1001,5 +1001,5 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
-	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+	return fmt.Sprintf("%s/explore/%s?xsec_token=%s&xsec_source=pc_feed", Site().Base, feedID, xsecToken)
 }

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -17,7 +17,7 @@ type FeedsListAction struct {
 func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 	pp := page.Timeout(60 * time.Second)
 
-	pp.MustNavigate("https://www.xiaohongshu.com")
+	pp.MustNavigate(Site().Base)
 	pp.MustWaitDOMStable()
 
 	return &FeedsListAction{page: pp}

--- a/xiaohongshu/locale.go
+++ b/xiaohongshu/locale.go
@@ -1,0 +1,22 @@
+package xiaohongshu
+
+import (
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/ysmood/gson"
+)
+
+// applySiteLocale 对海外站页面强制中文 locale。
+// rednote.com 与国内站共用 xhs-pc-web 前端,切中文后既有的中文文本选择器
+// (发布页 TAB、正文 placeholder 等)可直接复用。
+func applySiteLocale(page *rod.Page) {
+	if !Site().ForceZhCN {
+		return
+	}
+
+	_ = proto.NetworkSetExtraHTTPHeaders{Headers: proto.NetworkHeaders{
+		"Accept-Language": gson.New("zh-CN,zh;q=0.9,en;q=0.8"),
+	}}.Call(page)
+
+	_ = (&proto.EmulationSetLocaleOverride{Locale: "zh-CN"}).Call(page)
+}

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type LoginAction struct {
@@ -20,21 +21,22 @@ func NewLogin(page *rod.Page) *LoginAction {
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	// 加超时保护：只是查登录态的快速检查，不应无限挂（登录扫码的等待在 Login/WaitForLogin 里）
 	pp := a.page.Context(ctx).Timeout(30 * time.Second)
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	applySiteLocale(pp)
+	pp.MustNavigate(Site().Home).MustWaitLoad()
 
 	time.Sleep(1 * time.Second)
 
-	exists, _, err := pp.Has(`.main-container .user .link-wrapper .channel`)
+	exists, _, err := pp.Has(Site().LoggedInSel)
 	if err != nil {
 		return false, errors.Wrap(err, "check login status failed")
 	}
 
-	if !exists {
-		return false, errors.Wrap(err, "login status element not found")
-	}
-
-	return true, nil
+	return exists, nil
 }
+
+// Login 打开站点首页,等待用户在窗口中完成登录(扫码/手机验证码均可)。
+// 轮询已登录标志,最长等待 loginWaitTimeout;比旧版的单次 MustElement 更鲁棒。
+const loginWaitTimeout = 10 * time.Minute
 
 // CurrentUser 当前登录用户的基础信息。
 type CurrentUser struct {
@@ -72,33 +74,52 @@ func (a *LoginAction) CurrentUser(ctx context.Context) (*CurrentUser, error) {
 
 func (a *LoginAction) Login(ctx context.Context) error {
 	pp := a.page.Context(ctx)
-
-	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	applySiteLocale(pp)
+	pp.MustNavigate(Site().Home).MustWaitLoad()
 
 	time.Sleep(2 * time.Second)
 
-	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+	if exists, _, _ := pp.Has(Site().LoggedInSel); exists {
 		return nil
 	}
 
-	pp.MustElement(".main-container .user .link-wrapper .channel")
+	logrus.Infof("请在浏览器窗口中完成 %s 登录(扫码或手机验证码),最长等待 %v...", Site().Name, loginWaitTimeout)
 
-	return nil
+	deadline := time.NewTimer(loginWaitTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return errors.Errorf("等待登录超时(%v)", loginWaitTimeout)
+		case <-ticker.C:
+			if exists, _, _ := pp.Has(Site().LoggedInSel); exists {
+				logrus.Info("检测到登录成功")
+				// 稍等让会话 cookie 全部落定
+				time.Sleep(2 * time.Second)
+				return nil
+			}
+		}
+	}
 }
 
 func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error) {
 	pp := a.page.Context(ctx)
+	applySiteLocale(pp)
 
-	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate(Site().Home).MustWaitLoad()
 
 	time.Sleep(2 * time.Second)
 
-	if exists, _, _ := pp.Has(".main-container .user .link-wrapper .channel"); exists {
+	if exists, _, _ := pp.Has(Site().LoggedInSel); exists {
 		return "", true, nil
 	}
 
+	// 获取二维码图片(海外站可能无扫码入口,此时返回错误,请改用窗口手动登录)
 	src, err := pp.MustElement(".login-container .qrcode-img").Attribute("src")
 	if err != nil {
 		return "", false, errors.Wrap(err, "get qrcode src failed")
@@ -120,7 +141,7 @@ func (a *LoginAction) WaitForLogin(ctx context.Context) bool {
 		case <-ctx.Done():
 			return false
 		case <-ticker.C:
-			el, err := pp.Element(".main-container .user .link-wrapper .channel")
+			el, err := pp.Element(Site().LoggedInSel)
 			if err == nil && el != nil {
 				return true
 			}

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -19,7 +19,7 @@ func NewNavigate(page *rod.Page) *NavigateAction {
 func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 	page := n.page.Context(ctx).Timeout(60 * time.Second) // 加超时保护，避免 MustNavigate/MustWaitStable 无限挂
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").
+	page.MustNavigate(Site().Home).
 		MustWaitLoad().
 		MustElement(`div#app`)
 

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -33,18 +33,17 @@ type PublishAction struct {
 	page *rod.Page
 }
 
-const (
-	urlOfPublic = `https://creator.xiaohongshu.com/publish/publish?source=official`
-
-	// contentElemTimeout 查找正文输入框的轮询窗口
-	contentElemTimeout = 10 * time.Second
-)
+// contentElemTimeout 查找正文输入框的轮询窗口
+const contentElemTimeout = 10 * time.Second
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
 
 	pp := page.Timeout(300 * time.Second)
 
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	applySiteLocale(pp)
+
+	// 使用更稳健的导航和等待策略
+	if err := pp.Navigate(Site().PublishURL); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/publish_video.go
+++ b/xiaohongshu/publish_video.go
@@ -27,7 +27,7 @@ type PublishVideoContent struct {
 func NewPublishVideoAction(page *rod.Page) (*PublishAction, error) {
 	pp := page.Timeout(300 * time.Second)
 
-	if err := pp.Navigate(urlOfPublic); err != nil {
+	if err := pp.Navigate(Site().PublishURL); err != nil {
 		return nil, errors.Wrap(err, "导航到发布页面失败")
 	}
 

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -256,5 +256,5 @@ func makeSearchURL(keyword string) string {
 
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
-	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+	return fmt.Sprintf("%s/search_result?%s", Site().Base, values.Encode())
 }

--- a/xiaohongshu/site.go
+++ b/xiaohongshu/site.go
@@ -1,0 +1,54 @@
+package xiaohongshu
+
+import "fmt"
+
+// 站点标识。
+const (
+	SiteXiaohongshu = "xiaohongshu" // 国内站 xiaohongshu.com
+	SiteRednote     = "rednote"     // 海外站 rednote.com(与国内站同一套 xhs-pc-web 前端,账号体系独立)
+)
+
+// SiteConfig 站点配置:同一套自动化流程支持国内站与海外站。
+type SiteConfig struct {
+	Name        string // 站点标识
+	Base        string // 主站根,用于拼接笔记/用户/搜索链接
+	Home        string // 首页(explore),登录与导航入口
+	PublishURL  string // 创作平台图文/视频发布页
+	LoggedInSel string // 已登录判定:侧栏用户入口(class 选择器,语言无关)
+	ForceZhCN   bool   // 页面强制中文 locale(海外站默认英文,中文化后文本选择器可复用)
+}
+
+var sites = map[string]SiteConfig{
+	SiteXiaohongshu: {
+		Name:        SiteXiaohongshu,
+		Base:        "https://www.xiaohongshu.com",
+		Home:        "https://www.xiaohongshu.com/explore",
+		PublishURL:  "https://creator.xiaohongshu.com/publish/publish?source=official",
+		LoggedInSel: `.main-container .user .link-wrapper .channel`,
+		ForceZhCN:   false,
+	},
+	SiteRednote: {
+		Name:        SiteRednote,
+		Base:        "https://www.rednote.com",
+		Home:        "https://www.rednote.com/explore",
+		PublishURL:  "https://creator.rednote.com/publish/publish?source=official",
+		LoggedInSel: `.main-container .user .link-wrapper .channel`,
+		ForceZhCN:   true,
+	},
+}
+
+// 当前站点,默认国内站保持向后兼容;启动时通过 SetSite 切换。
+var currentSite = sites[SiteXiaohongshu]
+
+// SetSite 设置当前站点,进程启动时调用一次。
+func SetSite(name string) error {
+	s, ok := sites[name]
+	if !ok {
+		return fmt.Errorf("未知站点: %q(支持 %s / %s)", name, SiteXiaohongshu, SiteRednote)
+	}
+	currentSite = s
+	return nil
+}
+
+// Site 返回当前站点配置。
+func Site() SiteConfig { return currentSite }

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -46,6 +46,8 @@ type UserProfileAction struct {
 
 func NewUserProfileAction(page *rod.Page) *UserProfileAction {
 	pp := page.Timeout(60 * time.Second)
+	// selectTab 按中文 tab 文本定位;海外站(rednote)须强制中文渲染,与 login/publish 入口一致
+	applySiteLocale(pp)
 	return &UserProfileAction{page: pp}
 }
 
@@ -138,7 +140,7 @@ func (u *UserProfileAction) extractUserProfileData(page *rod.Page, tab ProfileTa
 }
 
 func makeUserProfileURL(userID, xsecToken string, tab ProfileTab) string {
-	url := fmt.Sprintf("https://www.xiaohongshu.com/user/profile/%s?xsec_token=%s&xsec_source=pc_note", userID, xsecToken)
+	url := fmt.Sprintf("%s/user/profile/%s?xsec_token=%s&xsec_source=pc_note", Site().Base, userID, xsecToken)
 	if tab != "" && tab != TabNotes {
 		url += fmt.Sprintf("&tab=%s&subTab=note", tab)
 	}


### PR DESCRIPTION
## 动机

`rednote.com` 与 `xiaohongshu.com` 在 Web 端是**两套独立的登录态与账号体系**:海外注册的账号归属 rednote 侧,在 xiaohongshu.com 的登录二维码用 rednote App 扫码后确认信号回不到会话(实测复现)。这类海外用户目前无法使用本项目。

好消息是两站共用同一套 `xhs-pc-web` 前端(CDN bundle 一致、DOM 结构同构),复用整套自动化流程的成本很低。

## 设计

| 改动 | 说明 |
|---|---|
| `xiaohongshu/site.go`(新) | 站点配置集中一处:`-site xiaohongshu\|rednote` flag,URL/登录判定选择器/locale 开关整套跟随;**默认 xiaohongshu,默认行为完全不变** |
| `xiaohongshu/locale.go`(新) | 海外站默认英文渲染,经 **CDP**(`EmulationSetLocaleOverride` + Accept-Language,非 JS 注入)强制 zh-CN,发布 TAB「上传图文」等既有中文文本选择器全部复用 |
| URL 参数化 | `feeds/feed_detail/navigate/search/publish/publish_video/user_profile` 中硬编码域名改走 `Site()` |
| cookies/seed 按站点隔离 | `GetCookiesFilePathForSite`:默认站点沿用 `GetCookiesFilePath`(含 `COOKIES_PATH`)原路径;其他站点在同目录用 `cookies-<site>.json`。指纹 seed 会话文件随之隔离,两站账号互不干扰,附单测 |
| 登录轮询化 | `Login()` 改为 1s 轮询 + 10 分钟等待窗口:rednote 无扫码弹窗入口,须在窗口中手动登录(扫码/手机验证码);国内站手机验证码流程原先单次 `MustElement` 约 40s 的窗口也常常不够。顺带简化了 `CheckLoginStatus` 中一处恒为 nil 的 `errors.Wrap(nil, ...)` 等价逻辑 |

`browser` 包经 `WithSite` Option 注入站点,避免 import cycle。

## 验证

- rednote 实测:窗口手机验证码登录 46s 完成、`check_login_status` ✅、`list_feeds` 返回个性化推荐、`publish_content` 图文发布(仅自己可见 + 全参数:标题/正文/tags/可见性)链路通过
- 默认站点:未传 `-site` 时所有路径/选择器/cookie 文件与现状逐字节一致
- `go build` / `go vet` / `go test ./...` 全部通过(含新增 `TestGetCookiesFilePathForSite`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)