### PR TITLE
fix(search): 等搜索结果注水而非等 DOM 静止，修 search_feeds 60s 超时

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -101,13 +101,13 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	}
 
 	// 注意 .Context(ctx) 会替换掉 NewSearchAction 里设的 60s deadline，必须在其后重新 Timeout，
-	// 否则搜索页不 stable 时 MustWaitStable/MustWait 会永久挂起（无 deadline 可依赖）。
+	// 否则页面等待没有 deadline 可依赖，异常时会永久挂起。
 	page := s.page.Context(ctx).Timeout(60 * time.Second)
 
 	searchURL := makeSearchURL(keyword)
 	page.MustNavigate(searchURL)
-	page.MustWaitStable()
-	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
+	page.MustWaitLoad()
+	waitFeedsLoaded(page, 20*time.Second)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
 	if len(pending) > 0 {
@@ -178,6 +178,26 @@ func readFeedIDs(page *rod.Page) string {
 		return ""
 	}
 	return res.Value.Str()
+}
+
+// waitFeedsLoaded 等首屏搜索结果注水进 __INITIAL_STATE__.search.feeds。
+//
+// 不能用 MustWaitStable：搜索页有信息流和图片懒加载，DOM 一直在变、等不到静止，
+// 60s deadline 会整个耗在这一步。
+//
+// 也不能只判断 __INITIAL_STATE__ !== undefined：导航刚发起时它还是上一页的对象，
+// 条件立刻为真，于是读到上一页的 feeds——和下面 waitFeedsChanged 记的是同一个坑。
+//
+// 超时不报错：把判定交给后面统一的 ErrNoFeeds，与 feeds.go 里等注水的做法一致。
+func waitFeedsLoaded(page *rod.Page, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if readFeedIDs(page) != "" {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	logrus.Warnf("等待搜索结果加载超时（%s）", timeout)
 }
 
 // waitFeedsChanged 等筛选后的数据到位。


### PR DESCRIPTION
## 问题

`search_feeds` 在已登录状态下稳定 60s 超时（`context deadline exceeded`），`list_feeds` 等其它工具正常。对应 #813、#836。

## 根因

`xiaohongshu/search.go` 里导航之后的两行等待都不成立：

```go
page.MustWaitStable()
page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
```

1. **`MustWaitStable()` 等不到静止。** 搜索页有信息流和图片懒加载，DOM 一直在变，60s deadline 会整个耗在这一步 —— 这是超时的直接原因。

2. **`__INITIAL_STATE__ !== undefined` 不是就绪信号。** 导航刚发起时它还是**上一个页面**的对象，条件立刻为真。把第 1 点单独修掉之后，这一点会让搜索**快速返回上一页的 feeds**（我实测搜「螺蛳粉」返回的是首页推荐流，标题命中 0/20）——比超时更隐蔽。

这第 2 点其实项目里已经记录过：`waitFeedsChanged` 的注释写着「原先用 MustWait(__INITIAL_STATE__ !== undefined) 等，而这个条件从首屏起就为真、立即返回，等于没等」。当时修了筛选那一半，首屏这一半没修到。

## 改动

```go
page.MustWaitLoad()
waitFeedsLoaded(page, 20*time.Second)
```

`waitFeedsLoaded` 先由 `MustWaitLoad()` 确保新文档就位（旧 JS 上下文随之销毁，不会再读到上一页），再按 300ms 间隔轮询已有的 `readFeedIDs()` 直到结果注水。

几点取舍：

- **不新增 JS 注入**，复用已有的 `readFeedIDs()` / `feedIDsJS`。
- **超时不报错**，交给后面统一的 `ErrNoFeeds` 判定，与 `feeds.go` 里等 `__INITIAL_STATE__.feed` 注水、`waitFeedsChanged` 等筛选结果的做法一致。
- 20s 上限是在 60s 页面 deadline 内留出余量给后续筛选和取数。副作用是**真正零结果的关键词会等满 20s 才返回 `ErrNoFeeds`**；如果希望更短，把这个值调小即可。

## 验证

本地构建镜像实测（已登录，账号信息打码）。**修改前**三次调用均为 60s 超时 panic：

```
Tool handler panicked  panic="context deadline exceeded"  tool=search_feeds
    at xiaohongshu/search.go:110  rod.(*Page).MustWait
```

**修改后**：

```
$ check_login_status
✅ 已登录
用户名: ***

$ search_feeds 螺蛳粉
笔记数=20  标题命中=16/20   耗时 7316 ms
   · 北京螺蛳粉唯一真神
   · 你在北京吃过最好吃的螺蛳粉是哪家的？
   · 北京螺蛳粉品鉴
   · 好欢螺·臭宝·李子柒·三只松鼠 无广实测

$ search_feeds 潜水
笔记数=20  标题命中=15/20   耗时 7944 ms
   · 潜水界的泥石流be like
   · 北京的潜水池还挺好玩的
   · 潜水遇到这些东西有的要跑，有的不用跑！

$ search_feeds 北京老破小
笔记数=20  标题命中=13/20   耗时 8659 ms
   · 北京老破小二手房已成交
   · 190万！拿下东二环两居室！
   · 刚刚签约北京老破小
```

「标题命中」= 返回笔记标题中包含关键词字符的条数，用来确认返回的确实是该关键词的搜索结果，而不是上一页残留。

> 本项目是无界面的服务端工具，演示以终端输出形式给出；账号名已打码，搜索结果均为公开笔记标题。

环境：Linux Docker（基于仓库 Dockerfile 构建）、v2.5.0 源码、headless。

## Checklist

- [x] 代码已在本地运行并验证通过
- [x] 一个 PR 仅包含一个修复
- [x] 附上演示（账号信息已打码）
- [x] 没有新增 JS 注入，复用已有 helper
- [x] `gofmt` / `go vet` / `go build` / `go test ./xiaohongshu/` 均通过，注释为中文
