### PR TITLE
fix(login): 二维码等待加超时，避免页面结构对不上时无声挂死

### DIFF
--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -9,6 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// 等二维码渲染的上限。扫码本身的等待在 WaitForLogin 里，不受这个限制。
+const qrcodeWaitTimeout = 20 * time.Second
+
 type LoginAction struct {
 	page *rod.Page
 }
@@ -99,7 +102,14 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 		return "", true, nil
 	}
 
-	src, err := pp.MustElement(".login-container .qrcode-img").Attribute("src")
+	// 带超时地等二维码：等不到就报错。MustElement 无限期等待，
+	// 页面结构对不上时会无声挂死——不报错、不超时、日志也没有。
+	el, err := pp.Timeout(qrcodeWaitTimeout).Element(".login-container .qrcode-img")
+	if err != nil {
+		return "", false, errors.Wrap(err, "qrcode element not found")
+	}
+
+	src, err := el.Attribute("src")
 	if err != nil {
 		return "", false, errors.Wrap(err, "get qrcode src failed")
 	}


### PR DESCRIPTION
## 问题

`FetchQrcodeImage` 用 `MustElement` 取二维码：

```go
src, err := pp.MustElement(".login-container .qrcode-img").Attribute("src")
```

`MustElement` 是**无限期等待**。当页面结构与选择器对不上时（登录页改版、或用户被重定向到别的站点），调用方会永远卡在这里 —— 不报错、不超时、日志里也看不出任何异常，表现为「点了登录没有任何反应」。

我在海外域名（rednote.com）下踩到了这个：该站点首页不会自动弹出二维码，`.login-container .qrcode-img` 永远不出现，`get_login_qrcode` 就一直挂着，排查了很久才定位到。域名问题本身不在这个 PR 的范围内，但**「无声挂死」这个行为本身值得修**——不管什么原因导致元素不出现，都应该报错而不是静默卡住。

## 改动

改为带 20 秒超时的 `Element`，等不到返回明确错误：

```go
el, err := pp.Timeout(qrcodeWaitTimeout).Element(".login-container .qrcode-img")
if err != nil {
    return "", false, errors.Wrap(err, "qrcode element not found")
}
```

- 只影响**失败路径**：正常情况下二维码几秒内就渲染出来，行为完全不变
- 扫码本身的等待仍在 `WaitForLogin` 里，**不受这个超时限制**（不会影响用户慢慢扫码）
- `CheckLoginStatus` 已经有类似的超时保护（`pp := a.page.Context(ctx).Timeout(30 * time.Second)`），这里补上同样的处理，保持一致

## 测试

`go build ./...` / `go vet ./...` / `go test ./xiaohongshu/...` 均通过。

需要说明的是：**我人在海外，`www.xiaohongshu.com` 从我的网络访问会被边缘节点拦截（404），所以无法在原站上做端到端验证。** 这个改动不改变成功路径的任何行为，只是把「永远卡住」换成「20 秒后报错」，风险应该可控，但还请 maintainer 按需复核。
