### PR TITLE
fix(search): 跳过默认筛选并选择可点击节点

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -60,12 +60,12 @@ type pendingFilter struct {
 	option string // 选项文本
 }
 
-// collectFilters 把入参展开成待应用的筛选项，顺便校验取值。
+// collectFilters 把入参整理成待应用的筛选项，同一组以最后一个非空值为准。
 //
 // 校验放在这里是为了在打开浏览器之前就挡掉写错的值——否则要等导航、悬停、
 // 在面板里找不到之后才能报错，等于为了说一句"你写错了"先向平台发一次请求。
 func collectFilters(filters []FilterOption) ([]pendingFilter, error) {
-	var pending []pendingFilter
+	selected := make(map[string]string, len(filterGroups))
 
 	for _, f := range filters {
 		for _, g := range filterGroups {
@@ -77,11 +77,17 @@ func collectFilters(filters []FilterOption) ([]pendingFilter, error) {
 				return nil, fmt.Errorf("%s 不支持 %q，可选：%s",
 					g.label, value, strings.Join(g.allowed, "、"))
 			}
-			if value == g.defaultValue {
-				continue
-			}
-			pending = append(pending, pendingFilter{group: g.label, option: value})
+			selected[g.label] = value
 		}
+	}
+
+	var pending []pendingFilter
+	for _, g := range filterGroups {
+		value, ok := selected[g.label]
+		if !ok || value == g.defaultValue {
+			continue
+		}
+		pending = append(pending, pendingFilter{group: g.label, option: value})
 	}
 
 	return pending, nil

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -35,21 +35,22 @@ type FilterOption struct {
 // 组和选项一律按文本定位，不用序号。面板里同一个选项可能渲染成多个 div.tags
 // （数量随视口而变），首项是否重复各组也不一致，下标对不齐。
 type filterGroup struct {
-	label   string                    // 面板上这一组的标签文本
-	pick    func(FilterOption) string // 从入参里取这一组的值
-	allowed []string                  // 合法取值；在打开页面之前就能挡掉写错的值
+	label        string                    // 面板上这一组的标签文本
+	defaultValue string                    // 页面初始选中的值，不需要重复点击
+	pick         func(FilterOption) string // 从入参里取这一组的值
+	allowed      []string                  // 合法取值；在打开页面之前就能挡掉写错的值
 }
 
 var filterGroups = []filterGroup{
-	{"排序依据", func(f FilterOption) string { return f.SortBy },
+	{"排序依据", "综合", func(f FilterOption) string { return f.SortBy },
 		[]string{"综合", "最新", "最多点赞", "最多评论", "最多收藏"}},
-	{"笔记类型", func(f FilterOption) string { return f.NoteType },
+	{"笔记类型", "不限", func(f FilterOption) string { return f.NoteType },
 		[]string{"不限", "视频", "图文"}},
-	{"发布时间", func(f FilterOption) string { return f.PublishTime },
+	{"发布时间", "不限", func(f FilterOption) string { return f.PublishTime },
 		[]string{"不限", "一天内", "一周内", "半年内"}},
-	{"搜索范围", func(f FilterOption) string { return f.SearchScope },
+	{"搜索范围", "不限", func(f FilterOption) string { return f.SearchScope },
 		[]string{"不限", "已看过", "未看过", "已关注"}},
-	{"位置距离", func(f FilterOption) string { return f.Location },
+	{"位置距离", "不限", func(f FilterOption) string { return f.Location },
 		[]string{"不限", "同城", "附近"}},
 }
 
@@ -75,6 +76,9 @@ func collectFilters(filters []FilterOption) ([]pendingFilter, error) {
 			if !slices.Contains(g.allowed, value) {
 				return nil, fmt.Errorf("%s 不支持 %q，可选：%s",
 					g.label, value, strings.Join(g.allowed, "、"))
+			}
+			if value == g.defaultValue {
+				continue
 			}
 			pending = append(pending, pendingFilter{group: g.label, option: value})
 		}
@@ -203,7 +207,7 @@ func waitFeedsChanged(page *rod.Page, before string, timeout time.Duration) {
 //
 // 全程不用序号。同一个选项在面板里可能渲染成多个 div.tags（数量随视口而变，
 // 且首项是否重复各组不一致），下标对不齐；早前用 div.tags:nth-child(N) 会选错项。
-// 多份重复的位置尺寸完全相同，取第一个点下去落在同一处。
+// 同文本节点中可能混有隐藏副本，必须选择有可点击区域的那个。
 //
 // 作用域必须限定在 div.filter-panel 内且只认 div.tags：页面别处存在同文本的
 // 可见元素（顶部频道栏的「图文」「视频」、标签「综合」），放宽会点错地方。
@@ -230,16 +234,26 @@ func findFilterOption(page *rod.Page, pf pendingFilter) (*rod.Element, error) {
 		}
 
 		var available []string
+		matched := false
 		for _, opt := range options {
 			t, err := opt.Text()
 			if err != nil {
 				continue
 			}
 			t = strings.TrimSpace(t)
-			if t == pf.option {
+			available = append(available, t)
+			if t != pf.option {
+				continue
+			}
+
+			matched = true
+			shape, err := opt.Shape()
+			if err == nil && len(shape.Quads) > 0 {
 				return opt, nil
 			}
-			available = append(available, t)
+		}
+		if matched {
+			return nil, fmt.Errorf("「%s」里的选项「%s」没有可点击区域", pf.group, pf.option)
 		}
 		return nil, fmt.Errorf("「%s」里没有选项「%s」，页面上是：%s",
 			pf.group, pf.option, strings.Join(available, "、"))

--- a/xiaohongshu/search_integration_test.go
+++ b/xiaohongshu/search_integration_test.go
@@ -48,11 +48,14 @@ func TestSearchWithFilters(t *testing.T) {
 	action := NewSearchAction(page)
 
 	filter := FilterOption{
-		NoteType:    "图文",
-		PublishTime: "一天内",
+		SortBy:      "最新",
+		NoteType:    "不限",
+		PublishTime: "半年内",
+		SearchScope: "不限",
+		Location:    "不限",
 	}
 
-	feeds, err := action.Search(context.Background(), "dn432", filter)
+	feeds, err := action.Search(context.Background(), "无锡 夏天 遛娃 凉快 户外", filter)
 	require.NoError(t, err)
 	require.NotEmpty(t, feeds, "feeds should not be empty")
 
@@ -62,4 +65,29 @@ func TestSearchWithFilters(t *testing.T) {
 		fmt.Printf("Feed ID: %s\n", feed.ID)
 		fmt.Printf("Feed Title: %s\n", feed.NoteCard.DisplayTitle)
 	}
+}
+
+func TestFindFilterOptionSkipsHiddenDuplicate(t *testing.T) {
+	b := browser.NewBrowser(true)
+	defer b.Close()
+
+	page := b.NewPage()
+	defer func() {
+		_ = page.Close()
+	}()
+
+	page.MustSetDocumentContent(`<div class="filter-panel">
+		<div class="filters">
+			<span>笔记类型</span>
+			<div id="hidden" class="tags" style="display: none">图文</div>
+			<div id="visible" class="tags" style="width: 80px; height: 24px">图文</div>
+		</div>
+	</div>`)
+
+	option, err := findFilterOption(page, pendingFilter{group: "笔记类型", option: "图文"})
+	require.NoError(t, err)
+	id, err := option.Attribute("id")
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	require.Equal(t, "visible", *id)
 }

--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -64,6 +64,26 @@ func TestCollectFilters(t *testing.T) {
 		}, pending)
 	})
 
+	t.Run("同组最后一个默认值会清除前面的筛选", func(t *testing.T) {
+		pending, err := collectFilters([]FilterOption{
+			{NoteType: "图文"},
+			{NoteType: "不限"},
+		})
+		require.NoError(t, err)
+		require.Empty(t, pending)
+	})
+
+	t.Run("同组最后一个非默认值生效", func(t *testing.T) {
+		pending, err := collectFilters([]FilterOption{
+			{NoteType: "图文"},
+			{NoteType: "视频"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []pendingFilter{
+			{group: "笔记类型", option: "视频"},
+		}, pending)
+	})
+
 	t.Run("全空则无待应用项", func(t *testing.T) {
 		pending, err := collectFilters([]FilterOption{{}})
 		require.NoError(t, err)

--- a/xiaohongshu/search_test.go
+++ b/xiaohongshu/search_test.go
@@ -19,7 +19,7 @@ func TestCollectFilters(t *testing.T) {
 		}, pending)
 	})
 
-	t.Run("五个字段全给", func(t *testing.T) {
+	t.Run("五个非默认字段全给", func(t *testing.T) {
 		pending, err := collectFilters([]FilterOption{{
 			SortBy:      "最新",
 			NoteType:    "视频",
@@ -31,6 +31,37 @@ func TestCollectFilters(t *testing.T) {
 		require.Len(t, pending, 5)
 		require.Equal(t, pendingFilter{group: "排序依据", option: "最新"}, pending[0])
 		require.Equal(t, pendingFilter{group: "位置距离", option: "同城"}, pending[4])
+	})
+
+	t.Run("默认值不需要重复点击", func(t *testing.T) {
+		pending, err := collectFilters([]FilterOption{
+			{
+				SortBy:      "综合",
+				NoteType:    "不限",
+				PublishTime: "不限",
+				SearchScope: "不限",
+				Location:    "不限",
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, pending)
+	})
+
+	t.Run("只保留非默认筛选项", func(t *testing.T) {
+		pending, err := collectFilters([]FilterOption{
+			{
+				SortBy:      "最新",
+				NoteType:    "不限",
+				PublishTime: "半年内",
+				SearchScope: "不限",
+				Location:    "不限",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []pendingFilter{
+			{group: "排序依据", option: "最新"},
+			{group: "发布时间", option: "半年内"},
+		}, pending)
 	})
 
 	t.Run("全空则无待应用项", func(t *testing.T) {
@@ -59,20 +90,26 @@ func TestCollectFilters(t *testing.T) {
 // 否则以后新增字段会被静默忽略。
 func TestFilterGroupsCoverFilterOption(t *testing.T) {
 	all := FilterOption{
-		SortBy:      "综合",
-		NoteType:    "不限",
-		PublishTime: "不限",
-		SearchScope: "不限",
-		Location:    "不限",
+		SortBy:      "sort_by",
+		NoteType:    "note_type",
+		PublishTime: "publish_time",
+		SearchScope: "search_scope",
+		Location:    "location",
 	}
 
-	pending, err := collectFilters([]FilterOption{all})
-	require.NoError(t, err)
-	require.Len(t, pending, 5, "组表漏了 FilterOption 的字段")
+	var picked []string
+	for _, g := range filterGroups {
+		picked = append(picked, g.pick(all))
+	}
+	require.ElementsMatch(t, []string{
+		"sort_by", "note_type", "publish_time", "search_scope", "location",
+	}, picked, "组表漏了 FilterOption 的字段")
 
 	for _, g := range filterGroups {
 		require.NotEmpty(t, g.label)
+		require.NotEmpty(t, g.defaultValue, "%s 没有默认值", g.label)
 		require.NotEmpty(t, g.allowed, "%s 没有合法取值清单", g.label)
+		require.Contains(t, g.allowed, g.defaultValue, "%s 的默认值不在合法取值中", g.label)
 		require.NotNil(t, g.pick, "%s 没有取值函数", g.label)
 	}
 }


### PR DESCRIPTION
Fixes #801

## 问题

搜索页可能为同一个筛选项渲染多个 `div.tags`。原实现按文本命中后直接返回第一个节点；当第一个是隐藏副本时，`ClickNoWait` 会因为元素没有可点击区域而失败。

显式传入页面默认值（`综合` / `不限`）时，原实现还会重复点击已经选中的项，增加命中隐藏副本或找不到默认分组的机会。

## 改动

- 为每个筛选组记录页面默认值；同一组出现多次时先取最后一个非空值，再跳过最终默认值
- 同名筛选节点中，只返回 `Shape` 包含可点击区域的元素
- 将 #801 的参数加入搜索集成测试，并补充隐藏重复节点的回归用例

筛选节点的判断使用 go-rod 原生 API，没有新增 `Eval` / `MustEval`。

## 验证

- `gofmt -l` 无输出
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -tags integration ./xiaohongshu -run '^TestFindFilterOptionSkipsHiddenDuplicate$' -count=1 -v`
- 使用 #801 的关键词和筛选参数在真实登录态下运行 `TestSearchWithFilters`，成功返回 18 条结果
