### PR TITLE
docs: 纳管 README_EN 到 all-contributors，并修正名单与微信群二维码

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,7 @@
 {
   "files": [
-    "README.md"
+    "README.md",
+    "README_EN.md"
   ],
   "imageSize": 100,
   "commit": false,
@@ -185,7 +186,7 @@
       ]
     },
     {
-      "login": "triepod-ai",
+      "login": "bryankthompson",
       "name": "Bryan Thompson",
       "avatar_url": "https://avatars.githubusercontent.com/u/199543909?v=4",
       "profile": "https://triepod.ai",
@@ -266,6 +267,15 @@
       "name": "qiuxsgit",
       "avatar_url": "https://avatars.githubusercontent.com/u/15036686?v=4",
       "profile": "https://github.com/qiuxsgit",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ZhuYichuan",
+      "name": "openlts",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7954801?v=4",
+      "profile": "https://github.com/ZhuYichuan",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # xiaohongshu-mcp
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-28-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![善款已捐](https://img.shields.io/badge/善款已捐-CNY%201810.00-brightgreen?style=flat-square)](./DONATIONS.md)
@@ -1081,7 +1081,7 @@ npx mcporter list xiaohongshu-mcp
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ctrlz526"><img src="https://avatars.githubusercontent.com/u/143257420?v=4?s=100" width="100px;" alt="Ctrlz"/><br /><sub><b>Ctrlz</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=ctrlz526" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/flippancy"><img src="https://avatars.githubusercontent.com/u/6467703?v=4?s=100" width="100px;" alt="flippancy"/><br /><sub><b>flippancy</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=flippancy" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Infinityay"><img src="https://avatars.githubusercontent.com/u/103165980?v=4?s=100" width="100px;" alt="Yuhang Lu"/><br /><sub><b>Yuhang Lu</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=Infinityay" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://triepod.ai"><img src="https://avatars.githubusercontent.com/u/199543909?v=4?s=100" width="100px;" alt="Bryan Thompson"/><br /><sub><b>Bryan Thompson</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=triepod-ai" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://triepod.ai"><img src="https://avatars.githubusercontent.com/u/199543909?v=4?s=100" width="100px;" alt="Bryan Thompson"/><br /><sub><b>Bryan Thompson</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=bryankthompson" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://www.megvii.com"><img src="https://avatars.githubusercontent.com/u/7806992?v=4?s=100" width="100px;" alt="tan jun"/><br /><sub><b>tan jun</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=tanxxjun321" title="Code">💻</a></td>
     </tr>
     <tr>
@@ -1092,6 +1092,9 @@ npx mcporter list xiaohongshu-mcp
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/prehisle"><img src="https://avatars.githubusercontent.com/u/2081344?v=4?s=100" width="100px;" alt="prehisle"/><br /><sub><b>prehisle</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=prehisle" title="Code">💻</a> <a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=prehisle" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/blablabiu"><img src="https://avatars.githubusercontent.com/u/123888078?v=4?s=100" width="100px;" alt="Xinhao Chen"/><br /><sub><b>Xinhao Chen</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=blablabiu" title="Code">💻</a> <a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=blablabiu" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/qiuxsgit"><img src="https://avatars.githubusercontent.com/u/15036686?v=4?s=100" width="100px;" alt="qiuxsgit"/><br /><sub><b>qiuxsgit</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=qiuxsgit" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ZhuYichuan"><img src="https://avatars.githubusercontent.com/u/7954801?v=4?s=100" width="100px;" alt="openlts"/><br /><sub><b>openlts</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=ZhuYichuan" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,9 +1,7 @@
 # xiaohongshu-mcp
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
-[![All Contributors](https://img.shields.io/badge/all_contributors-27-orange.svg?style=flat-square)](#contributors-)
-
+[![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![Philanthropy](https://img.shields.io/badge/Philanthropy-CNY%201810.00-brightgreen?style=flat-square)](./DONATIONS.md)
@@ -1088,7 +1086,7 @@ Thanks to all friends who have contributed to this project! (In no particular or
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ctrlz526"><img src="https://avatars.githubusercontent.com/u/143257420?v=4?s=100" width="100px;" alt="Ctrlz"/><br /><sub><b>Ctrlz</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=ctrlz526" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/flippancy"><img src="https://avatars.githubusercontent.com/u/6467703?v=4?s=100" width="100px;" alt="flippancy"/><br /><sub><b>flippancy</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=flippancy" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Infinityay"><img src="https://avatars.githubusercontent.com/u/103165980?v=4?s=100" width="100px;" alt="Yuhang Lu"/><br /><sub><b>Yuhang Lu</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=Infinityay" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://triepod.ai"><img src="https://avatars.githubusercontent.com/u/199543909?v=4?s=100" width="100px;" alt="Bryan Thompson"/><br /><sub><b>Bryan Thompson</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=triepod-ai" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://triepod.ai"><img src="https://avatars.githubusercontent.com/u/199543909?v=4?s=100" width="100px;" alt="Bryan Thompson"/><br /><sub><b>Bryan Thompson</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=bryankthompson" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://www.megvii.com"><img src="https://avatars.githubusercontent.com/u/7806992?v=4?s=100" width="100px;" alt="tan jun"/><br /><sub><b>tan jun</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=tanxxjun321" title="Code">💻</a></td>
     </tr>
     <tr>
@@ -1098,6 +1096,10 @@ Thanks to all friends who have contributed to this project! (In no particular or
       <td align="center" valign="top" width="14.28%"><a href="https://www.hnfnu.edu.cn/"><img src="https://avatars.githubusercontent.com/u/134906805?v=4?s=100" width="100px;" alt="e0_7"/><br /><sub><b>e0_7</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=Daily-AC" title="Code">💻</a> <a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=Daily-AC" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/prehisle"><img src="https://avatars.githubusercontent.com/u/2081344?v=4?s=100" width="100px;" alt="prehisle"/><br /><sub><b>prehisle</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=prehisle" title="Code">💻</a> <a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=prehisle" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/blablabiu"><img src="https://avatars.githubusercontent.com/u/123888078?v=4?s=100" width="100px;" alt="Xinhao Chen"/><br /><sub><b>Xinhao Chen</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=blablabiu" title="Code">💻</a> <a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=blablabiu" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/qiuxsgit"><img src="https://avatars.githubusercontent.com/u/15036686?v=4?s=100" width="100px;" alt="qiuxsgit"/><br /><sub><b>qiuxsgit</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=qiuxsgit" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ZhuYichuan"><img src="https://avatars.githubusercontent.com/u/7954801?v=4?s=100" width="100px;" alt="openlts"/><br /><sub><b>openlts</b></sub></a><br /><a href="https://github.com/xpzouying/xiaohongshu-mcp/commits?author=ZhuYichuan" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/README_EN.md
+++ b/README_EN.md
@@ -1038,9 +1038,9 @@ If you do not specifically need OpenClaw, we strongly recommend switching to a c
 
 > These are Chinese-language community groups — discussion in the groups is in Chinese.
 
-|                                                 WeChat Group 24                                     |                                                 WeChat Group 25                                      |
+|                                                 WeChat Group 25                                     |                                                 WeChat Group 26                                      |
 | :------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------: |
-| <img src="https://github.com/user-attachments/assets/918a48d5-1d3c-40ce-b225-4af0d77078db" alt="WechatIMG119" width="300"> | <img src="https://github.com/user-attachments/assets/c49ad483-0f27-46f3-a6a7-31b3ba31540f" alt="WechatIMG119" width="300">|
+| <img src="https://github.com/user-attachments/assets/c4c0f7a0-fc7c-453a-8bb9-890e53a907d4" alt="WechatIMG119" width="300"> | <img src="https://github.com/user-attachments/assets/e9569332-cac5-4e9e-92d8-c1498ef8699b" alt="WechatIMG119" width="300">|
 
 ### Feishu (Lark) Groups
 


### PR DESCRIPTION
起因：#804（all-contributors 机器人为 @qiuxsgit 建的 PR）只更新了 `README.md`，`README_EN.md` 没被同步。顺着这条线做了一次完整审计。

## 1. 根因：机器人只纳管了一个文件

`.all-contributorsrc` 里 `"files": ["README.md"]` —— 不在这个数组里的文件**永远不会被重写**，所以英文版一直在漂移，badge 已经差到 28 vs 27。

补一次是治标，这里把 `README_EN.md` 加进 `files`，之后再加贡献者两边会自动同步。该文件本来就有 `ALL-CONTRIBUTORS-LIST` 标记，机器人能找到插入点。

表格由官方 CLI（`all-contributors-cli@6 generate`）重新生成，未手写。

## 2. 修正一条失效 login：`triepod-ai` → `bryankthompson`

审计时发现名单里这条记录已经指错人了：

| | login | 数字 ID |
|---|---|---|
| rc 记录 | `triepod-ai` | avatar 用的是 `199543909` |
| 当前 `199543909` | **`bryankthompson`**（name: Bryan Thompson, blog: triepod.ai） | — |
| 当前 `triepod-ai` | 另一个账号，id `315501253`，0 个已合并 PR | — |

即：原账号改名为 `bryankthompson`，腾出的旧用户名被**无关的人抢注**。名单里 `commits?author=triepod-ai` 的链接现在指向一个陌生人。

> all-contributors 同时存了可变的 `login` 和不可变的数字 ID（藏在 `avatar_url` 里），两者会随改名脱钩。我按数字 ID 回查了全部 28 条，**只有这一条**不一致。

## 3. 补充遗漏贡献者：@ZhuYichuan（openlts）

PR #666「修复发布图文时找不到上传TAB的问题」，+36/-1，此前未入名单。

审计方式与排除项：

| 身份 | 结论 |
|---|---|
| `chekayo`（22 个提交，gitee 邮箱） | 其提交经 #207/#301/#322 由 **@haikow** 的 PR 合入，同一人，已在名单 |
| `liangzx` | = `yqdaddy`，已在名单 |
| `tanjun` | = `tanxxjun321`，已在名单 |
| `Claude` | AI 署名，非贡献者 |
| `ubbcou` | **见下方待确认** |

## 4. 同步微信群二维码（英文版落后两轮）

`8f2d489`、`da9ba03` 两次更新只改了 `README.md`，`README_EN.md` 仍停在 24/25 群，旧二维码可能已满或过期。已同步为 25/26 群。

保留了英文版特有的那句 `> These are Chinese-language community groups...`。

## 其余差异核对结果

- 章节结构：两边各 61 个标题，编号序列完全一致 ✅
- 代码块：各 70 个 ✅
- 捐赠金额：1810.00 / 1524.64 一致 ✅
- 仅剩差异是 badge 的本地化文案（善款已捐/爱心汇聚 ↔ Philanthropy/Gratitude），属正常翻译

## ⚠️ 需要你确认：@ubbcou 是否要加

PR #530「feat: improve publish page readiness check before clicking tab」标记为 merged，但：

- `commits` 数为 **0**
- `merge_commit_sha` 指向的是 **另一个 PR**（#538 的赞赏记录更新）
- 主干历史里搜不到对应改动

典型的 fork 端 main 被 force-push 后 GitHub 丢失提交记录。**内容实际没有落到主干**，所以本 PR 没有加入。如果你记得这个贡献确有其事，告诉我，我补上。