### PR TITLE
fix(login): 补齐创作平台登录态，修复发布图文上传后 401

### DIFF
--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/browser"
 	"github.com/xpzouying/xiaohongshu-mcp/configs"
@@ -38,18 +42,22 @@ func main() {
 
 	logrus.Infof("当前登录状态: %v", status)
 
-	if status {
-		return
+	if !status {
+		// 开始登录流程
+		logrus.Info("开始登录流程...")
+		if err = action.Login(context.Background()); err != nil {
+			logrus.Fatalf("登录失败: %v", err)
+		}
 	}
 
-	// 开始登录流程
-	logrus.Info("开始登录流程...")
-	if err = action.Login(context.Background()); err != nil {
-		logrus.Fatalf("登录失败: %v", err)
-	} else {
-		if err := saveCookies(page); err != nil {
-			logrus.Fatalf("failed to save cookies: %v", err)
-		}
+	// 登录只走了主站，创作平台是另一套 cookie。不先访问一次让它签发，
+	// 发布时上传图片会被踢回创作平台首页。已登录时也要补，所以不能提前 return。
+	if err := warmupCreator(page); err != nil {
+		logrus.Warnf("预热创作平台失败: %v，仍然保存当前 cookies", err)
+	}
+
+	if err := saveCookies(page); err != nil {
+		logrus.Fatalf("failed to save cookies: %v", err)
 	}
 
 	// 再次检查登录状态确认成功
@@ -66,10 +74,77 @@ func main() {
 
 }
 
+const (
+	// 直接打登录页。发布页不需要登录态也能加载，导航过去不会触发任何认证。
+	creatorLoginURL = "https://creator.xiaohongshu.com/login?source=official"
+	// 创作平台要单独扫码，留够人操作的时间
+	creatorLoginWait = 3 * time.Minute
+)
+
+// warmupCreator 走一遍创作平台的登录，拿到 creator 域下的登录凭据。
+func warmupCreator(page *rod.Page) error {
+	pp := page.Timeout(creatorLoginWait + 30*time.Second)
+
+	if err := pp.Navigate(creatorLoginURL); err != nil {
+		return err
+	}
+	if err := pp.WaitLoad(); err != nil {
+		return err
+	}
+
+	logrus.Warnf("如果窗口里出现二维码，请扫码登录创作平台（最多等 %v）", creatorLoginWait)
+
+	deadline := time.Now().Add(creatorLoginWait)
+	lastURL := ""
+
+	for {
+		info, err := pp.Info()
+		if err != nil {
+			return err
+		}
+
+		if info.URL != lastURL {
+			logrus.Infof("创作平台当前页面: %s", info.URL)
+			lastURL = info.URL
+		}
+
+		// 离开登录页即认为认证完成
+		if !strings.Contains(info.URL, "/login") {
+			time.Sleep(3 * time.Second) // 等 cookie 写完
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("等待创作平台登录超时，仍停在 %s", info.URL)
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// hasCreatorAuth 判断有没有拿到创作平台的登录凭据。
+// 注意凭据是发在父域 .xiaohongshu.com 上的，creator 字样出现在 name 里而不是 domain，
+// 按 domain 找只会捞到 acw_tc 这个 WAF 探针。
+func hasCreatorAuth(cks []*proto.NetworkCookie) bool {
+	for _, ck := range cks {
+		if strings.HasPrefix(ck.Name, "access-token-creator.") ||
+			ck.Name == "galaxy_creator_session_id" {
+			return true
+		}
+	}
+	return false
+}
+
 func saveCookies(page *rod.Page) error {
 	cks, err := page.Browser().GetCookies()
 	if err != nil {
 		return err
+	}
+
+	if hasCreatorAuth(cks) {
+		logrus.Infof("保存 cookies: 共 %d 个，创作平台登录态已拿到", len(cks))
+	} else {
+		logrus.Warnf("保存 cookies: 共 %d 个，但没拿到创作平台登录态，发布图文会失败", len(cks))
 	}
 
 	data, err := json.Marshal(cks)

--- a/xiaohongshu/publish.go
+++ b/xiaohongshu/publish.go
@@ -82,6 +82,12 @@ func (p *PublishAction) Publish(ctx context.Context, content PublishImageContent
 		return errors.Wrap(err, "小红书上传图片失败")
 	}
 
+	// 创作平台登录态失效时，上传会触发重定向把发布页整个换掉，后面找不到任何表单元素。
+	// 与其让选择器空转到 300 秒超时，不如在这里直接报清楚。
+	if err := ensureStillOnPublishPage(page); err != nil {
+		return err
+	}
+
 	tags := content.Tags
 	if len(tags) >= 10 {
 		logrus.Warnf("标签数量超过10，截取前10个标签")
@@ -95,6 +101,24 @@ func (p *PublishAction) Publish(ctx context.Context, content PublishImageContent
 	}
 
 	return nil
+}
+
+// ensureStillOnPublishPage 确认页面没被踢出发布页。
+func ensureStillOnPublishPage(page *rod.Page) error {
+	info, err := page.Info()
+	if err != nil {
+		logrus.Warnf("读取当前页面 URL 失败: %v，跳过检查", err)
+		return nil
+	}
+
+	slog.Info("图片上传完成", "url", info.URL)
+	if strings.Contains(info.URL, "/publish/publish") {
+		return nil
+	}
+
+	return errors.Errorf("上传图片后页面被重定向到 %s，发布页已丢失。"+
+		"通常是创作平台登录态失效——cookies.json 里缺少 creator.xiaohongshu.com 域下的 cookie，"+
+		"重新运行登录工具即可", info.URL)
 }
 
 // hasPopCover 当前页面是否还有挡人的浮层。


### PR DESCRIPTION
## 问题

发布图文时，图片一上传页面就被重定向到 `creator.xiaohongshu.com/login?source=official&redirectReason=401&lastUrl=...`，发布页整个丢失。后续 `submitPublish` 找 `div.d-input input` 一路重试到 300 秒 context 结束，只报 `context deadline exceeded`，看不出真实原因。

## 根因

创作平台的登录凭据（`access-token-creator.xiaohongshu.com`、`galaxy_creator_session_id`、`customer-sso-sid`、`x-user-id-creator.xiaohongshu.com` 等）发在父域 `.xiaohongshu.com` 上，但**只有访问过创作平台才会签发**。

而 `cmd/login/main.go` 的登录流程只打开主站 `www.xiaohongshu.com/explore` 扫码，从未碰过创作平台，这批 cookie 从不存在。加上 `if status { return }` 让已登录时提前退出，重跑登录工具也补不上。

主站 `web_session` 足以让登录检查通过、发布页正常加载，所以问题一直被掩盖到上传那一刻才暴露。

## 改动

**`cmd/login/main.go`**

- 登录后访问一次创作平台 `/login`，等认证完成再保存 cookies
- 已登录时不再提前 return，否则缺失的凭据永远补不回来
- 保存时校验凭据是否到手，按 cookie **name** 判断（`creator` 字样在 name 里，按 domain 找只会捞到 `acw_tc` 这个 WAF 探针）

必须打 `/login`：发布页不需要登录态也能加载，导航过去不会触发认证。

**`xiaohongshu/publish.go`**

- 上传后校验仍在发布页，被重定向直接报错并带上目标 URL

## 验证

- `go build ./...`、`go vet ./...`、`go test ./...` 通过
- 修复前：cookies.json 19 个 cookie，无创作平台凭据，发布必失败
- 修复后：27 个 cookie，六个创作平台凭据到位，**9 图笔记发布成功**（152 秒）
- 报错路径实测从 300 秒缩短到 16 秒

真实账号验证，非 mock。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
