### PR TITLE
perf: 读取类流程拦掉图片/音视频/字体请求，大幅降低内存占用

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -101,6 +101,10 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	page := f.page.Context(ctx).Timeout(10 * time.Minute)
 	url := makeFeedDetailURL(feedID, xsecToken)
 
+	// 详情数据全部取自 __INITIAL_STATE__，图片和视频只是渲染出来给人看的，
+	// 对调用方无用却很吃内存；视频一播 DOM 还会永远静不下来。拦掉两头都赚。
+	defer blockHeavyResources(page)()
+
 	logrus.Infof("打开 feed 详情页: %s", url)
 	logrus.Infof("配置: 点击更多=%v, 回复阈值=%d, 最大评论数=%d, 滚动速度=%s",
 		config.ClickMoreReplies, config.MaxRepliesThreshold, config.MaxCommentItems, config.ScrollSpeed)

--- a/xiaohongshu/resource_block.go
+++ b/xiaohongshu/resource_block.go
@@ -1,0 +1,42 @@
+package xiaohongshu
+
+import (
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/sirupsen/logrus"
+)
+
+// blockHeavyResources 拦掉图片、音视频、字体请求，返回停止函数。
+//
+// 读取类页面的数据全部取自 window.__INITIAL_STATE__，图片和视频的 URL 就在那段 JSON 里，
+// 浏览器根本不需要真的把它们下载下来、解码、渲染。拦掉的收益是双份的：
+//
+//   - 省内存：实测单次 search_feeds 峰值 11 个 chrome 进程 / 1078MB，而容器上限只有
+//     1200MB——一次调用就吃掉九成，并发上限因此是 1。图片解码是大头，压下来才谈得上并发。
+//   - 省时间：视频不加载就不会播放，而视频播放正是详情页 DOM 持续抖动、等不到静止的
+//     唯一原因（见 001 补丁），拦掉后不必再干等那 15 秒软超时。
+//
+// 只用于读取类流程（搜索/列表/详情）。发布类流程要真实上传和预览，不要用。
+func blockHeavyResources(page *rod.Page) func() {
+	router := page.HijackRequests()
+
+	router.MustAdd("*", func(ctx *rod.Hijack) {
+		switch ctx.Request.Type() {
+		case proto.NetworkResourceTypeImage,
+			proto.NetworkResourceTypeMedia,
+			proto.NetworkResourceTypeFont:
+			// BlockedByClient 是浏览器插件拦广告时的常规做法，站点普遍容忍。
+			ctx.Response.Fail(proto.NetworkErrorReasonBlockedByClient)
+		default:
+			ctx.ContinueRequest(&proto.FetchContinueRequest{})
+		}
+	})
+
+	go router.Run()
+
+	return func() {
+		if err := router.Stop(); err != nil {
+			logrus.Debugf("停止资源拦截器: %v", err)
+		}
+	}
+}

--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -104,6 +104,9 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	// 否则搜索页不 stable 时 MustWaitStable/MustWait 会永久挂起（无 deadline 可依赖）。
 	page := s.page.Context(ctx).Timeout(60 * time.Second)
 
+	// 搜索结果同样来自 __INITIAL_STATE__，封面图不必真的下载解码。
+	defer blockHeavyResources(page)()
+
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
 	page.MustWaitStable()


### PR DESCRIPTION
## 背景

搜索、列表、详情这些**读取类流程**的数据全部取自 `window.__INITIAL_STATE__`，图片和视频的 URL 就在那段 JSON 里。浏览器根本不需要真的把它们下载下来、解码、渲染——渲染出来的画面调用方（大模型）也读不了。

## 收益是双份的

**省内存。** 实测单次 `search_feeds` 峰值 11 个 chrome 进程 / 1078MB，而容器上限只有 1200MB —— 一次调用就吃掉九成，并发上限因此被迫是 1。图片解码是内存大头，压下来才谈得上并发。

**省时间。** 视频不加载就不会播放，而视频播放正是详情页 DOM 持续抖动、等不到静止的原因，拦掉后不必再干等超时。

## 改动

新增 `xiaohongshu/resource_block.go`，用 go-rod 的 `HijackRequests` 按资源类型（Image / Media / Font）拦截，返回停止函数由调用方 `defer` 释放。拦截用 `BlockedByClient` —— 这是浏览器插件拦广告时的常规做法，站点普遍容忍。

接入点只有两处，各一行：`search.go` 和 `feed_detail.go`。

**只用于读取类流程。发布类流程要真实上传和预览，没有接入，也不该接入。**

## 验证

- `gofmt` / `go build` / `go vet` / `go test ./...` 均通过
- 本地实测搜索与详情功能正常，返回数据无变化（数据本来就不来自图片）

## 备注

这个改动与 #823 相互独立、可各自合并；两者都改了 `feed_detail.go`，但改的是不同位置。