### PR TITLE
fix(search): 去掉 MustWaitStable，改等结果数据到位

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -106,8 +106,10 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	// 不用 MustWaitStable：搜索页图片和卡片持续补位，经常永远等不到 stable，会把上面
+	// 那 60s 预算烧光，然后在下一行以「超时」的名义 panic。
 	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	waitFeedsLoaded(page, 15*time.Second)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	if len(pending) > 0 {
@@ -178,6 +180,21 @@ func readFeedIDs(page *rod.Page) string {
 		return ""
 	}
 	return res.Value.Str()
+}
+
+// waitFeedsLoaded 等首屏结果填充完。
+//
+// 等不到就照常往下走：搜索结果确实为空时不该白等满预算，让后面的读取逻辑
+// 返回 ErrNoFeeds 即可。
+func waitFeedsLoaded(page *rod.Page, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if readFeedIDs(page) != "" {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	logrus.Warnf("等待搜索结果填充超时（%s），可能确实没有结果", timeout)
 }
 
 // waitFeedsChanged 等筛选后的数据到位。


### PR DESCRIPTION
## 问题

`search_feeds` 会随机卡满 60 秒后失败，报错：

```
Tool handler panicked  panic="context deadline exceeded" tool=search_feeds
  rod.(*Page).MustWait(...)
  xiaohongshu.(*SearchAction).Search  xiaohongshu/search.go:110
```

报错指向 110 行（等 `__INITIAL_STATE__`），但真正耗时的是上一行的 `page.MustWaitStable()`。

搜索页的图片和卡片会持续补位，`MustWaitStable` 经常永远等不到 stable，把 `Search` 开头设的 60s 预算耗尽；预算耗尽后下一行立刻以 `context deadline exceeded` panic，于是看起来像是 `MustWait` 的问题。

表现为**同一个关键词时好时坏**，与关键词内容无关：

| 轮次 | 关键词 | 结果 |
|---|---|---|
| 1 | 咖啡 | MustWaitStable 59.4s → panic |
| 2 | 咖啡 | MustWaitStable 5.8s → 成功，总计 6.7s |
| 1 | （另一长关键词）| MustWaitStable 59.2s → panic |
| 2 | （另一长关键词）| MustWaitStable 59.4s → panic |

## 改动

去掉 `MustWaitStable()`，改为等待真正的前置条件 —— 结果数据到位：

- 先等 `__INITIAL_STATE__` 出现（几乎瞬时）
- 再轮询等 `feeds` 填充，复用已有的 `readFeedIDs`，上限 15s
- 等不到不报错、照常往下走：搜索结果确实为空时由后续逻辑返回 `ErrNoFeeds`，不必白等满预算

个人主页此前也因为同样原因去掉过 `MustWaitStable`（无限滚动页面同样永远不 stable）。

## 验证

- 修改前：6 次中 4 次卡满 60s panic，2 次 6–7s 成功
- 修改后：6/6 成功，稳定 4–5s 返回
- `go test ./xiaohongshu/` 通过

实测环境为英国 IP（页面为 rednote 域），不涉及任何域名相关改动，逻辑与主站一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)