### PR TITLE
feat: 笔记、评论、通知补上可读时间，不再只给裸时间戳

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -483,6 +483,7 @@ Content-Type: application/json
         "desc": "笔记详细内容描述",
         "type": "normal",
         "time": 1702195200000,
+        "timeText": "2023-12-10 16:00",
         "ipLocation": "浙江",
         "user": {
           "userId": "user_id_123",
@@ -516,6 +517,7 @@ Content-Type: application/json
             "content": "评论内容",
             "likeCount": "10",
             "createTime": 1702195200000,
+            "createTimeText": "2023-12-10 16:00",
             "ipLocation": "北京",
             "liked": false,
             "userInfo": {
@@ -529,6 +531,7 @@ Content-Type: application/json
                 "id": "sub_comment_id_1",
                 "content": "子评论内容",
                 "createTime": 1702195300000,
+                "createTimeText": "2023-12-10 16:01",
                 "userInfo": {
                   "nickname": "回复者昵称"
                 }

--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -994,10 +994,16 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 		return nil, fmt.Errorf("feed %s not found in noteDetailMap", feedID)
 	}
 
-	return &FeedDetailResponse{
+	detail := &FeedDetailResponse{
 		Note:     noteDetail.Note,
 		Comments: noteDetail.Comments,
-	}, nil
+	}
+
+	// 站点只给裸时间戳，可读形式在这里补上，见 timefmt.go
+	detail.Note.TimeText = timestampText(detail.Note.Time)
+	fillCommentTimeText(detail.Comments.List)
+
+	return detail, nil
 }
 
 func makeFeedDetailURL(feedID, xsecToken string) string {

--- a/xiaohongshu/notification.go
+++ b/xiaohongshu/notification.go
@@ -64,10 +64,12 @@ type NotificationUser struct {
 // FeedID / FeedXsecToken 取自笔记信息，与 get_feed_detail、reply_comment_in_feed
 // 所需的参数一致，调用方可以直接拿去读原帖或走笔记页回复。
 type NotificationItem struct {
-	ID            string           `json:"id"`
-	Type          string           `json:"type"`
-	Title         string           `json:"title"`
-	Time          int64            `json:"time"`
+	ID    string `json:"id"`
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	Time  int64  `json:"time"`
+	// TimeText 是 Time 的可读形式（东八区），由服务端回填。
+	TimeText      string           `json:"time_text,omitempty"`
 	From          NotificationUser `json:"from"`
 	CommentID     string           `json:"comment_id,omitempty"`
 	CommentText   string           `json:"comment_text,omitempty"`
@@ -332,10 +334,11 @@ func convertNotifications(raw []rawNotification, limit int) ([]NotificationItem,
 
 		u := r.from()
 		item := NotificationItem{
-			ID:    r.ID,
-			Type:  r.Type,
-			Title: r.Title,
-			Time:  r.Time,
+			ID:       r.ID,
+			Type:     r.Type,
+			Title:    r.Title,
+			Time:     r.Time,
+			TimeText: timestampText(r.Time),
 			From: NotificationUser{
 				UserID:    u.UserID,
 				Nickname:  u.Nickname,

--- a/xiaohongshu/timefmt.go
+++ b/xiaohongshu/timefmt.go
@@ -1,0 +1,43 @@
+package xiaohongshu
+
+import "time"
+
+// cstZone 小红书是国内站点，时间戳一律按东八区渲染。
+//
+// 用 FixedZone 而不是 LoadLocation("Asia/Shanghai")：后者依赖系统 tzdata，
+// 精简镜像（scratch、未装 tzdata 的 alpine）里会返回错误，稍不留神就静默退化成
+// UTC，整体差 8 小时——而这种偏差在返回体里看不出异常，只会让调用方算错日期。
+var cstZone = time.FixedZone("CST", 8*60*60)
+
+// msTimestampMin 秒与毫秒时间戳的分界。
+//
+// 1e12 当秒是公元 33658 年，当毫秒是 2001-09-09，现代时间戳落在哪一侧都没有歧义。
+// 之所以自适应而不是写死单位：笔记与评论的时间戳是 13 位毫秒，
+// 而通知列表的 time 单位站点未作保证，写死一种会在另一处错三个数量级。
+const msTimestampMin int64 = 1e12
+
+// timestampText 把站点给的 Unix 时间戳渲染成东八区的 "2006-01-02 15:04"。
+//
+// 非正数（字段缺失时的零值）返回空串，配合 tag 上的 omitempty 直接不落进返回体。
+// 否则调用方会读到 "1970-01-01 08:00" 并当成真实发布日期。
+func timestampText(ts int64) string {
+	if ts <= 0 {
+		return ""
+	}
+
+	t := time.Unix(ts, 0)
+	if ts >= msTimestampMin {
+		t = time.UnixMilli(ts)
+	}
+	return t.In(cstZone).Format("2006-01-02 15:04")
+}
+
+// fillCommentTimeText 递归回填评论及其子评论的可读时间。
+//
+// 必须按下标改写：for range 拿到的是 Comment 副本，写进副本等于什么都没做。
+func fillCommentTimeText(comments []Comment) {
+	for i := range comments {
+		comments[i].CreateTimeText = timestampText(comments[i].CreateTime)
+		fillCommentTimeText(comments[i].SubComments)
+	}
+}

--- a/xiaohongshu/timefmt_test.go
+++ b/xiaohongshu/timefmt_test.go
@@ -1,0 +1,83 @@
+package xiaohongshu
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestampText(t *testing.T) {
+	cases := []struct {
+		name string
+		ts   int64
+		want string
+	}{
+		// 笔记与评论给的是 13 位毫秒
+		{"毫秒", 1702195200000, "2023-12-10 16:00"},
+		// 单位判断错会把这个值读成 1970-01-20
+		{"秒", 1702195200, "2023-12-10 16:00"},
+		{"分界值按毫秒读", msTimestampMin, "2001-09-09 09:46"},
+		{"分界值下一位按秒读", msTimestampMin - 1, "33658-09-27 09:46"},
+		// 站点没给该字段时的零值，不能渲染成 1970
+		{"零值", 0, ""},
+		{"负数", -1, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, timestampText(c.ts))
+		})
+	}
+}
+
+// TestTimestampText_IgnoresLocalZone 钉住时区：输出跟着东八区走，
+// 不跟运行机器的 TZ 走，否则同一条笔记在不同部署环境里日期会不一样。
+func TestTimestampText_IgnoresLocalZone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	assert.Equal(t, "2023-12-10 16:00", timestampText(1702195200000))
+}
+
+// TestFillCommentTimeText_Nested 子评论同样要回填。
+// 这里也钉住「按下标改写」——若改回 for range 副本，断言会全部落空。
+func TestFillCommentTimeText_Nested(t *testing.T) {
+	comments := []Comment{
+		{
+			ID:         "c1",
+			CreateTime: 1702195200000,
+			SubComments: []Comment{
+				{ID: "c1-1", CreateTime: 1702195300000},
+				{ID: "c1-2", CreateTime: 0}, // 缺失时间戳，保持空串
+			},
+		},
+		{ID: "c2", CreateTime: 1702281600000},
+	}
+
+	fillCommentTimeText(comments)
+
+	assert.Equal(t, "2023-12-10 16:00", comments[0].CreateTimeText)
+	assert.Equal(t, "2023-12-10 16:01", comments[0].SubComments[0].CreateTimeText)
+	assert.Empty(t, comments[0].SubComments[1].CreateTimeText)
+	assert.Equal(t, "2023-12-11 16:00", comments[1].CreateTimeText)
+}
+
+// TestTimeText_OmitEmpty 没有时间戳时字段不应出现在返回体里，
+// 免得调用方看到 "timeText": "" 以为站点真给了个空日期。
+func TestTimeText_OmitEmpty(t *testing.T) {
+	empty, err := json.Marshal(Comment{ID: "c1"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(empty), "createTimeText")
+
+	filled, err := json.Marshal(Comment{ID: "c1", CreateTimeText: "2023-12-10 16:00"})
+	require.NoError(t, err)
+	assert.Contains(t, string(filled), `"createTimeText":"2023-12-10 16:00"`)
+
+	note, err := json.Marshal(FeedDetail{NoteID: "n1"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(note), "timeText")
+
+	item, err := json.Marshal(NotificationItem{ID: "i1"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(item), "time_text")
+}

--- a/xiaohongshu/types.go
+++ b/xiaohongshu/types.go
@@ -115,12 +115,15 @@ type FeedDetailResponse struct {
 
 // FeedDetail 表示详情页的笔记内容
 type FeedDetail struct {
-	NoteID       string            `json:"noteId"`
-	XsecToken    string            `json:"xsecToken"`
-	Title        string            `json:"title"`
-	Desc         string            `json:"desc"`
-	Type         string            `json:"type"`
-	Time         int64             `json:"time"`
+	NoteID    string `json:"noteId"`
+	XsecToken string `json:"xsecToken"`
+	Title     string `json:"title"`
+	Desc      string `json:"desc"`
+	Type      string `json:"type"`
+	Time      int64  `json:"time"`
+	// TimeText 是 Time 的可读形式（东八区），站点原始数据里没有，由服务端回填。
+	// 裸时间戳交给大模型自己换算，常见的错法是漏掉毫秒或忽略时区。
+	TimeText     string            `json:"timeText,omitempty"`
 	IPLocation   string            `json:"ipLocation"`
 	User         User              `json:"user"`
 	InteractInfo InteractInfo      `json:"interactInfo"`
@@ -255,11 +258,13 @@ type CommentList struct {
 
 // Comment 表示单条评论
 type Comment struct {
-	ID              string    `json:"id"`
-	NoteID          string    `json:"noteId"`
-	Content         string    `json:"content"`
-	LikeCount       string    `json:"likeCount"`
-	CreateTime      int64     `json:"createTime"`
+	ID         string `json:"id"`
+	NoteID     string `json:"noteId"`
+	Content    string `json:"content"`
+	LikeCount  string `json:"likeCount"`
+	CreateTime int64  `json:"createTime"`
+	// CreateTimeText 是 CreateTime 的可读形式（东八区），由服务端回填，子评论同样有。
+	CreateTimeText  string    `json:"createTimeText,omitempty"`
 	IPLocation      string    `json:"ipLocation"`
 	Liked           bool      `json:"liked"`
 	UserInfo        User      `json:"userInfo"`


### PR DESCRIPTION
## 动机

站点返回的时间只有 Unix 时间戳。裸时间戳交给大模型自己换算，常见的错法是**漏掉毫秒**（差三个数量级）或**忽略时区**（差 8 小时），而这类偏差在返回体里看不出异常，只会让调用方安静地算错日期。

## 改动

- 新增 `xiaohongshu/timefmt.go`，把时间戳渲染成东八区的 `2006-01-02 15:04`
- 三处新增字段，均为 `omitempty`，不影响现有返回结构：
  - `FeedDetail.TimeText`
  - `Comment.CreateTimeText`（含子评论，递归回填）
  - `NotificationItem.TimeText`
- `docs/API.md` 同步补上示例字段

## 几个实现取舍

**1. 时区用 `time.FixedZone` 而不是 `LoadLocation("Asia/Shanghai")`。**

后者依赖系统 tzdata，精简镜像（scratch、未装 tzdata 的 alpine）里会返回错误，稍不留神就静默退化成 UTC，整体差 8 小时。

**2. 秒 / 毫秒自适应，以 `1e12` 为界。**

这个界当秒是公元 33658 年，当毫秒是 2001-09-09，现代时间戳落在哪一侧都没有歧义。之所以不写死单位——笔记与评论是 13 位毫秒，而通知列表的 `time` 单位站点未作保证，写死一种会在另一处错三个数量级。

**3. 时间戳非正数时返回空串**，配合 `omitempty` 直接不落进返回体。否则调用方会读到 `1970-01-01 08:00` 并当成真实发布日期。

## 验证

附 `timefmt_test.go`，覆盖秒/毫秒、分界值两侧、零值与负数，并有一个用例固定 `TZ` 验证不受宿主时区影响：

```
--- PASS: TestTimestampText/毫秒
--- PASS: TestTimestampText/秒
--- PASS: TestTimestampText/分界值按毫秒读
--- PASS: TestTimestampText/分界值下一位按秒读
--- PASS: TestTimestampText/零值
--- PASS: TestTimestampText/负数
--- PASS: TestTimestampText_IgnoresLocalZone
```

`gofmt` / `go build` / `go vet` / `go test ./...` 均通过。