### PR TITLE
ci: 升级 Actions 至 node24 运行时，消除 Node 20 弃用警告

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     # tag 触发时版本号取自 tag 本身；手动触发时取输入参数
     - name: Resolve version
@@ -34,16 +34,16 @@ jobs:
         fi
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: xpzouying
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Log in to Aliyun Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: crpi-hocnvtkomt7w9v8t.cn-beijing.personal.cr.aliyuncs.com
         username: ${{ secrets.ALIYUN_REGISTRY_USERNAME }}
@@ -51,7 +51,7 @@ jobs:
 
     # 一次构建，同时推送 Docker Hub 和阿里云
     - name: Build and push Docker image (AMD64)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'xpzouying/xiaohongshu-mcp'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: xpzouying/star-history@v1
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
         echo "Version $VERSION is valid"
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v7
       with:
         go-version: '1.24'
 
@@ -107,7 +107,7 @@ jobs:
         } >> $GITHUB_OUTPUT
 
     - name: Create tag and release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.version.outputs.version }}
         name: Release ${{ steps.version.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.24"
           cache: true

--- a/.github/workflows/update-browser.yml
+++ b/.github/workflows/update-browser.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'xpzouying/xiaohongshu-mcp'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: 检测最新版本（读 CDN latest 指针）
         id: check


### PR DESCRIPTION
Closes #808

## 背景

所有 workflow 日志里都带着这条警告：

```
Node 20 is being deprecated. This workflow is running with Node 24 by default.
```

这不是"我们的版本过期"，而是**运行时**过期：JS 类型的 action 在 `action.yml` 里用 `runs.using` 声明需要的 Node 版本，GitHub 已经在强制用 Node 24 运行声明了 node20 的 action。目前"能跑但有警告"，风险在于 action 代码按 Node 20 打包却在 Node 24 上执行。

## 改动

| Action | 前 | 后 | 说明 |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | 5 处 |
| `actions/setup-go` | v5 | **v7** | test.yml |
| `actions/setup-go` | **v4** | **v7** | tag-release.yml，原本是 **node16** |
| `docker/login-action` | v3 | **v4** | 2 处 |
| `docker/setup-buildx-action` | v3 | **v4** | |
| `docker/build-push-action` | v5 | **v7** | v6 仍是 node20，必须跳到 v7 |
| `softprops/action-gh-release` | **v1** | **v3** | 原本 node16；v2 仍是 node20 |

六个目标版本均已拉取各自 `action.yml` 确认为 `using: node24`。

## 破坏性变更评估

逐个查过 release notes，对本仓库均无影响：

- **`actions/checkout` v7** — 阻止 `pull_request_target` / `workflow_run` 检出 fork PR。已核对本仓库全部 5 个 workflow 的触发器，只用到 `push` / `pull_request` / `schedule` / `workflow_dispatch`，**未使用这两个触发器**
- **`docker/setup-buildx-action` v4** — 移除废弃输入。本仓库裸用无参数
- **`docker/build-push-action` v6** — 新增 build summary（可用 `DOCKER_BUILD_SUMMARY: false` 关闭），无害
- 其余均为 node24 迁移 + ESM 化

五个 workflow 文件已验证 YAML 可正常解析。

## ⚠️ 验证范围与残留风险

- ✅ `test.yml` 会在本 PR 上运行，覆盖 `checkout@v7` + `setup-go@v7`
- ✅ `docker-release.yml` 可在合并后用 `workflow_dispatch` 手动验证
- ⚠️ **`tag-release.yml` 无法在合并前验证** —— 它只有打 tag 才触发，且 `workflow_dispatch` 会真的创建 Release。其中的 `setup-go@v7` 与 `action-gh-release@v3` 要等下次发版才能确认。考虑到 v1→v3 跨了两个大版本，下次发版时需留意 Release 是否正常创建

## 需在另一个仓库处理

`xpzouying/star-history@v1` 本身是 `composite`（不受 Node 运行时影响），但内部调用了 `actions/setup-go@v5`（node20）。本 PR 修不了，需要在 [xpzouying/star-history](https://github.com/xpzouying/star-history) 里一并升级，否则 `star-history.yml` 仍会出现该警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)