### PR TITLE
fix(feed): 视频帖详情页不再等 DOM 稳定，避免详情/点赞/评论卡死

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,12 @@ go.work.sum
 # .vscode/
 .claude/
 
+# macOS
+.DS_Store
+
 # Build artifacts
 xiaohongshu-mcp
+bin/
 
 # Test scripts
 test_*.sh

--- a/deploy/macos/xhsmcp.local.plist
+++ b/deploy/macos/xhsmcp.local.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>xhsmcp</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Volumes/Extreme SSD/R40_MCP-servers-ExSSD-fork/xiaohongshu-mcp/bin/xiaohongshu-mcp</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Volumes/Extreme SSD/R40_MCP-servers-ExSSD-fork/xiaohongshu-mcp</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/xhsmcp.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/xhsmcp.err</string>
+</dict>
+</plist>

--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -30,7 +30,7 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 
 	// 导航到详情页
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	waitFeedPageReady(page)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	// 检测页面是否可访问
@@ -120,7 +120,7 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 
 	// 导航到详情页
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	waitFeedPageReady(page)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	// 检测页面是否可访问

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -109,7 +109,7 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	err := retry.Do(
 		func() error {
 			page.MustNavigate(url)
-			page.MustWaitDOMStable()
+			waitFeedPageReady(page)
 			return nil
 		},
 		retry.Attempts(3),

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -49,7 +49,7 @@ func (a *interactAction) preparePage(ctx context.Context, actionType interactAct
 	logrus.Infof("Opening feed detail page for %s: %s", actionType, url)
 
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	waitFeedPageReady(page)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	return page

--- a/xiaohongshu/page_ready.go
+++ b/xiaohongshu/page_ready.go
@@ -1,0 +1,56 @@
+package xiaohongshu
+
+import (
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// feedReadyTimeout 等待详情页出结果的上限。
+//
+// 定这么短是因为等待从 load 事件之后才开始，只覆盖 SPA 的水合延迟：实测正常笔记
+// （含视频帖）在 load 那一刻容器就已存在，等待接近零成本。而笔记不存在时页面既不
+// 渲染下面任何一个容器、又会在几秒后跳回首页信息流（首页容器正常笔记页上也有，
+// 没法拿来区分），只能靠超时兜底——这个上限直接决定失效笔记要白等多久，
+// 放大到十几秒就会比改动前更慢。超时不算失败，交给后续选择器自己轮询。
+const feedReadyTimeout = 8 * time.Second
+
+// feedReadySelectors 详情页导航完成的判据。
+// 前两个是正常笔记的内容容器（点赞收藏栏 / 笔记滚动容器）；后四个是
+// checkPageAccessible 认的错误容器，笔记私密或违规时出现，一并等上是为了这类
+// 情况不用等满 feedReadyTimeout。具体是哪种由随后的 checkPageAccessible 判定，
+// 这里只负责「页面有结果了」。
+const feedReadySelectors = ".interact-container, .note-scroller, " +
+	".access-wrapper, .error-wrapper, .not-found-wrapper, .blocked-wrapper"
+
+// waitFeedPageReady 等待 feed 详情页可用。
+//
+// 背景：视频帖的播放器（进度条等 UI）会持续改动 DOM，导致 rod 的
+// MustWaitDOMStable 在超时内永远等不到「DOM 稳定」，点赞/评论/详情全部卡死
+// （2026-08-12 实测：图文帖正常，所有视频帖 MustWaitDOMStable 60s 超时）。
+// 这里改为等 load 事件 + 轮询关键容器，不再要求整页 DOM 静止。
+func waitFeedPageReady(page *rod.Page) {
+	page.MustWaitLoad()
+
+	if _, err := page.Timeout(feedReadyTimeout).Element(feedReadySelectors); err != nil {
+		// 没等到不代表页面不可用，后续 Element 各自带轮询，继续往下走。
+		// 用 Warn 不用 Debug：本项目没配日志级别，Debug 打不出来，
+		// 而这是排查「页面结构变了」的第一手线索，丢了就只剩后面一串莫名的超时。
+		logrus.Warnf("详情页关键容器未在 %s 内出现，继续尝试: %v", feedReadyTimeout, err)
+	}
+
+	pauseVideos(page)
+}
+
+// pauseVideos 暂停页面内所有视频并关掉自动播放，减少播放器造成的持续 DOM 变动。
+// go-rod 没有对应原语，只能走 Eval；图文帖没有 video，等同空操作。
+func pauseVideos(page *rod.Page) {
+	_, _ = page.Eval(`() => {
+		document.querySelectorAll('video').forEach(v => {
+			try { v.pause(); } catch (e) {}
+			v.autoplay = false;
+			v.muted = true;
+		});
+	}`)
+}


### PR DESCRIPTION
## 问题

视频帖的播放器（进度条等 UI）会持续改动 DOM，`page.MustWaitDOMStable()` 在超时窗口内等不到「DOM 稳定」。四处导航到笔记详情页的调用都踩到这个问题：

- `feed_detail.go` 的 page timeout 是 10 分钟，于是一路熬到播放器碰巧安静下来才返回；
- `like_favorite.go`（60s）、`comment_feed.go`（60s / 5min）到点直接失败。

结果就是详情、点赞、收藏、评论、回复在**所有视频帖**上都不可用，图文帖正常。

## 改动

新增 `xiaohongshu/page_ready.go` 的 `waitFeedPageReady()`，顶替这四处 `MustWaitDOMStable()`：

1. 等 `load` 事件；
2. 轮询关键容器，不再要求整页 DOM 静止；
3. 暂停页面内视频，减少后续操作期间的 DOM 抖动。

判据取「正常笔记的内容容器」与「`checkPageAccessible` 认的错误容器」，先出现哪个算哪个：

```
.interact-container, .note-scroller,                                    ← 正常笔记
.access-wrapper, .error-wrapper, .not-found-wrapper, .blocked-wrapper   ← 私密/违规笔记
```

只等成功容器的话，笔记私密或违规时会每次白等满超时。具体是哪一种不在这里判，仍交给原有的 `checkPageAccessible`。等不到也不算失败，只记一条 warning 继续走——后续 `Element` 各自带轮询兜底。

## 实测

同账号、同机器、同一批 feed，改动前后对照：

| 用例 | 改动前 | 改动后 |
|---|---|---|
| 视频帖详情 | **239.4s** | **5.9s** |
| 视频帖详情（另一条） | — | 6.0s |
| 图文帖详情 | — | 6.8s |
| 视频帖点赞路径 | 60s 超时失败 | 5.2s |
| 视频帖收藏路径 | 60s 超时失败 | 5.4s |
| 笔记不存在 | 13.0s | 14.3s |

点赞/收藏是用空操作验证的：对未点赞的笔记调 `unlike`，代码读到状态一致会跳过点击（日志确认走 `skip clicking`），导航和等待完整执行，不产生真实互动。

`gofmt` / `go build ./...` / `go vet ./...` / 测试包编译均通过。

## 两处实测得到的取舍，供 review 参考

**超时定 8s 而不是更长。** 笔记不存在时，页面既不渲染上面任何一个容器，又会在 ~4.4s 后跳回首页信息流；而首页容器（`div#mfContainer.feeds-page`）在正常笔记页上同样存在——详情是盖在信息流之上的浮层——所以没法拿来区分。这类请求只能靠超时兜底，超时上限直接等于失效笔记要白等多久。先前试过 15s，实测让失效笔记从 13.0s 变成 20.9s，比改动前更慢；收到 8s 后是 14.3s，与改动前持平。正常笔记（含视频帖）的容器在 `load` 那一刻就已存在，8s 是纯余量。

**关于 `pauseVideos` 里的 `page.Eval`。** 项目倾向用 go-rod 原生行为替代 JS 注入，这里是例外：暂停 `<video>`、关掉 `autoplay` 没有对应的 go-rod 原语，只能走 `Eval`。注入范围限定在这一件事上，图文帖没有 `video` 元素时等同空操作。等待逻辑本身已全部用 go-rod 的选择器轮询，没有用 JS 实现。

## 另外

本 PR 顺带含一个 `.gitignore` 提交（忽略 `bin/` 与 macOS `.DS_Store`）。如果觉得与主题无关，我可以拆掉。
