### PR TITLE
feat: 视频笔记详情返回字幕正文

### DIFF
--- a/mcp_server.go
+++ b/mcp_server.go
@@ -288,7 +288,7 @@ func registerTools(server *mcp.Server, appServer *AppServer) {
 	mcp.AddTool(server,
 		&mcp.Tool{
 			Name:        "get_feed_detail",
-			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。视频笔记额外返回 video 字段，含各编码档位的视频直链与字幕地址（均带签名、有时效）。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
+			Description: "获取小红书笔记详情，返回笔记内容、图片、作者信息、互动数据（点赞/收藏/分享数）及评论列表。视频笔记额外返回 video 字段，其中 subtitleText 是字幕正文（已去掉时间轴的完整文字转录，subtitleLang 为语种）——视频画面读不了，这段文字就是视频的可读内容，讲解/教程类视频尤其值得看；video 里另有各编码档位的直链与字幕原始地址（均带签名、有时效）。默认返回前10条一级评论，如需更多评论请设置load_all_comments=true",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Feed Detail",
 				ReadOnlyHint: true,

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -140,7 +140,16 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 		return nil, err
 	}
 
-	return f.extractFeedDetail(page, feedID)
+	resp, err := f.extractFeedDetail(page, feedID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 视频画面调用方读不了，字幕才是视频笔记可读的内容。
+	// 页面里只有带签名的 .srt 链接，正文得另外下一次，失败不影响详情本身。
+	fillSubtitleText(ctx, resp.Note.Video)
+
+	return resp, nil
 }
 
 // ========== 评论加载器 ==========

--- a/xiaohongshu/subtitle.go
+++ b/xiaohongshu/subtitle.go
@@ -1,0 +1,136 @@
+package xiaohongshu
+
+// 视频字幕的下载与解析。
+//
+// 视频画面本身对调用方（大模型）没有价值，真正可读的是字幕——它等于视频内容的
+// 文字转录。字幕的 URL 躺在 __INITIAL_STATE__ 里，但正文要另外下载 .srt，
+// 且链接带签名有时效（url 里的 sign/t 参数），客户端拿到 URL 也取不动，
+// 所以在服务端取好、去掉时间轴，直接把台词交出去。
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// subtitleFetchTimeout 单个字幕文件的下载超时。
+	// 实测一条 166 秒视频的 srt 约 4.7KB / 0.2s，给足余量又不拖累详情接口。
+	subtitleFetchTimeout = 8 * time.Second
+
+	// subtitleMaxBytes 字幕正文读取上限，防异常大文件撑爆内存（服务器只有 1.6G）。
+	subtitleMaxBytes = 2 << 20 // 2MB
+)
+
+// subtitleLangPriority 挑字幕的优先级。
+// source 是视频的原始语种，最贴近里面实际说的话；其次简中。
+var subtitleLangPriority = []string{"source", "zh-CN", "zh"}
+
+// pickSubtitle 从多语言字幕里挑一档，返回语言标识与下载地址。
+// 都取不到时返回空串，调用方据此跳过。
+func pickSubtitle(subs map[string][]VideoSubtitle) (lang, url string) {
+	pick := func(key string) (string, string, bool) {
+		items, ok := subs[key]
+		if !ok || len(items) == 0 || items[0].URL == "" {
+			return "", "", false
+		}
+		l := items[0].Language
+		if l == "" {
+			l = key
+		}
+		return l, items[0].URL, true
+	}
+
+	for _, key := range subtitleLangPriority {
+		if l, u, ok := pick(key); ok {
+			return l, u
+		}
+	}
+	// 优先级都没命中就退回任意一档，聊胜于无。
+	for key := range subs {
+		if l, u, ok := pick(key); ok {
+			return l, u
+		}
+	}
+	return "", ""
+}
+
+// parseSRT 去掉 srt 的序号与时间轴，只留台词。
+// 每条字幕单独成行——原文本就是按语句切的，保留换行比硬拼成一段更好读。
+func parseSRT(r io.Reader) string {
+	var b strings.Builder
+
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.Contains(line, "-->") {
+			continue
+		}
+		// 纯数字行是字幕序号，丢掉
+		if _, err := strconv.Atoi(line); err == nil {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(line)
+	}
+	if err := sc.Err(); err != nil {
+		logrus.Warnf("解析字幕中断: %v", err)
+	}
+
+	return b.String()
+}
+
+// fillSubtitleText 下载字幕正文并填进 v。
+// 字幕是附加信息，任何一步失败都只告警不报错——不该因为它拖垮整个详情接口。
+func fillSubtitleText(ctx context.Context, v *VideoDetail) {
+	if v == nil || len(v.Subtitles) == 0 {
+		return
+	}
+
+	lang, url := pickSubtitle(v.Subtitles)
+	if url == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, subtitleFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		logrus.Warnf("构造字幕请求失败(%s): %v", lang, err)
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logrus.Warnf("下载字幕失败(%s): %v", lang, err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		logrus.Warnf("下载字幕失败(%s): HTTP %d", lang, resp.StatusCode)
+		return
+	}
+
+	text := parseSRT(io.LimitReader(resp.Body, subtitleMaxBytes))
+	if text == "" {
+		logrus.Warnf("字幕内容为空(%s)", lang)
+		return
+	}
+
+	v.SubtitleText = text
+	v.SubtitleLang = lang
+	logrus.Infof("字幕已取回: %s，%d 字", lang, utf8.RuneCountInString(text))
+}

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -135,6 +135,14 @@ type VideoDetail struct {
 	Media VideoMedia      `json:"media"`
 	// Subtitles 字幕，从 mediaV2 里解出来（见 UnmarshalJSON）。key 为语言，另有 source 表示原始语种。
 	Subtitles map[string][]VideoSubtitle `json:"subtitles,omitempty"`
+
+	// SubtitleText 字幕正文，已去掉序号与时间轴。
+	// 视频画面调用方（大模型）读不了，这段文字才是视频笔记真正可读的内容；
+	// 而 Subtitles 里只有带签名和时效的 .srt 链接，客户端拿到也取不动，
+	// 所以在服务端下载好一并交出去。见 subtitle.go。
+	SubtitleText string `json:"subtitleText,omitempty"`
+	// SubtitleLang SubtitleText 对应的语言。
+	SubtitleLang string `json:"subtitleLang,omitempty"`
 }
 
 // UnmarshalJSON 额外解开 mediaV2。


### PR DESCRIPTION
## 动机

视频画面本身对调用方（大模型）没有价值，**真正可读的是字幕**——它等于视频内容的文字转录。没有它，视频笔记在 MCP 这条链路上基本等于一条只有标题和评论的空笔记。

字幕的 URL 其实已经解出来了（`VideoDetail.Subtitles`，来自 `mediaV2`），但那只是 `.srt` 链接，**且带签名有时效**（url 里的 `sign` / `t` 参数），客户端拿到也取不动。所以在服务端取好、去掉序号与时间轴，直接把台词随详情一并交出去。

## 改动

**新增 `xiaohongshu/subtitle.go`**：按 `source` → `zh-CN` → `zh` 的优先级挑一档字幕，下载并解析 srt。`source` 是视频的原始语种，最贴近里面实际说的话；优先级都没命中就退回任意一档。

**`VideoDetail` 新增两个字段**：`SubtitleText`（字幕正文）和 `SubtitleLang`（对应语言）。两个都是 `omitempty`，**没有字幕的视频和图文笔记的返回结构完全不受影响**。

## 稳健性

字幕是附加信息，不该拖垮详情接口本身：

- 挑选、下载、解析的**任何一步失败都只告警不报错**，详情照常返回
- 下载 8 秒超时（实测一条 166 秒视频的 srt 约 4.7KB / 0.2s，余量充足）
- 读取上限 2MB，防异常大文件撑爆内存

## 验证

- `gofmt` / `go build` / `go vet` / `go test ./...` 均通过
- 本地实测带字幕视频笔记可正常取回正文；无字幕视频与图文笔记返回不变