### PR TITLE
fix(log): 4xx 记为 warning，并清理鉴权 PR 的遗留项

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,6 @@ COPY --from=builder /out/app .
 
 ENV HOME=/app/data/home
 ENV XDG_CONFIG_HOME=/app/data/config
-ENV AUTH_TOKEN=""
 
 EXPOSE 18060
 

--- a/handlers_api.go
+++ b/handlers_api.go
@@ -19,7 +19,13 @@ func respondError(c *gin.Context, statusCode int, code, message string, details 
 		Details: details,
 	}
 
-	logrus.Errorf("%s %s %d", c.Request.Method, c.Request.URL.Path, statusCode)
+	// 4xx 是调用方传错，5xx 才是服务端故障，用日志级别区分开。
+	// 否则鉴权开启后被扫描器打，401 会把 ERROR 刷满。
+	if statusCode < http.StatusInternalServerError {
+		logrus.Warnf("%s %s %d", c.Request.Method, c.Request.URL.Path, statusCode)
+	} else {
+		logrus.Errorf("%s %s %d", c.Request.Method, c.Request.URL.Path, statusCode)
+	}
 
 	c.JSON(statusCode, response)
 }

--- a/handlers_api_test.go
+++ b/handlers_api_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// respondError 是全仓库共用的错误出口。分级只是一行 if，改回去编译和其他单测
+// 都不会报错，但鉴权开启后被扫描器打的 401 会重新刷满 ERROR。
+func TestRespondErrorLogLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantLevel  logrus.Level
+	}{
+		{name: "401 记为 warning", statusCode: http.StatusUnauthorized, wantLevel: logrus.WarnLevel},
+		{name: "400 记为 warning", statusCode: http.StatusBadRequest, wantLevel: logrus.WarnLevel},
+		{name: "500 记为 error", statusCode: http.StatusInternalServerError, wantLevel: logrus.ErrorLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logrustest.NewGlobal()
+			defer hook.Reset()
+
+			gin.SetMode(gin.TestMode)
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/login/status", nil)
+
+			respondError(c, tt.statusCode, "CODE", "消息", nil)
+
+			require.Len(t, hook.Entries, 1)
+			assert.Equal(t, tt.wantLevel, hook.LastEntry().Level)
+		})
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -60,6 +60,8 @@ func TestAuthMiddlewareRejectsInvalidCredentials(t *testing.T) {
 		{name: "wrong scheme", authorization: "Basic secret-token"},
 		{name: "missing token", authorization: "Bearer "},
 		{name: "wrong token", authorization: "Bearer wrong-token"},
+		// 下面两个头部两侧带空格的用例只在内存态成立：真实请求经 net/textproto
+		// 解析时两侧 OWS 已被剥掉，客户端多打空格实际会放行，不会被拒。
 		{name: "leading whitespace", authorization: " Bearer secret-token"},
 		{name: "trailing whitespace", authorization: "Bearer secret-token "},
 	}


### PR DESCRIPTION
接 #803 的 review，处理当时标注为「非阻塞」的两项，外加一处测试注释。

## 1. 4xx 记为 warning，与 5xx 区分

`respondError` 是全仓库共用的错误出口，此前 **32 个调用点一律打 ERROR**（19 处 500、13 处 400）。

#803 合入后鉴权可以开启，端口被扫描时 401 会把 ERROR 刷满；更根本的问题是「调用方传错参数」和「服务端自己崩了」在日志里无法用 level 区分。

改为按状态码分级：`4xx → Warnf`，`5xx → Errorf`。

新增 `TestRespondErrorLogLevel` 锁住该行为。已做变异验证：把分级改回全 `Errorf` 时测试变红（expected WarnLevel，actual ErrorLevel），还原后通过，确认不是空转测试。

> 注意：这会改变全部 13 处 400 的日志级别。本项目未依赖 ERROR 关键字做告警，影响可控。

## 2. 移除 Dockerfile 冗余 ENV

`ENV AUTH_TOKEN=""` 与不设置该变量行为完全一致，`docker run -e` / compose 的 `${AUTH_TOKEN:-}` 同样能覆盖，属纯声明性质，删除。

## 3. 标注测试用例适用范围

`middleware_test.go` 中 `leading whitespace` / `trailing whitespace` 两个用例断言 401，但真实请求经 `net/textproto` 解析时两侧 OWS 已被剥掉——客户端多打空格实际会**放行**，这条契约真实客户端触发不到。

用裸 TCP 发真实报文验证过：

| Authorization 头 | 结果 |
|---|---|
| `Bearer secret-token` | 204 |
| `bearer secret-token`（小写 scheme） | 204 |
| `Bearer  secret-token`（两个空格） | 204 |
| ` Bearer secret-token`（前导 OWS） | **204** |
| `Bearer secret-token `（尾随 OWS） | **204** |
| `Bearer\tsecret-token`（Tab 分隔） | 401 |
| `Bearer wrong` | 401 |

用例本身没错（隔离测中间件逻辑），加注释避免后来者误读为真实契约。Tab 被拒符合 RFC 7235（scheme 与 credentials 之间是 `1*SP`）。

## 验证

- `gofmt -l` 无输出
- `go vet ./...` 通过
- `go test ./...` 全部通过
- `go.mod` / `go.sum` 未变动（logrus 的 `hooks/test` 属已有依赖）

🤖 Generated with [Claude Code](https://claude.com/claude-code)