### PR TITLE
fix: redact xsec_token from get_feed_detail logs

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -101,7 +101,7 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	page := f.page.Context(ctx).Timeout(10 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 
-	logrus.Infof("打开 feed 详情页: %s", url)
+	logFeedDetailNavigation(feedID)
 	logrus.Infof("配置: 点击更多=%v, 回复阈值=%d, 最大评论数=%d, 滚动速度=%s",
 		config.ClickMoreReplies, config.MaxRepliesThreshold, config.MaxCommentItems, config.ScrollSpeed)
 
@@ -1002,4 +1002,8 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
 	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+}
+
+func logFeedDetailNavigation(feedID string) {
+	logrus.Infof("打开 feed 详情页: feed_id=%s", feedID)
 }

--- a/xiaohongshu/feed_detail_test.go
+++ b/xiaohongshu/feed_detail_test.go
@@ -3,8 +3,25 @@ package xiaohongshu
 import (
 	"testing"
 
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestLogFeedDetailNavigationRedactsToken(t *testing.T) {
+	hook := logrustest.NewGlobal()
+	defer hook.Reset()
+
+	feedID := "64f123456789abcdef012345"
+	xsecToken := "secret-token-value"
+	logFeedDetailNavigation(feedID)
+
+	require.Len(t, hook.Entries, 1)
+	message := hook.LastEntry().Message
+	assert.Contains(t, message, feedID)
+	assert.NotContains(t, message, xsecToken)
+	assert.NotContains(t, message, makeFeedDetailURL(feedID, xsecToken))
+}
 
 // TestIsExpandRepliesButton 两种文案都要认：带数字的，以及点开一次后不带数字的。
 func TestIsExpandRepliesButton(t *testing.T) {


### PR DESCRIPTION
## Summary

- Keep the feed detail navigation URL unchanged.
- Log only the feed ID instead of the full URL, preventing `xsec_token` exposure.
- Add a focused log-capture regression test.

## Testing

- `go test ./xiaohongshu`

Fixes xpzouying/xiaohongshu-mcp#820