### PR TITLE
perf: 复用浏览器实例，每个请求只开一个标签页（每次调用省 4–5 秒）

### DIFF
--- a/browser_pool.go
+++ b/browser_pool.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/sirupsen/logrus"
+	"github.com/xpzouying/headless_browser"
+	"github.com/xpzouying/xiaohongshu-mcp/cookies"
+)
+
+// 复用浏览器。
+//
+// 上游每个请求都冷启动一个 Chrome（约 2–3 秒）再关掉；这里改成常驻一个浏览器，每个请求只开一个标签页。
+// 会触发重建的情况：cookies 文件有变化（重新登录 / 删除）、开页失败（浏览器已死）、存活超过 maxAge、
+// 累计开页数超过 maxPages（防内存缓慢增长）。设置 XHS_BROWSER_REUSE=0 可回到上游的每请求新开浏览器。
+
+const (
+	sharedBrowserMaxAge   = 30 * time.Minute
+	sharedBrowserMaxPages = 200
+)
+
+type sharedBrowser struct {
+	mu          sync.Mutex
+	b           *headless_browser.Browser
+	cookieMtime time.Time
+	createdAt   time.Time
+	pages       int
+}
+
+var browserPool sharedBrowser
+
+func browserReuseEnabled() bool {
+	return os.Getenv("XHS_BROWSER_REUSE") != "0"
+}
+
+func cookieFileMtime() time.Time {
+	st, err := os.Stat(cookies.GetCookiesFilePath())
+	if err != nil {
+		return time.Time{}
+	}
+	return st.ModTime()
+}
+
+func (p *sharedBrowser) closeLocked(reason string) {
+	if p.b == nil {
+		return
+	}
+	logrus.Infof("关闭共享浏览器（%s；已开 %d 页，存活 %s）", reason, p.pages, time.Since(p.createdAt).Round(time.Second))
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logrus.Warnf("关闭共享浏览器出错: %v", r)
+			}
+		}()
+		p.b.Close()
+	}()
+	p.b = nil
+}
+
+func (p *sharedBrowser) staleReasonLocked() string {
+	switch {
+	case p.b == nil:
+		return ""
+	case !cookieFileMtime().Equal(p.cookieMtime):
+		return "cookies 文件已变化"
+	case time.Since(p.createdAt) > sharedBrowserMaxAge:
+		return "超过最大存活时间"
+	case p.pages >= sharedBrowserMaxPages:
+		return "开页数达到上限"
+	}
+	return ""
+}
+
+func tryNewPage(b *headless_browser.Browser) (page *rod.Page, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return b.NewPage(), nil
+}
+
+// newPageLocked 在共享浏览器上开一页；浏览器已死（开页 panic）则重建一次再试。
+func (p *sharedBrowser) newPageLocked() (*headless_browser.Browser, *rod.Page) {
+	for attempt := 0; attempt < 2; attempt++ {
+		if p.b == nil {
+			p.b = newBrowser()
+			p.cookieMtime = cookieFileMtime()
+			p.createdAt = time.Now()
+			p.pages = 0
+			logrus.Info("共享浏览器已启动")
+		}
+		page, err := tryNewPage(p.b)
+		if err == nil {
+			p.pages++
+			return p.b, page
+		}
+		logrus.Warnf("共享浏览器开页失败，重建: %v", err)
+		p.closeLocked("开页失败")
+	}
+	panic("共享浏览器重建后仍无法开页")
+}
+
+// acquirePage 取一个可用页面。复用关闭时退化为上游行为：新开一个浏览器。
+func acquirePage() (*headless_browser.Browser, *rod.Page) {
+	if !browserReuseEnabled() {
+		b := newBrowser()
+		return b, b.NewPage()
+	}
+	p := &browserPool
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if reason := p.staleReasonLocked(); reason != "" {
+		p.closeLocked(reason)
+	}
+	return p.newPageLocked()
+}
+
+// releasePage 请求结束：关掉页面；不复用时连浏览器一起关。
+func releasePage(b *headless_browser.Browser, page *rod.Page) {
+	if err := page.Close(); err != nil {
+		logrus.Debugf("关闭页面出错: %v", err)
+	}
+	if !browserReuseEnabled() {
+		b.Close()
+	}
+}
+
+// resetSharedBrowser 主动关闭共享浏览器（删除 cookies 后调用，避免继续用旧登录态）。
+func resetSharedBrowser() {
+	p := &browserPool
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closeLocked("手动重置")
+}

--- a/service.go
+++ b/service.go
@@ -98,16 +98,15 @@ type UserProfileResponse struct {
 func (s *XiaohongshuService) DeleteCookies(ctx context.Context) error {
 	cookiePath := cookies.GetCookiesFilePath()
 	cookieLoader := cookies.NewLoadCookie(cookiePath)
-	return cookieLoader.DeleteCookies()
+	err := cookieLoader.DeleteCookies()
+	resetSharedBrowser()
+	return err
 }
 
 // CheckLoginStatus 检查登录状态
 func (s *XiaohongshuService) CheckLoginStatus(ctx context.Context) (*LoginStatusResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	loginAction := xiaohongshu.NewLogin(page)
 
@@ -272,11 +271,8 @@ func (s *XiaohongshuService) processImages(images []string) ([]string, error) {
 
 // publishContent 执行内容发布
 func (s *XiaohongshuService) publishContent(ctx context.Context, content xiaohongshu.PublishImageContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action, err := xiaohongshu.NewPublishImageAction(page)
 	if err != nil {
@@ -351,11 +347,8 @@ func (s *XiaohongshuService) PublishVideo(ctx context.Context, req *PublishVideo
 
 // publishVideo 执行视频发布
 func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongshu.PublishVideoContent) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action, err := xiaohongshu.NewPublishVideoAction(page)
 	if err != nil {
@@ -367,11 +360,8 @@ func (s *XiaohongshuService) publishVideo(ctx context.Context, content xiaohongs
 
 // ListFeeds 获取Feeds列表
 func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewFeedsListAction(page)
 
@@ -390,11 +380,8 @@ func (s *XiaohongshuService) ListFeeds(ctx context.Context) (*FeedsListResponse,
 }
 
 func (s *XiaohongshuService) SearchFeeds(ctx context.Context, keyword string, filters ...xiaohongshu.FilterOption) (*FeedsListResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewSearchAction(page)
 
@@ -418,11 +405,8 @@ func (s *XiaohongshuService) GetFeedDetail(ctx context.Context, feedID, xsecToke
 
 // GetFeedDetailWithConfig 使用配置获取Feed详情
 func (s *XiaohongshuService) GetFeedDetailWithConfig(ctx context.Context, feedID, xsecToken string, loadAllComments bool, config xiaohongshu.CommentLoadConfig) (*FeedDetailResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewFeedDetailAction(page)
 
@@ -446,11 +430,8 @@ func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken,
 		return nil, err
 	}
 
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewUserProfileAction(page)
 
@@ -470,11 +451,8 @@ func (s *XiaohongshuService) UserProfile(ctx context.Context, userID, xsecToken,
 
 // PostCommentToFeed 发表评论到Feed
 func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsecToken, content string) (*PostCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewCommentFeedAction(page)
 
@@ -487,11 +465,8 @@ func (s *XiaohongshuService) PostCommentToFeed(ctx context.Context, feedID, xsec
 
 // LikeFeed 点赞笔记
 func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewLikeAction(page)
 	if err := action.Like(ctx, feedID, xsecToken); err != nil {
@@ -502,11 +477,8 @@ func (s *XiaohongshuService) LikeFeed(ctx context.Context, feedID, xsecToken str
 
 // UnlikeFeed 取消点赞笔记
 func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewLikeAction(page)
 	if err := action.Unlike(ctx, feedID, xsecToken); err != nil {
@@ -517,11 +489,8 @@ func (s *XiaohongshuService) UnlikeFeed(ctx context.Context, feedID, xsecToken s
 
 // FavoriteFeed 收藏笔记
 func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewFavoriteAction(page)
 	if err := action.Favorite(ctx, feedID, xsecToken); err != nil {
@@ -532,11 +501,8 @@ func (s *XiaohongshuService) FavoriteFeed(ctx context.Context, feedID, xsecToken
 
 // UnfavoriteFeed 取消收藏笔记
 func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecToken string) (*ActionResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewFavoriteAction(page)
 	if err := action.Unfavorite(ctx, feedID, xsecToken); err != nil {
@@ -547,11 +513,8 @@ func (s *XiaohongshuService) UnfavoriteFeed(ctx context.Context, feedID, xsecTok
 
 // ReplyCommentToFeed 回复指定评论
 func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xsecToken, commentID, userID, content string) (*ReplyCommentResponse, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	action := xiaohongshu.NewCommentFeedAction(page)
 
@@ -570,11 +533,8 @@ func (s *XiaohongshuService) ReplyCommentToFeed(ctx context.Context, feedID, xse
 
 // GetUnreadCount 获取通知未读数
 func (s *XiaohongshuService) GetUnreadCount(ctx context.Context) (*xiaohongshu.NotificationCount, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	return xiaohongshu.NewNotificationAction(page).UnreadCount(ctx)
 }
@@ -586,33 +546,24 @@ func (s *XiaohongshuService) ListNotifications(ctx context.Context, tab string, 
 		return nil, err
 	}
 
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	return xiaohongshu.NewNotificationAction(page).List(ctx, parsed, limit)
 }
 
 // LikeNotification 给通知里的评论点赞或取消点赞
 func (s *XiaohongshuService) LikeNotification(ctx context.Context, commentID string, unlike bool) (*xiaohongshu.NotificationLikeResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	return xiaohongshu.NewNotificationAction(page).Like(ctx, commentID, unlike)
 }
 
 // ReplyNotification 在通知页就地回复评论
 func (s *XiaohongshuService) ReplyNotification(ctx context.Context, commentID, content string) (*xiaohongshu.NotificationReplyResult, error) {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	return xiaohongshu.NewNotificationAction(page).Reply(ctx, commentID, content)
 }
@@ -641,11 +592,8 @@ func saveCookies(page *rod.Page) error {
 
 // withBrowserPage 执行需要浏览器页面的操作的通用函数
 func withBrowserPage(fn func(*rod.Page) error) error {
-	b := newBrowser()
-	defer b.Close()
-
-	page := b.NewPage()
-	defer page.Close()
+	b, page := acquirePage()
+	defer releasePage(b, page)
 
 	return fn(page)
 }


### PR DESCRIPTION
## 背景

目前每个工具调用都走 `newBrowser()` → 用完 `Close()`。在本机（Linux x64，v2.5.0，headless）的服务日志里统计了一个会话：79 个 API 请求启动了 80 个浏览器。`check_login_status` 的中位耗时 5.2 秒，基本就是"冷启动 Chrome + 打开一页"的底价；`get_feed_detail` 中位 9.6 秒、`search_feeds` 13 秒，其中每次都有 4–5 秒花在启动和关闭浏览器上。

## 改动

新增 `browser_pool.go`：常驻一个浏览器，每个请求只 `NewPage()` 开一个标签页，用完关页。

- 自动重建的条件：cookies 文件有变化（重新登录 / 删除 cookies）、开页失败（浏览器已死，重建一次再试）、存活超过 30 分钟、累计开页超过 200（防内存缓慢增长）
- `DeleteCookies` 后主动重置，避免继续用旧登录态
- 二维码登录流程（`GetLoginQrcode`）仍使用独立浏览器，行为不变；登录成功写入 cookies 后，共享浏览器会因文件变化在下次请求时重建并加载新 cookies
- `XHS_BROWSER_REUSE=0` 可回到原来的每请求新开浏览器；如果更希望默认关闭，改 `browserReuseEnabled()` 一行即可

`service.go` 里 18 处 `b := newBrowser(); defer b.Close(); page := b.NewPage(); defer page.Close()` 统一改为 `b, page := acquirePage(); defer releasePage(b, page)`，逻辑本身不变。

## 效果（本机实测）

| 调用 | 改前 | 改后 |
|---|---|---|
| `get_feed_detail`（默认评论） | 9.6 s 中位 | 4–5 s |
| `search_feeds`（在 #839 基础上） | 6 s | 3.5–5 s |
| `check_login_status` | 5.2 s | 首次 5 s，之后约 1 s |

多个请求并发时各自开标签页，互不影响；跑了几十次 search / detail 混合调用无异常。

## 测试

`go build ./...`、`go vet ./...`、`go test ./...`、五个平台交叉编译、`go test -tags integration -run '^$'` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
