### PR TITLE
fix: 给浏览器实例加并发闸门，并修复扫码登录路径上的浏览器泄漏

### DIFF
--- a/browser_lease.go
+++ b/browser_lease.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/headless_browser"
+)
+
+// 浏览器并发闸门。
+//
+// 每次 newBrowser() 都是一整个 Chromium 进程组，而在此之前**全项目没有任何并发控制**：
+// 18 个 MCP 工具和 20 条 REST 端点共用一个 service 单例，net/http 一请求一 goroutine，
+// 两个请求撞上就是两套完整浏览器一起把容器推向 OOM——而 OOM 杀掉的是整个容器，
+// 不是那一个请求。
+//
+// 并发度取 2，依据是在目标机器（2 核 / 容器上限 1200MB）上的实测。注意口径：必须读
+// cgroup 的 memory.current，不能把 11 个 chrome 进程的 ps RSS 相加——后者会把进程间
+// 共享的二进制映射和 zygote 的 CoW 页重复计算 11 次，实测高估近一倍（996MB vs 528MB），
+// 照那个数字算会误判成"并发上限是 1"。
+//
+//	并发   峰值内存   单请求耗时   吞吐        余量
+//	 1      528MB      9.3s       6.5 次/分   672MB
+//	 2      736MB      13s        9.2 次/分   464MB   ← 取这个
+//	 3      975MB      18.5s      9.7 次/分   225MB
+//
+// 3 的吞吐只比 2 多 5%（2 核 CPU 已经争抢），延迟却翻倍，余量还掉到 225MB——
+// 评论多的详情页能轻松吃掉这点余量。
+//
+// 用 XHS_BROWSER_CONCURRENCY 覆盖；换机器（尤其是改了 mem_limit 或 CPU 数）要重新实测。
+const defaultBrowserConcurrency = 2
+
+// browserAcquireTimeout 排队等名额的上限。
+//
+// 短排队 + 明确失败，绝不长排队：单请求约 13 秒，排在第 2、3 位也就几十秒；
+// 等过这个数说明后面已经堆积，与其让调用方干等到自己超时（MCP 客户端通常 60 秒左右），
+// 不如立刻给个说得清的错误。
+const browserAcquireTimeout = 60 * time.Second
+
+var (
+	browserSem     chan struct{}
+	browserSemOnce sync.Once
+)
+
+func browserConcurrency() int {
+	if v := os.Getenv("XHS_BROWSER_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		logrus.Warnf("XHS_BROWSER_CONCURRENCY=%q 不是正整数，回退到 %d", v, defaultBrowserConcurrency)
+	}
+	return defaultBrowserConcurrency
+}
+
+func browserSlots() chan struct{} {
+	browserSemOnce.Do(func() {
+		n := browserConcurrency()
+		browserSem = make(chan struct{}, n)
+		logrus.Infof("浏览器并发上限: %d", n)
+	})
+	return browserSem
+}
+
+// leasedBrowser 给浏览器实例配一张名额票，Close 时归还。
+//
+// 内嵌 *headless_browser.Browser 是刻意的：调用方在 b 上只用到 Close 和 NewPage
+// （已 grep 核对，19 个调用点无一例外），靠 Go 的方法提升，全部调用点无需改动，
+// 唯一被拦截的就是 Close。
+type leasedBrowser struct {
+	*headless_browser.Browser
+	release func()
+}
+
+// Close 关浏览器并归还名额。名额一定要还，所以即便关闭本身出问题也不能跳过。
+func (b *leasedBrowser) Close() {
+	defer b.release()
+	b.Browser.Close()
+}
+
+// acquireBrowserSlot 取一张名额票，取不到就是明确失败。
+func acquireBrowserSlot() {
+	sem := browserSlots()
+
+	select {
+	case sem <- struct{}{}:
+		return
+	default:
+	}
+
+	// 满了，说明正在排队——记一笔，好在日志里看出压力
+	logrus.Warnf("浏览器名额已满（上限 %d），排队中", cap(sem))
+	start := time.Now()
+
+	select {
+	case sem <- struct{}{}:
+		logrus.Infof("排队 %s 后取得浏览器名额", time.Since(start).Round(time.Millisecond))
+	case <-time.After(browserAcquireTimeout):
+		// 这里 panic 而不是返回 error，是为了不改动 19 个调用点的签名；
+		// MCP 侧有 withPanicRecovery、REST 侧有 gin.Recovery()，都会转成正常的错误响应。
+		panic(fmt.Sprintf("浏览器繁忙：等待 %s 仍未取得名额（并发上限 %d），请稍后重试",
+			browserAcquireTimeout, cap(sem)))
+	}
+}
+
+// newLeasedBrowser 取名额、建浏览器，并保证建失败时名额不会漏掉。
+func newLeasedBrowser(build func() *headless_browser.Browser) *leasedBrowser {
+	acquireBrowserSlot()
+
+	var once sync.Once
+	release := func() { once.Do(func() { <-browserSlots() }) }
+
+	// build 可能 panic——browser.NewBrowser 在内置浏览器不可用时是主动 panic 的。
+	// 名额必须还回去，否则连续几次之后所有请求都会永久卡在 acquireBrowserSlot 上。
+	defer func() {
+		if r := recover(); r != nil {
+			release()
+			panic(r)
+		}
+	}()
+
+	return &leasedBrowser{Browser: build(), release: release}
+}

--- a/service.go
+++ b/service.go
@@ -627,11 +627,18 @@ func (s *XiaohongshuService) ReplyNotification(ctx context.Context, commentID, c
 	return xiaohongshu.NewNotificationAction(page).Reply(ctx, commentID, content)
 }
 
-func newBrowser() *headless_browser.Browser {
-	return browser.NewBrowser(configs.IsHeadless(),
-		browser.WithFingerprintSeed(configs.FingerprintSeed()),
-		browser.WithProxy(configs.Proxy()),
-	)
+// newBrowser 建一个浏览器实例，受并发闸门约束（见 browser_lease.go）。
+//
+// 返回的是 *leasedBrowser 而非裸 *headless_browser.Browser：它内嵌了后者，
+// 调用方用到的 NewPage 由方法提升直接透传，只有 Close 被拦下来顺便归还名额，
+// 所以 19 个调用点一处都不用改。
+func newBrowser() *leasedBrowser {
+	return newLeasedBrowser(func() *headless_browser.Browser {
+		return browser.NewBrowser(configs.IsHeadless(),
+			browser.WithFingerprintSeed(configs.FingerprintSeed()),
+			browser.WithProxy(configs.Proxy()),
+		)
+	})
 }
 
 func saveCookies(page *rod.Page) error {

--- a/service.go
+++ b/service.go
@@ -143,12 +143,20 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 		b.Close()
 	}
 
+	// 这是唯一一个浏览器要活过函数返回的方法（后台等扫码），所以不能简单 defer 关闭。
+	// 但也不能等确定分支再 defer：FetchQrcodeImage 内部有 Must* 会 panic，那时 deferFunc
+	// 还没挂上，整个浏览器进程组（实测约 300MB）就永久泄漏了，在 1200MB 的容器里
+	// 泄漏两次就够触发一次 OOM。改成默认关闭 + 显式移交。
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			deferFunc()
+		}
+	}()
+
 	loginAction := xiaohongshu.NewLogin(page)
 
 	img, loggedIn, err := loginAction.FetchQrcodeImage(ctx)
-	if err != nil || loggedIn {
-		defer deferFunc()
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +164,9 @@ func (s *XiaohongshuService) GetLoginQrcode(ctx context.Context) (*LoginQrcodeRe
 	timeout := 4 * time.Minute
 
 	if !loggedIn {
+		// 所有权交给后台 goroutine，由它负责关闭
 		s.waitScanInBackground(loginAction, page, deferFunc, timeout)
+		handedOff = true
 	}
 
 	return &LoginQrcodeResponse{


### PR DESCRIPTION
两个都是会把容器整个打挂的内存问题，共用同一套浏览器生命周期，放在一个 PR 里。

## 一、没有任何并发控制

每次 `newBrowser()` 都是一整个 Chromium 进程组，而在此之前**全项目没有并发控制**：18 个 MCP 工具和 20 条 REST 端点共用一个 service 单例，`net/http` 一请求一 goroutine，两个请求撞上就是两套完整浏览器一起把容器推向 OOM —— 而 OOM 杀掉的是**整个容器**，不是那一个请求。

新增 `browser_lease.go`：一个带上限的信号量，`newBrowser` 取名额、`Close` 归还。

并发度默认取 2，依据是在目标机器（2 核 / 容器上限 1200MB）上的实测：

| 并发 | 峰值内存 | 单请求耗时 | 吞吐 | 余量 |
|---|---|---|---|---|
| 1 | 528MB | 9.3s | 6.5 次/分 | 672MB |
| 2 | 736MB | 13s | 9.2 次/分 | 464MB ← 取这个 |
| 3 | 975MB | 18.5s | 9.7 次/分 | 225MB |

3 的吞吐只比 2 多 5%（2 核 CPU 已经争抢），延迟却翻倍，余量还掉到 225MB —— 评论多的详情页能轻松吃掉这点余量。可用 `XHS_BROWSER_CONCURRENCY` 覆盖，换机器（尤其是改了 mem_limit 或 CPU 数）要重新实测。

> **关于内存口径**：必须读 cgroup 的 `memory.current`，不能把 11 个 chrome 进程的 `ps` RSS 相加 —— 后者会把进程间共享的二进制映射和 zygote 的 CoW 页重复计算 11 次，实测高估近一倍（996MB vs 528MB），照那个数字算会误判成「并发上限只能是 1」。

## 二、扫码登录路径上泄漏整个浏览器进程组

`GetLoginQrcode` 是唯一一个浏览器要活过函数返回的方法（后台 goroutine 等扫码），所以不能简单 defer 关闭。但原先是等拿到结果再按分支 defer：

```go
img, loggedIn, err := loginAction.FetchQrcodeImage(ctx)
if err != nil || loggedIn {
    defer deferFunc()
}
```

`FetchQrcodeImage` 内部有 `Must*` 调用，失败时是 **panic 而非返回 error**。panic 发生在这行赋值语句里，此时 `deferFunc` 还没挂上，整个浏览器进程组（实测约 300MB）就永久泄漏了 —— 在 1200MB 的容器里泄漏两次就够触发一次 OOM。

改成默认关闭 + 显式移交：先无条件挂 defer，只有真正把所有权交给后台 goroutine 时才置 `handedOff` 跳过关闭。任何 panic 路径都能正常回收。

这两件事是耦合的：有了闸门之后，泄漏的就不只是内存，还有名额 —— 漏够 2 次所有请求会永久卡在取名额上。

## 实现上的两点取舍

1. `newBrowser` 返回 `*leasedBrowser`（内嵌 `*headless_browser.Browser`）而不是改所有调用点签名。调用方只用到 `Close` 和 `NewPage`（已 grep 核对，19 个调用点无一例外），靠 Go 的方法提升自动透传，唯一被拦截的就是 `Close`。

2. 排队超时（60 秒）后 panic 而非返回 error，同样是为了不改动 19 个调用点。MCP 侧有 `withPanicRecovery`、REST 侧有 `gin.Recovery()`，都会转成正常错误响应。建浏览器本身 panic 时（内置浏览器不可用）会先归还名额再继续抛。

## 验证

`gofmt` / `go build` / `go vet` / `go test ./...` 均通过。