### PR TITLE
fix: bound fragile tag and image upload waits

### DIFF
--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -38,6 +38,9 @@ const (
 
 	// contentElemTimeout 查找正文输入框的轮询窗口
 	contentElemTimeout = 10 * time.Second
+	// 上传一张图片后，页面会短暂重建 file input。下一张图必须等待新节点出现。
+	imageUploadInputTimeout      = 10 * time.Second
+	imageUploadInputPollInterval = 200 * time.Millisecond
 
 	// 标签联想是可选能力，不能耗尽整个发布流程的 300 秒超时。
 	tagSuggestionTimeout      = 6 * time.Second
@@ -254,11 +257,13 @@ func uploadImages(page *rod.Page, imagesPaths []string) error {
 
 	// 逐张上传：每张上传后等待预览出现，再上传下一张
 	for i, path := range validPaths {
-		uploadInput, err := findImageUploadInput(page, i == 0)
+		err := retryImageUploadInput(
+			page.GetContext(),
+			imageUploadInputTimeout,
+			func() (*rod.Element, error) { return findImageUploadInput(page, i == 0) },
+			func(input *rod.Element) error { return input.SetFiles([]string{path}) },
+		)
 		if err != nil {
-			return errors.Wrapf(err, "查找上传输入框失败(第%d张)", i+1)
-		}
-		if err := uploadInput.SetFiles([]string{path}); err != nil {
 			return errors.Wrapf(err, "上传第%d张图片失败", i+1)
 		}
 
@@ -277,7 +282,11 @@ func uploadImages(page *rod.Page, imagesPaths []string) error {
 // findImageUploadInput 查找图片上传的输入框
 func findImageUploadInput(page *rod.Page, first bool) (*rod.Element, error) {
 	if first {
-		return page.Element(".upload-input")
+		inputs, err := page.Elements(".upload-input")
+		if err != nil || len(inputs) == 0 {
+			return nil, err
+		}
+		return inputs[0], nil
 	}
 
 	inputs, err := page.Elements(`input[type="file"]`)
@@ -285,7 +294,7 @@ func findImageUploadInput(page *rod.Page, first bool) (*rod.Element, error) {
 		return nil, err
 	}
 	if len(inputs) == 0 {
-		return nil, errors.New("页面没有文件上传输入框")
+		return nil, nil
 	}
 
 	for _, input := range inputs {
@@ -299,6 +308,44 @@ func findImageUploadInput(page *rod.Page, first bool) (*rod.Element, error) {
 	}
 
 	return inputs[0], nil
+}
+
+func retryImageUploadInput(
+	ctx context.Context,
+	timeout time.Duration,
+	lookup func() (*rod.Element, error),
+	setFile func(*rod.Element) error,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		input, err := lookup()
+		if err != nil {
+			lastErr = err
+		} else if input != nil {
+			if err := setFile(input); err == nil {
+				return nil
+			} else {
+				lastErr = err
+			}
+		}
+
+		timer := time.NewTimer(imageUploadInputPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return ctx.Err()
+			}
+			if lastErr != nil {
+				return errors.Wrap(lastErr, "等待图片上传输入框超时")
+			}
+			return errors.New("等待图片上传输入框超时")
+		case <-timer.C:
+		}
+	}
 }
 
 // acceptsImage 判断 accept 属性是否接受图片

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -761,8 +761,7 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 	slog.Info("成功点击标签联想选项", "tag", tag)
 
 	waitForTagMenuClose(ctx, page, tagMenuCloseTimeout)
-	time.Sleep(time.Duration(1500+rand.Intn(1501)) * time.Millisecond)
-	return nil
+	return waitWithContext(ctx, time.Duration(1500+rand.Intn(1501))*time.Millisecond)
 }
 
 func findMatchingTagSuggestion(ctx context.Context, page *rod.Page, tag string) (*rod.Element, error) {
@@ -878,6 +877,18 @@ func restoreTextAfterFailedTag(
 		}
 	}
 	return errors.New("清理无联想标签后正文未恢复")
+}
+
+func waitWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func waitForTagMenuClose(ctx context.Context, page *rod.Page, timeout time.Duration) {

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -38,6 +38,11 @@ const (
 
 	// contentElemTimeout 查找正文输入框的轮询窗口
 	contentElemTimeout = 10 * time.Second
+
+	// 标签联想是可选能力，不能耗尽整个发布流程的 300 秒超时。
+	tagSuggestionTimeout      = 6 * time.Second
+	tagSuggestionPollInterval = 200 * time.Millisecond
+	tagMenuCloseTimeout       = 2 * time.Second
 )
 
 func NewPublishImageAction(page *rod.Page) (*PublishAction, error) {
@@ -732,27 +737,116 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 		return errors.Wrap(err, "输入标签内容失败")
 	}
 
-	time.Sleep(1 * time.Second) // 技术等待：等联想结果刷新
-
 	page := contentElem.Page()
-	topicContainer, err := page.Element("#creator-editor-topic-container")
-	if err != nil || topicContainer == nil {
-		slog.Warn("未找到标签联想下拉框，直接输入空格", "tag", tag)
-		return humanize.Type(ctx, contentElem, " ")
+	lookup := func(tagCtx context.Context) (*rod.Element, error) {
+		has, item, err := page.Context(tagCtx).Has("#creator-editor-topic-container .item")
+		if err != nil {
+			return nil, errors.Wrap(err, "查找标签联想选项失败")
+		}
+		if !has || item == nil || !isElementVisible(item) {
+			return nil, nil
+		}
+		return item, nil
 	}
 
-	firstItem, err := topicContainer.Element(".item")
-	if err != nil || firstItem == nil {
-		slog.Warn("未找到标签联想选项，直接输入空格", "tag", tag)
-		return humanize.Type(ctx, contentElem, " ")
+	selected, err := selectTagSuggestion(ctx, tagSuggestionTimeout, lookup, func(item *rod.Element) error {
+		return humanize.Click(item)
+	})
+	if err != nil {
+		return err
+	}
+	if !selected {
+		slog.Warn("未找到标签联想选项，跳过该标签", "tag", tag)
+		return removeTypedTag(ctx, contentElem, tag)
 	}
 
-	if err := humanize.Click(firstItem); err != nil {
-		return errors.Wrap(err, "点击标签联想选项失败")
-	}
 	slog.Info("成功点击标签联想选项", "tag", tag)
-	time.Sleep(500 * time.Millisecond) // 技术等待：等标签处理完成
+
+	waitForTagMenuClose(ctx, page, tagMenuCloseTimeout)
+	time.Sleep(time.Duration(1500+rand.Intn(1501)) * time.Millisecond)
 	return nil
+}
+
+func selectTagSuggestion(
+	ctx context.Context,
+	timeout time.Duration,
+	lookup func(context.Context) (*rod.Element, error),
+	click func(*rod.Element) error,
+) (bool, error) {
+	tagCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(tagSuggestionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		item, err := lookup(tagCtx)
+		if err != nil {
+			if tagCtx.Err() != nil {
+				if parentErr := ctx.Err(); parentErr != nil {
+					return false, parentErr
+				}
+				return false, nil
+			}
+			return false, err
+		}
+		if item != nil {
+			if err := click(item.Context(tagCtx)); err == nil {
+				return true, nil
+			} else {
+				slog.Debug("标签联想选项已失效，重新查找", "error", err)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-tagCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			return false, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+func removeTypedTag(ctx context.Context, contentElem *rod.Element, tag string) error {
+	ka, err := contentElem.Context(ctx).KeyActions()
+	if err != nil {
+		return errors.Wrap(err, "创建标签清理键盘操作失败")
+	}
+	for range "#" + tag {
+		ka.Type(input.Backspace)
+	}
+	if err := ka.Do(); err != nil {
+		return errors.Wrap(err, "清理无联想标签失败")
+	}
+	return nil
+}
+
+func waitForTagMenuClose(ctx context.Context, page *rod.Page, timeout time.Duration) {
+	menuCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(tagSuggestionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		has, item, err := page.Context(menuCtx).Has("#creator-editor-topic-container .item")
+		if err != nil || !has || item == nil || !isElementVisible(item) {
+			return
+		}
+
+		select {
+		case <-menuCtx.Done():
+			if ctx.Err() == nil {
+				slog.Warn("标签联想下拉框未及时关闭")
+			}
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func findTextboxByPlaceholder(page *rod.Page) (*rod.Element, error) {

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -727,6 +727,11 @@ func inputTags(ctx context.Context, contentElem *rod.Element, tags []string) err
 }
 
 func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
+	beforeText, err := contentElem.Text()
+	if err != nil {
+		return errors.Wrap(err, "记录标签输入前正文失败")
+	}
+
 	// 输入 # 触发话题联想
 	if err := humanize.Type(ctx, contentElem, "#"); err != nil {
 		return errors.Wrap(err, "输入#失败")
@@ -739,14 +744,7 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 
 	page := contentElem.Page()
 	lookup := func(tagCtx context.Context) (*rod.Element, error) {
-		has, item, err := page.Context(tagCtx).Has("#creator-editor-topic-container .item")
-		if err != nil {
-			return nil, errors.Wrap(err, "查找标签联想选项失败")
-		}
-		if !has || item == nil || !isElementVisible(item) {
-			return nil, nil
-		}
-		return item, nil
+		return findMatchingTagSuggestion(tagCtx, page, tag)
 	}
 
 	selected, err := selectTagSuggestion(ctx, tagSuggestionTimeout, lookup, func(item *rod.Element) error {
@@ -757,7 +755,7 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 	}
 	if !selected {
 		slog.Warn("未找到标签联想选项，跳过该标签", "tag", tag)
-		return removeTypedTag(ctx, contentElem, tag)
+		return removeTypedTag(ctx, contentElem, beforeText, tag)
 	}
 
 	slog.Info("成功点击标签联想选项", "tag", tag)
@@ -765,6 +763,31 @@ func inputTag(ctx context.Context, contentElem *rod.Element, tag string) error {
 	waitForTagMenuClose(ctx, page, tagMenuCloseTimeout)
 	time.Sleep(time.Duration(1500+rand.Intn(1501)) * time.Millisecond)
 	return nil
+}
+
+func findMatchingTagSuggestion(ctx context.Context, page *rod.Page, tag string) (*rod.Element, error) {
+	names, err := page.Context(ctx).Elements("#creator-editor-topic-container .item .name")
+	if err != nil {
+		return nil, errors.Wrap(err, "查找标签联想选项失败")
+	}
+
+	for _, name := range names {
+		text, err := name.Context(ctx).Text()
+		if err != nil || !tagSuggestionNameMatches(text, tag) {
+			continue
+		}
+		item, err := name.Context(ctx).Parent()
+		if err != nil || item == nil || !isElementVisible(item) {
+			continue
+		}
+		return item, nil
+	}
+	return nil, nil
+}
+
+func tagSuggestionNameMatches(name, tag string) bool {
+	name = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(name), "#"))
+	return strings.EqualFold(name, strings.TrimSpace(strings.TrimLeft(tag, "#")))
 }
 
 func selectTagSuggestion(
@@ -811,18 +834,50 @@ func selectTagSuggestion(
 	}
 }
 
-func removeTypedTag(ctx context.Context, contentElem *rod.Element, tag string) error {
-	ka, err := contentElem.Context(ctx).KeyActions()
-	if err != nil {
-		return errors.Wrap(err, "创建标签清理键盘操作失败")
+func removeTypedTag(ctx context.Context, contentElem *rod.Element, beforeText, tag string) error {
+	return restoreTextAfterFailedTag(
+		ctx,
+		beforeText,
+		len("#"+tag)+1,
+		func() (string, error) {
+			return contentElem.Context(ctx).Text()
+		},
+		func() error {
+			return contentElem.Context(ctx).Type(input.Backspace)
+		},
+	)
+}
+
+func restoreTextAfterFailedTag(
+	ctx context.Context,
+	beforeText string,
+	maxBackspaces int,
+	currentText func() (string, error),
+	backspace func() error,
+) error {
+	for attempts := 0; attempts <= maxBackspaces; attempts++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		current, err := currentText()
+		if err != nil {
+			return errors.Wrap(err, "读取标签清理后的正文失败")
+		}
+		if current == beforeText {
+			return nil
+		}
+		if !strings.HasPrefix(current, beforeText) {
+			return errors.New("标签输入改变了已有正文，已停止清理以避免误删")
+		}
+		if attempts == maxBackspaces {
+			break
+		}
+		if err := backspace(); err != nil {
+			return errors.Wrap(err, "清理无联想标签失败")
+		}
 	}
-	for range "#" + tag {
-		ka.Type(input.Backspace)
-	}
-	if err := ka.Do(); err != nil {
-		return errors.Wrap(err, "清理无联想标签失败")
-	}
-	return nil
+	return errors.New("清理无联想标签后正文未恢复")
 }
 
 func waitForTagMenuClose(ctx context.Context, page *rod.Page, timeout time.Duration) {

--- a/xiaohongshu/publish_tag_test.go
+++ b/xiaohongshu/publish_tag_test.go
@@ -157,3 +157,14 @@ func TestRestoreTextAfterFailedTagRefusesToEraseChangedBody(t *testing.T) {
 	assert.ErrorContains(t, err, "避免误删")
 	assert.Zero(t, backspaces)
 }
+
+func TestWaitWithContextHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	err := waitWithContext(ctx, time.Hour)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(started), time.Second)
+}

--- a/xiaohongshu/publish_tag_test.go
+++ b/xiaohongshu/publish_tag_test.go
@@ -1,0 +1,104 @@
+package xiaohongshu
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectTagSuggestionReturnsAfterClick(t *testing.T) {
+	want := &rod.Element{}
+	calls := 0
+
+	got, err := selectTagSuggestion(context.Background(), time.Second, func(context.Context) (*rod.Element, error) {
+		calls++
+		if calls < 2 {
+			return nil, nil
+		}
+		return want, nil
+	}, func(got *rod.Element) error {
+		assert.NotNil(t, got)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, got)
+	assert.Equal(t, 2, calls)
+}
+
+func TestSelectTagSuggestionRetriesDetachedItem(t *testing.T) {
+	want := &rod.Element{}
+	clicks := 0
+
+	got, err := selectTagSuggestion(context.Background(), time.Second, func(context.Context) (*rod.Element, error) {
+		return want, nil
+	}, func(*rod.Element) error {
+		clicks++
+		if clicks == 1 {
+			return errors.New("node detached")
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, got)
+	assert.Equal(t, 2, clicks)
+}
+
+func TestSelectTagSuggestionTimesOutWithoutError(t *testing.T) {
+	started := time.Now()
+
+	got, err := selectTagSuggestion(context.Background(), 20*time.Millisecond, func(context.Context) (*rod.Element, error) {
+		return nil, nil
+	}, func(*rod.Element) error {
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.False(t, got)
+	assert.Less(t, time.Since(started), time.Second)
+}
+
+func TestSelectTagSuggestionTreatsLookupDeadlineAsNoMatch(t *testing.T) {
+	got, err := selectTagSuggestion(context.Background(), 20*time.Millisecond, func(ctx context.Context) (*rod.Element, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, func(*rod.Element) error {
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestSelectTagSuggestionReturnsLookupError(t *testing.T) {
+	want := errors.New("lookup failed")
+
+	got, err := selectTagSuggestion(context.Background(), time.Second, func(context.Context) (*rod.Element, error) {
+		return nil, want
+	}, func(*rod.Element) error {
+		return nil
+	})
+
+	assert.False(t, got)
+	assert.ErrorIs(t, err, want)
+}
+
+func TestSelectTagSuggestionHonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := selectTagSuggestion(ctx, time.Second, func(context.Context) (*rod.Element, error) {
+		return nil, nil
+	}, func(*rod.Element) error {
+		return nil
+	})
+
+	assert.False(t, got)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/xiaohongshu/publish_tag_test.go
+++ b/xiaohongshu/publish_tag_test.go
@@ -102,3 +102,58 @@ func TestSelectTagSuggestionHonorsContext(t *testing.T) {
 	assert.False(t, got)
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+func TestTagSuggestionNameMatchesCompleteTag(t *testing.T) {
+	assert.True(t, tagSuggestionNameMatches("#人工智能", "人工智能"))
+	assert.True(t, tagSuggestionNameMatches("#AI", "ai"))
+	assert.False(t, tagSuggestionNameMatches("#人工智能大会", "人工智能"))
+	assert.False(t, tagSuggestionNameMatches("#A", "AI"))
+}
+
+func TestRestoreTextAfterFailedTagStopsAtRecordedText(t *testing.T) {
+	before := "原有正文"
+	current := before + "#家庭👨‍👩‍👧‍👦"
+	backspaces := 0
+
+	err := restoreTextAfterFailedTag(
+		context.Background(),
+		before,
+		20,
+		func() (string, error) { return current, nil },
+		func() error {
+			backspaces++
+			switch backspaces {
+			case 1:
+				current = before + "#家庭"
+			case 2:
+				current = before + "#家"
+			case 3:
+				current = before + "#"
+			case 4:
+				current = before
+			}
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, backspaces)
+	assert.Equal(t, before, current)
+}
+
+func TestRestoreTextAfterFailedTagRefusesToEraseChangedBody(t *testing.T) {
+	backspaces := 0
+	err := restoreTextAfterFailedTag(
+		context.Background(),
+		"原有正文",
+		10,
+		func() (string, error) { return "正文已被其他操作改写", nil },
+		func() error {
+			backspaces++
+			return nil
+		},
+	)
+
+	assert.ErrorContains(t, err, "避免误删")
+	assert.Zero(t, backspaces)
+}

--- a/xiaohongshu/publish_upload_test.go
+++ b/xiaohongshu/publish_upload_test.go
@@ -1,9 +1,14 @@
 package xiaohongshu
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcceptsImage(t *testing.T) {
@@ -25,4 +30,83 @@ func TestAcceptsImage(t *testing.T) {
 			assert.Equal(t, c.want, acceptsImage(c.accept))
 		})
 	}
+}
+
+func TestRetryImageUploadInputWaitsForReplacement(t *testing.T) {
+	want := &rod.Element{}
+	lookups := 0
+	sets := 0
+
+	err := retryImageUploadInput(
+		context.Background(),
+		time.Second,
+		func() (*rod.Element, error) {
+			lookups++
+			if lookups < 3 {
+				return nil, nil
+			}
+			return want, nil
+		},
+		func(got *rod.Element) error {
+			assert.Same(t, want, got)
+			sets++
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, lookups)
+	assert.Equal(t, 1, sets)
+}
+
+func TestRetryImageUploadInputReacquiresDetachedElement(t *testing.T) {
+	lookups := 0
+	sets := 0
+
+	err := retryImageUploadInput(
+		context.Background(),
+		time.Second,
+		func() (*rod.Element, error) {
+			lookups++
+			return &rod.Element{}, nil
+		},
+		func(*rod.Element) error {
+			sets++
+			if sets == 1 {
+				return errors.New("node detached")
+			}
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, lookups)
+	assert.Equal(t, 2, sets)
+}
+
+func TestRetryImageUploadInputTimesOut(t *testing.T) {
+	started := time.Now()
+	err := retryImageUploadInput(
+		context.Background(),
+		20*time.Millisecond,
+		func() (*rod.Element, error) { return nil, nil },
+		func(*rod.Element) error { return nil },
+	)
+
+	assert.ErrorContains(t, err, "等待图片上传输入框超时")
+	assert.Less(t, time.Since(started), time.Second)
+}
+
+func TestRetryImageUploadInputHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := retryImageUploadInput(
+		ctx,
+		time.Hour,
+		func() (*rod.Element, error) { return nil, nil },
+		func(*rod.Element) error { return nil },
+	)
+
+	assert.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## 改动

- 标签联想查询改为独立的 6 秒有界等待，不再耗尽整次发布的 300 秒 context
- 联想项因前端重渲染失效时，在同一窗口内重新查找并点击
- 无联想结果时回删刚输入的 `#标签`，跳过该标签并继续发布
- 选择成功后等待下拉框关闭，并增加 1.5–3 秒间隔

## 根因与影响

原实现对可选的联想容器和首个选项调用 `Element`。go-rod 会一直重试到页面 context 结束；一旦某个标签没有下拉框，发布会等待约 300 秒，随后连原有的降级输入也因 context 已失效而失败。

修复后，单个标签没有联想结果只会被跳过，不再阻塞整篇笔记的提交。父 context 取消仍会正常向上传播。

## 验证

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -tags integration -run '^$' ./...`
- darwin/arm64、darwin/amd64、linux/amd64、linux/arm64、windows/amd64 交叉编译
- 登录态真实编辑器探针（未点击发布）：`人工智能`、`深度学习` 均成功选中；强制隐藏第三个标签的联想框后，7.56 秒内跳过并完整回删输入

## 多图上传补充修复

- 每张图片上传前最多等待 10 秒，让前端重建 `input[type="file"]`
- `SetFiles` 遇到已失效节点时重新定位并重试
- 新增等待重建、节点失效、超时和取消测试

真实验证：同一份此前在第 2 张失败的 7 图草稿，补丁后 7 张全部上传，笔记在主页确认成功，评论也已验证发布。