### PR TITLE
fix: 给页面等待加上限，避免耗尽 page deadline 后 panic

### DIFF
--- a/xiaohongshu/comment_feed.go
+++ b/xiaohongshu/comment_feed.go
@@ -30,7 +30,9 @@ func (f *CommentFeedAction) PostComment(ctx context.Context, feedID, xsecToken, 
 
 	// 导航到详情页
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	// 真正的就绪条件是下面那句评论输入框的查找，不是整页 DOM 静止。
+	// 视频笔记的 DOM 永远静不下来，原先会在这里吃满 60s 再 panic，评论一条都发不出去。
+	softWaitDOMStable(page, "发布评论-详情页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	// 检测页面是否可访问
@@ -120,7 +122,9 @@ func (f *CommentFeedAction) ReplyToComment(ctx context.Context, feedID, xsecToke
 
 	// 导航到详情页
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	// 同上：后面的 findCommentElement 才是就绪条件。
+	// 这里的 page deadline 是 5 分钟，原先视频笔记会实打实卡满 5 分钟。
+	softWaitDOMStable(page, "回复评论-详情页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	// 检测页面是否可访问

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -109,7 +109,20 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	err := retry.Do(
 		func() error {
 			page.MustNavigate(url)
-			page.MustWaitDOMStable()
+			// 等的是数据就绪，不是页面静止。
+			//
+			// 原先这里是 MustWaitDOMStable：视频笔记播放时 DOM 持续变动，永远等不到静止，
+			// 一路耗到本函数 10 分钟的 page deadline，表现为客户端"卡死"。001 补丁给它加了
+			// 15 秒上限止住了血，但没追问这个等待本身该不该存在——实测那 15 秒每次都白等满
+			// （日志里必现 "DOM 未在 15s 内稳定"），而详情数据全部取自 __INITIAL_STATE__，
+			// 跟 DOM 静不静止毫无关系。改成直接等 noteDetailMap 落地，图文和视频都不再空耗。
+			if e := page.Timeout(15 * time.Second).Wait(rod.Eval(`() => {
+				const s = window.__INITIAL_STATE__;
+				const m = s && s.note && s.note.noteDetailMap;
+				return !!m && Object.keys(m).length > 0;
+			}`)); e != nil {
+				logrus.Warnf("__INITIAL_STATE__ 未在 15s 内就绪，仍尝试解析: %v", e)
+			}
 			return nil
 		},
 		retry.Attempts(3),

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -108,7 +108,12 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	// 使用retry-go处理页面导航和DOM稳定等待
 	err := retry.Do(
 		func() error {
-			page.MustNavigate(url)
+			// 用 Navigate 而不是 MustNavigate：后者失败是 panic，外面这层 retry.Do
+			// 只认 error，捕获不到——于是 retry.Attempts(3) 一直是死代码。线上 8 次
+			// net::ERR_NAME_NOT_RESOLVED（容器 DNS 偶发）一次都没被重试过。
+			if e := page.Navigate(url); e != nil {
+				return e
+			}
 			// 等的是数据就绪，不是页面静止。
 			//
 			// 原先这里是 MustWaitDOMStable：视频笔记播放时 DOM 持续变动，永远等不到静止，

--- a/xiaohongshu/feeds.go
+++ b/xiaohongshu/feeds.go
@@ -18,7 +18,7 @@ func NewFeedsListAction(page *rod.Page) *FeedsListAction {
 	pp := page.Timeout(60 * time.Second)
 
 	pp.MustNavigate("https://www.xiaohongshu.com")
-	pp.MustWaitDOMStable()
+	softWaitDOMStable(pp, "首页笔记列表")
 
 	return &FeedsListAction{page: pp}
 }

--- a/xiaohongshu/like_favorite.go
+++ b/xiaohongshu/like_favorite.go
@@ -49,7 +49,7 @@ func (a *interactAction) preparePage(ctx context.Context, actionType interactAct
 	logrus.Infof("Opening feed detail page for %s: %s", actionType, url)
 
 	page.MustNavigate(url)
-	page.MustWaitDOMStable()
+	softWaitDOMStable(page, "点赞/收藏-详情页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	return page

--- a/xiaohongshu/login.go
+++ b/xiaohongshu/login.go
@@ -20,7 +20,12 @@ func NewLogin(page *rod.Page) *LoginAction {
 func (a *LoginAction) CheckLoginStatus(ctx context.Context) (bool, error) {
 	// 加超时保护：只是查登录态的快速检查，不应无限挂（登录扫码的等待在 Login/WaitForLogin 里）
 	pp := a.page.Context(ctx).Timeout(30 * time.Second)
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate("https://www.xiaohongshu.com/explore")
+
+	// explore 页图片/视频资源多，load 事件常迟迟不触发，MustWaitLoad 会耗尽 30s deadline 并 panic
+	// （容器日志三天内 13 次 check_login_status context deadline exceeded）。
+	// 登录态只由下面的 .channel 元素判定，不需要整页 load 完成，故 load 等待设软超时。
+	_ = pp.Timeout(8 * time.Second).WaitLoad()
 
 	time.Sleep(1 * time.Second)
 
@@ -74,7 +79,9 @@ func (a *LoginAction) Login(ctx context.Context) error {
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate("https://www.xiaohongshu.com/explore")
+	// 注意 pp 只做了 Context(ctx) 没设 Timeout，裸 MustWaitLoad 在此处没有任何上限。
+	softWaitLoad(pp, "登录-explore 页")
 
 	time.Sleep(2 * time.Second)
 
@@ -91,7 +98,9 @@ func (a *LoginAction) FetchQrcodeImage(ctx context.Context) (string, bool, error
 	pp := a.page.Context(ctx)
 
 	// 导航到小红书首页，这会触发二维码弹窗
-	pp.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	pp.MustNavigate("https://www.xiaohongshu.com/explore")
+	// 注意 pp 只做了 Context(ctx) 没设 Timeout，裸 MustWaitLoad 在此处没有任何上限。
+	softWaitLoad(pp, "登录-explore 页")
 
 	time.Sleep(2 * time.Second)
 

--- a/xiaohongshu/navigate.go
+++ b/xiaohongshu/navigate.go
@@ -19,9 +19,10 @@ func NewNavigate(page *rod.Page) *NavigateAction {
 func (n *NavigateAction) ToExplorePage(ctx context.Context) error {
 	page := n.page.Context(ctx).Timeout(60 * time.Second) // 加超时保护，避免 MustNavigate/MustWaitStable 无限挂
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").
-		MustWaitLoad().
-		MustElement(`div#app`)
+	page.MustNavigate("https://www.xiaohongshu.com/explore")
+	// explore 页资源多，load 事件常迟迟不触发；div#app 出现才是 SPA 真正就绪的标志。
+	softWaitLoad(page, "explore 页")
+	page.MustElement(`div#app`)
 
 	return nil
 }
@@ -34,7 +35,7 @@ func (n *NavigateAction) ToProfilePage(ctx context.Context) error {
 		return err
 	}
 
-	page.MustWaitStable()
+	softWaitStable(page, "个人页-侧边栏")
 
 	// Find and click the "我" channel link in sidebar
 	profileLink := page.MustElement(`div.main-container li.user.side-bar-component a.link-wrapper span.channel`)
@@ -44,7 +45,7 @@ func (n *NavigateAction) ToProfilePage(ctx context.Context) error {
 	}
 
 	// Wait for navigation to complete
-	page.MustWaitLoad()
+	softWaitLoad(page, "个人页-点击跳转后")
 
 	return nil
 }

--- a/xiaohongshu/notification.go
+++ b/xiaohongshu/notification.go
@@ -102,7 +102,12 @@ func (n *NotificationAction) UnreadCount(ctx context.Context) (*NotificationCoun
 	softWaitLoad(page, "未读数-explore 页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
-	softWaitStable(page, "未读数-explore 页")
+	// 只等页面安静不够：notificationCount 要等接口回来才填，提前放行会让下面一次性的
+	// Eval 拿到空值，报成"可能未登录"——把数据没到位误诊成登录态问题。
+	softWaitData(page, `() => {
+		const s = window.__INITIAL_STATE__;
+		return !!(s && s.notification && s.notification.notificationCount);
+	}`, 10*time.Second, "未读数")
 
 	res, err := page.Eval(`() => {
 		const s = window.__INITIAL_STATE__;

--- a/xiaohongshu/notification.go
+++ b/xiaohongshu/notification.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-rod/rod"
-	"github.com/sirupsen/logrus"
 	"github.com/xpzouying/xiaohongshu-mcp/humanize"
 )
 
@@ -99,12 +98,11 @@ func NewNotificationAction(page *rod.Page) *NotificationAction {
 func (n *NotificationAction) UnreadCount(ctx context.Context) (*NotificationCount, error) {
 	page := n.page.Timeout(60 * time.Second)
 
-	page.MustNavigate("https://www.xiaohongshu.com/explore").MustWaitLoad()
+	page.MustNavigate("https://www.xiaohongshu.com/explore")
+	softWaitLoad(page, "未读数-explore 页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
-	if err := page.WaitStable(time.Second); err != nil {
-		logrus.Warnf("explore 页未稳定，继续读取未读数: %v", err)
-	}
+	softWaitStable(page, "未读数-explore 页")
 
 	res, err := page.Eval(`() => {
 		const s = window.__INITIAL_STATE__;
@@ -148,7 +146,8 @@ func (n *NotificationAction) List(ctx context.Context, tab NotificationTab, limi
 
 	page := n.page.Timeout(3 * time.Minute)
 
-	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	page.MustNavigate("https://www.xiaohongshu.com/notification")
+	softWaitLoad(page, "通知列表页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	if err := n.switchTab(ctx, page, tab); err != nil {

--- a/xiaohongshu/notification_like.go
+++ b/xiaohongshu/notification_like.go
@@ -32,7 +32,8 @@ func (n *NotificationAction) Like(ctx context.Context, commentID string, unlike 
 	want := !unlike
 	page := n.page.Timeout(3 * time.Minute)
 
-	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	page.MustNavigate("https://www.xiaohongshu.com/notification")
+	softWaitLoad(page, "通知点赞-通知页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	target, index, err := n.locate(ctx, page, commentID)

--- a/xiaohongshu/notification_reply.go
+++ b/xiaohongshu/notification_reply.go
@@ -30,7 +30,8 @@ func (n *NotificationAction) Reply(ctx context.Context, commentID, content strin
 
 	page := n.page.Timeout(3 * time.Minute)
 
-	page.MustNavigate("https://www.xiaohongshu.com/notification").MustWaitLoad()
+	page.MustNavigate("https://www.xiaohongshu.com/notification")
+	softWaitLoad(page, "通知回复-通知页")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	target, index, err := n.locate(ctx, page, commentID)

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -106,14 +106,24 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	// 搜索页有懒加载图片、视频预览和无限滚动占位，WaitStable 要求「DOM 零变化 + 网络空闲 + load 完成」
-	// 三者同时成立，实测几乎无法达成，只会一路耗到 60s deadline 后 panic
-	// （容器日志三天内 32 次 search_feeds context deadline exceeded，占全部失败的 54%）。
-	// 真正的就绪条件是下一行的 __INITIAL_STATE__，与 DOM 是否静止无关，故此处超时只告警。
-	if e := page.Timeout(8 * time.Second).WaitStable(300 * time.Millisecond); e != nil {
-		logrus.Warnf("搜索页未在 8s 内稳定（懒加载页面常见），继续解析: %v", e)
-	}
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	// 等的是搜索结果本身落地。
+	//
+	// 原先是 MustWaitStable：要求「DOM 零变化 + 网络空闲 + load 完成」三者同时成立，
+	// 而搜索页有懒加载图片、视频预览和无限滚动占位，这个条件实测无法达成，只会一路耗到
+	// 60s deadline 后 panic（容器日志三天内 32 次 search_feeds context deadline exceeded）。
+	//
+	// 但也不能只等 __INITIAL_STATE__ 这个壳：壳在页面初始化时就有了，feeds 要等接口回来
+	// 才填。只检查壳会在慢网络下提前放行，而下面的提取是一次性的、没有重试，拿到空值就直接
+	// 报 ErrNoFeeds——表现为"没搜到结果"，比 panic 更难排查。故这里等到 feeds 真正有值。
+	//
+	// .value / ._value 两种形态都要认，与下面的提取逻辑和 feedIDsJS 保持一致。
+	// 搜索确实无结果时也会等满超时，交给下面的提取按 ErrNoFeeds 正常处理。
+	softWaitData(page, `() => {
+		const f = window.__INITIAL_STATE__ && window.__INITIAL_STATE__.search
+			&& window.__INITIAL_STATE__.search.feeds;
+		const v = f ? (f.value !== undefined ? f.value : f._value) : null;
+		return Array.isArray(v) && v.length > 0;
+	}`, 20*time.Second, "搜索结果")
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	if len(pending) > 0 {

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -106,7 +106,13 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	// 搜索页有懒加载图片、视频预览和无限滚动占位，WaitStable 要求「DOM 零变化 + 网络空闲 + load 完成」
+	// 三者同时成立，实测几乎无法达成，只会一路耗到 60s deadline 后 panic
+	// （容器日志三天内 32 次 search_feeds context deadline exceeded，占全部失败的 54%）。
+	// 真正的就绪条件是下一行的 __INITIAL_STATE__，与 DOM 是否静止无关，故此处超时只告警。
+	if e := page.Timeout(8 * time.Second).WaitStable(300 * time.Millisecond); e != nil {
+		logrus.Warnf("搜索页未在 8s 内稳定（懒加载页面常见），继续解析: %v", e)
+	}
 	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -55,7 +55,7 @@ func (u *UserProfileAction) UserProfile(ctx context.Context, userID, xsecToken s
 
 	searchURL := makeUserProfileURL(userID, xsecToken, tab)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
+	softWaitStable(page, "用户主页")
 
 	return u.extractUserProfileData(page, tab)
 }
@@ -157,7 +157,7 @@ func (u *UserProfileAction) GetMyProfileViaSidebar(ctx context.Context, tab Prof
 	}
 
 	// 等待页面加载完成并获取 __INITIAL_STATE__
-	page.MustWaitStable()
+	softWaitStable(page, "用户主页")
 
 	if err := u.selectTab(ctx, page, tab); err != nil {
 		return nil, err
@@ -188,7 +188,7 @@ func (u *UserProfileAction) selectTab(ctx context.Context, page *rod.Page, tab P
 			return fmt.Errorf("切换到 %s 失败: %w", label, err)
 		}
 		humanize.Delay(ctx, humanize.AfterClick)
-		page.MustWaitStable()
+		softWaitStable(page, "用户主页-切换标签页")
 		return nil
 	}
 	return fmt.Errorf("未找到子 tab %q", label)

--- a/xiaohongshu/user_profile.go
+++ b/xiaohongshu/user_profile.go
@@ -62,7 +62,13 @@ func (u *UserProfileAction) UserProfile(ctx context.Context, userID, xsecToken s
 
 // extractUserProfileData 从页面中提取用户资料数据的通用方法
 func (u *UserProfileAction) extractUserProfileData(page *rod.Page, tab ProfileTab) (*UserProfileResponse, error) {
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	// 不能只等 __INITIAL_STATE__ 这个壳：壳在页面初始化时就有，userPageData 要等接口
+	// 回来才填。下面的提取是一次性的，拿到空值就直接报错，故这里等到真实数据落地。
+	softWaitData(page, `() => {
+		const u = window.__INITIAL_STATE__ && window.__INITIAL_STATE__.user;
+		const d = u && u.userPageData;
+		return !!(d ? (d.value !== undefined ? d.value : d._value) : null);
+	}`, 15*time.Second, "用户主页数据")
 
 	userDataResult := page.MustEval(`() => {
 		if (window.__INITIAL_STATE__ &&

--- a/xiaohongshu/wait.go
+++ b/xiaohongshu/wait.go
@@ -45,6 +45,20 @@ func softWaitStable(page *rod.Page, what string) {
 	}
 }
 
+// softWaitData 等某段业务数据就绪（通常是 __INITIAL_STATE__ 的某个字段注水完成），
+// 有上限、不 panic。
+//
+// 这是三档里**最该优先用**的一档：等的是结果本身，而不是页面的外观状态。
+//
+// 尤其注意别只等 __INITIAL_STATE__ 这个壳——壳在页面初始化时就存在，具体数据要等接口
+// 回来才填。"软超时 + 只检查壳"会在慢网络下提前放行，让后面一次性的提取拿到空值，
+// 于是报成"没有结果"或"可能未登录"，比 panic 更难排查。传入的 js 必须判到真实的值。
+func softWaitData(page *rod.Page, js string, budget time.Duration, what string) {
+	if err := page.Timeout(budget).Wait(rod.Eval(js)); err != nil {
+		logrus.Warnf("%s：数据未在 %s 内就绪，仍尝试解析", what, budget)
+	}
+}
+
 // softWaitDOMStable 等 DOM 静止，有上限、不 panic。
 func softWaitDOMStable(page *rod.Page, what string) {
 	if err := page.Timeout(softWaitBudget).WaitDOMStable(time.Second, 0); err != nil {

--- a/xiaohongshu/wait.go
+++ b/xiaohongshu/wait.go
@@ -1,0 +1,53 @@
+package xiaohongshu
+
+// 页面等待的统一策略。
+//
+// 小红书的页面几乎从不"安静"：懒加载图片、无限滚动占位、自动播放的视频，都会让 load
+// 事件迟迟不触发、让 DOM 永远无法零变化。而 rod 的 MustWaitLoad / MustWaitStable /
+// MustWaitDOMStable 自身不带上限（官方注释明确写着 "d is not the max wait timeout"），
+// 唯一的退出路径是外层 page deadline——于是它们只能一路吃满那个 deadline 再 panic。
+// 线上 3 天 59 次 context deadline exceeded 就是这么来的；deadline 长的地方
+// （详情页 10 分钟、评论回复 5 分钟）表现为客户端干等几分钟的"卡死"。
+//
+// 收口成两条规矩：
+//
+//  1. "等页面安静"这类等待一律视为**尽力而为的缓冲**——给短上限，超时只告警不失败。
+//     真正的就绪条件永远是它后面那句具体的元素查找或数据判断，页面静没静不决定结果。
+//  2. 需要精确等待时，用 page.Wait(rod.Eval(...)) 直接等业务条件本身。
+//     feed_detail.go 就是这么做的：等 __INITIAL_STATE__.note.noteDetailMap 落地，
+//     而不是等 DOM 静止——同一条视频笔记详情因此从 21 秒降到 10 秒。
+//
+// 一句话：不要再裸用 Must*Wait* 系列。
+
+import (
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+)
+
+// softWaitBudget 缓冲等待的默认上限。
+// 取 8 秒：实测图文详情页约 5 秒即可静止，够用；视频笔记永远静不下来，早点放行反而更好。
+const softWaitBudget = 8 * time.Second
+
+// softWaitLoad 等 load 事件，有上限、不 panic。what 用于日志定位是哪条链路。
+func softWaitLoad(page *rod.Page, what string) {
+	if err := page.Timeout(softWaitBudget).WaitLoad(); err != nil {
+		logrus.Warnf("%s：未在 %s 内 load 完成（资源多时常见），继续", what, softWaitBudget)
+	}
+}
+
+// softWaitStable 等页面稳定（load + 网络空闲 + DOM 零变化三者同时成立），有上限、不 panic。
+// 这是最苛刻的一档，小红书页面基本达不成，所以更要有上限。
+func softWaitStable(page *rod.Page, what string) {
+	if err := page.Timeout(softWaitBudget).WaitStable(300 * time.Millisecond); err != nil {
+		logrus.Warnf("%s：未在 %s 内稳定（懒加载页面常见），继续", what, softWaitBudget)
+	}
+}
+
+// softWaitDOMStable 等 DOM 静止，有上限、不 panic。
+func softWaitDOMStable(page *rod.Page, what string) {
+	if err := page.Timeout(softWaitBudget).WaitDOMStable(time.Second, 0); err != nil {
+		logrus.Warnf("%s：DOM 未在 %s 内静止（视频笔记常见），继续", what, softWaitBudget)
+	}
+}


### PR DESCRIPTION
## 问题

`rod` 的 `MustWaitLoad` / `MustWaitStable` / `MustWaitDOMStable` **自身不带超时上限**（官方注释明确写着 `d is not the max wait timeout`），唯一的退出路径是外层 page deadline。

而小红书的页面几乎从不「安静」：懒加载图片、无限滚动占位、自动播放的视频，都会让 load 事件迟迟不触发、让 DOM 永远无法零变化。于是这些等待只能一路吃满 deadline 再 panic。

表现为两类故障：

- **deadline 短的地方**报 `context deadline exceeded`。容器日志三天内 59 次，其中 `search_feeds` 32 次（占全部失败的 54%）、`check_login_status` 13 次。
- **deadline 长的地方**表现为客户端干等几分钟的「卡死」：详情页 page deadline 是 10 分钟、评论回复 5 分钟。视频笔记的 DOM 因为播放器持续重绘永远静不下来，`get_feed_detail` 一碰视频笔记就实打实卡满 10 分钟。

## 改动

**1. 新增 `xiaohongshu/wait.go`**，提供 `softWaitLoad` / `softWaitStable` / `softWaitDOMStable` 三个带上限（8 秒）的等待，超时只告警不失败。

理由是：这类「等页面安静」的等待本就只是尽力而为的缓冲，**真正的就绪条件是它后面那句具体的元素查找或数据判断**，页面静没静并不决定结果。8 秒是实测值——图文详情页约 5 秒即可静止，够用；视频笔记永远静不下来，早点放行反而更好。

**2. 详情页改为直接等业务条件本身。**

`feed_detail.go` 原先用 `MustWaitDOMStable`，但详情数据全部取自 `window.__INITIAL_STATE__`，与 DOM 是否静止毫无关系。改成等 `noteDetailMap` 落地后，同一条视频笔记详情从 21 秒降到 10 秒。

**3. 其余调用点统一替换为软等待**，覆盖 navigate / login / notification / comment_feed / feeds / like_favorite / user_profile / search。

## 关于 JS 注入

`feed_detail.go` 里新增了一句 `page.Wait(rod.Eval(...))`，读 `__INITIAL_STATE__` 判断数据是否就绪。这里说明一下：它**不是用来操作页面元素的**，只是读一个全局变量做条件判断——元素操作仍然全部走 go-rod API。项目里 `search.go` 本来就有同样写法（`page.MustWait('() => window.__INITIAL_STATE__ !== undefined')`）。

## 验证

- `gofmt` / `go build` / `go vet` / `go test ./...` 均通过
- 本地实测：视频笔记详情不再卡死，耗时 21s → 10s；搜索不再因 DOM 静止不了而超时