### PR TITLE
fix(ci): 关闭 provenance/sbom，修复阿里云 ACR 推送失败

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -66,3 +66,8 @@ jobs:
           crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        # BuildKit v0.32 起默认附加 provenance / sbom 证明，其空配置描述符用
+        # application/vnd.oci.empty.v1+json，阿里云个人版 ACR 不认这个媒体类型，
+        # 会在推送时 denied。项目没用到这些证明，直接关掉。
+        provenance: false
+        sbom: false


### PR DESCRIPTION
v2.5.0 发版时 `Docker Release` 流水线失败。**Docker Hub 推送成功，阿里云 ACR 失败**，导致走阿里云镜像的国内用户拉不到 v2.5.0。

## 报错

```
#27 pushing manifest for crpi-....cn-beijing.personal.cr.aliyuncs.com/xpzouying/xiaohongshu-mcp:v2.5.0
#27 ERROR: failed to push ...: denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

## 原因：环境漂移，不是代码变更

v2.4.3 及之前 8 次发版全部成功，本 workflow 一个字没改过。变的是 GitHub runner 上的 BuildKit：

| | v2.4.3（2026-08-02 成功） | v2.5.0（2026-08-13 失败） |
|---|---|---|
| BuildKit | **v0.31.2** | **v0.32.2** |
| buildx | — | v0.35.0 |

workflow 用的是浮动版本 `docker/setup-buildx-action@v3`，BuildKit 在这 11 天里自动升了级。新版**默认给镜像附加 provenance / sbom 证明**，这类附件的空配置描述符使用 `application/vnd.oci.empty.v1+json` 媒体类型 —— Docker Hub 支持，**阿里云个人版 ACR 不支持**，直接 denied。

同一次构建推两个仓库，所以出现一半成功一半失败。

## 修复

在构建步骤显式关闭这两项证明：

```yaml
provenance: false
sbom: false
```

这是官方推荐的注册表兼容做法。代价是镜像不再携带构建来源证明 —— 本项目未使用。

## 合并后的补救

**不需要重新打 tag。** 用 `workflow_dispatch` 手动触发 `Docker Release` 并传入 `v2.5.0` 即可补推阿里云。Docker Hub 上已存在的 v2.5.0 / latest 会以相同内容重新推送，无副作用。

## 当前受影响范围

| 产物 | 状态 |
|---|---|
| GitHub Release v2.5.0 | ✅ 已发布 |
| Docker Hub `v2.5.0` / `latest` | ✅ 已推送（digest `sha256:4c10bd38…`） |
| 阿里云 ACR | ❌ 仍停在 v2.4.3，待本 PR 合并后补推 |

> 附带发现：日志里有 `Node 20 is being deprecated` 警告，几个 action 后续需要升级。本 PR 不处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)