### PR TITLE
perf(detail): 详情页等 noteDetailMap 注水而不是等 DOM 静止；导航限时 12 秒（单篇 9.6s → 5s）

### DIFF
--- a/xiaohongshu/feed_detail.go
+++ b/xiaohongshu/feed_detail.go
@@ -108,9 +108,10 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 	// 使用retry-go处理页面导航和DOM稳定等待
 	err := retry.Do(
 		func() error {
-			page.MustNavigate(url)
-			page.MustWaitDOMStable()
-			return nil
+			// 导航限 12 秒：站点偶尔会把页面 HTML 拖住几十秒，MustNavigate 会一直等到整页
+			// 10 分钟的 deadline；这里超时返回 error 交给 retry.Do 重试。
+			// 不等 load 事件（图片多时它来得很晚），后面直接等 noteDetailMap 注水。
+			return page.Timeout(12 * time.Second).Navigate(url)
 		},
 		retry.Attempts(3),
 		retry.Delay(500*time.Millisecond),
@@ -123,10 +124,16 @@ func (f *FeedDetailAction) GetFeedDetailWithConfig(ctx context.Context, feedID, 
 		logrus.Errorf("页面导航失败: %v", err)
 		return nil, err
 	}
+	// 等这篇笔记的数据注水进 __INITIAL_STATE__.note.noteDetailMap，而不是等 DOM 静止：
+	// 详情页评论区和图片懒加载让 DOM 迟迟不静止，rod 的 WaitDOMStable 至少白等 1 秒、常常 2–3 秒。
+	loaded := waitNoteDetailLoaded(page, feedID, 15*time.Second)
 	humanize.Delay(ctx, humanize.AfterNavigate)
 
-	if err := checkPageAccessible(page); err != nil {
-		return nil, err
+	// 数据到了就不用再花 500ms+ 找错误提示容器；没到才去看是不是被删 / 私密 / 需登录。
+	if !loaded {
+		if err := checkPageAccessible(page); err != nil {
+			return nil, err
+		}
 	}
 
 	if loadAllComments {
@@ -1002,4 +1009,36 @@ func (f *FeedDetailAction) extractFeedDetail(page *rod.Page, feedID string) (*Fe
 
 func makeFeedDetailURL(feedID, xsecToken string) string {
 	return fmt.Sprintf("https://www.xiaohongshu.com/explore/%s?xsec_token=%s&xsec_source=pc_feed", feedID, xsecToken)
+}
+
+// waitNoteDetailLoaded 轮询直到 noteDetailMap[feedID].note 出现（首屏笔记数据），
+// 然后再给首屏评论最多 4 秒到位（评论是挂载后异步请求的；没有评论的笔记不等）。
+// 超时不报错：交给后面的 checkPageAccessible / extractFeedDetail 给出具体原因。
+func waitNoteDetailLoaded(page *rod.Page, feedID string, timeout time.Duration) bool {
+	const noteJS = `(id) => {
+		const m = window.__INITIAL_STATE__ && window.__INITIAL_STATE__.note && window.__INITIAL_STATE__.note.noteDetailMap;
+		return !!(m && m[id] && m[id].note && m[id].note.noteId);
+	}`
+	const commentsJS = `(id) => {
+		const d = window.__INITIAL_STATE__.note.noteDetailMap[id];
+		const list = d.comments && d.comments.list;
+		const count = String((d.note.interactInfo && d.note.interactInfo.commentCount) || "0");
+		return (list && list.length > 0) || count === "0" || count === "";
+	}`
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if res, err := page.Eval(noteJS, feedID); err == nil && res.Value.Bool() {
+			commentDeadline := time.Now().Add(4 * time.Second)
+			for time.Now().Before(commentDeadline) {
+				if r2, err := page.Eval(commentsJS, feedID); err == nil && r2.Value.Bool() {
+					return true
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+			return true
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	logrus.Warnf("等待笔记 %s 数据加载超时（%s）", feedID, timeout)
+	return false
 }


### PR DESCRIPTION
## 背景

`GetFeedDetailWithConfig` 导航后调用 `page.MustWaitDOMStable()`。rod 的实现是"取一次 DOM 快照、等 1 秒、再比较"，所以至少等 1 秒；而详情页的评论区和图片懒加载让 DOM 一直在变，实际经常要 2–3 秒才静止。随后 `checkPageAccessible` 又固定 `time.Sleep(500ms)`，再花最多 2 秒去找错误提示容器——而绝大多数请求页面都是正常的。

另外 `page.MustNavigate(url)` 躺在整页 10 分钟的 deadline 里：站点偶尔会把页面 HTML 拖住几十秒（搜索页上实测过 30–60 秒的案例），详情页遇到同样情况会挂很久。

## 改动

- 导航改为 `page.Timeout(12 * time.Second).Navigate(url)`，超时返回 error 交给已有的 `retry.Do`（3 次）
- 不再等 `load` 事件（图片多的笔记 load 来得很晚，而数据早就注水了），改为轮询 `__INITIAL_STATE__.note.noteDetailMap[feedID].note` 出现（最多 15 秒），再给首屏评论最多 4 秒到位（评论是挂载后异步请求的；`commentCount` 为 0 的笔记不等）
- 数据已到位就跳过 `checkPageAccessible`；没到位才检查，原来的"笔记已删除 / 私密 / 因违规无法查看"等错误信息不变
- 加载全部评论的滚动逻辑不动

思路和 #839 处理搜索页的方式一致：等数据注水，不等 DOM 静止。

## 效果（本机实测）

`get_feed_detail` 单篇从 9.6 秒中位降到约 5 秒；配合 #840 复用浏览器可到 3.5–5 秒。返回的正文、互动数据和首屏评论数与改前一致（同一篇笔记对比：760 字正文、10 条评论）。

## 测试

`go build ./...`、`go vet ./...`、`go test ./...`、五个平台交叉编译、`go test -tags integration -run '^$'` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
