### PR TITLE
fix(search): 搜索页导航限时 12 秒并原地重试一次，站点拖住 HTML 时快速恢复

### DIFF
--- a/xiaohongshu/search.go
+++ b/xiaohongshu/search.go
@@ -105,7 +105,12 @@ func (s *SearchAction) Search(ctx context.Context, keyword string, filters ...Fi
 	page := s.page.Context(ctx).Timeout(60 * time.Second)
 
 	searchURL := makeSearchURL(keyword)
-	page.MustNavigate(searchURL)
+	// 导航单独限时：站点偶尔会把 search_result 的 HTML 拖住几十秒不返回，
+	// MustNavigate 会一直等到整个 60 秒 deadline 才 panic。正常导航不到 1 秒，
+	// 这里 12 秒超时、原地重试一次（第二次通常很快），再不行才报错让调用方处理。
+	if err := navigateWithRetry(page, searchURL, 12*time.Second); err != nil {
+		return nil, fmt.Errorf("打开搜索页失败: %w", err)
+	}
 	page.MustWaitStable()
 	page.MustWait(`() => window.__INITIAL_STATE__ !== undefined`)
 	humanize.Delay(ctx, humanize.AfterNavigate)
@@ -257,4 +262,16 @@ func makeSearchURL(keyword string) string {
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_search_result_notes
 	//https://www.xiaohongshu.com/search_result?keyword=%25E7%258E%258B%25E5%25AD%2590&source=web_explore_feed
 	return fmt.Sprintf("https://www.xiaohongshu.com/search_result?%s", values.Encode())
+}
+
+// navigateWithRetry 带上限的导航，超时立即重试一次。
+func navigateWithRetry(page *rod.Page, url string, timeout time.Duration) error {
+	var err error
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err = page.Timeout(timeout).Navigate(url); err == nil {
+			return nil
+		}
+		logrus.Warnf("导航 %s 超时（第 %d 次，%s）: %v", url, attempt, timeout, err)
+	}
+	return err
 }


### PR DESCRIPTION
## 背景

偶发情况下小红书会把 `search_result` 页面的 HTML 拖住几十秒不返回。这时 `page.MustNavigate(searchURL)` 会一直等到整个 60 秒 deadline 才以 `context deadline exceeded` panic，服务日志里的栈顶就在 `search.go` 的 `MustNavigate`：

```
context deadline exceeded
github.com/go-rod/rod@v0.116.2/must.go:232
github.com/xpzouying/xiaohongshu-mcp/xiaohongshu/search.go:108
```

这 60 秒里什么都做不了，调用方也只能等满 60 秒才能重试；本机一次遇到连续两次，同一个关键词白白花了 2 分钟。这和 #836 里 `MustWaitStable` 等不到 DOM 静止是两个不同的卡点。

## 改动

正常导航不到 1 秒。这里给导航 12 秒超时、立即原地重试一次，两次都不行才返回错误；其余等待逻辑不变：

```go
if err := navigateWithRetry(page, searchURL, 12*time.Second); err != nil {
    return nil, fmt.Errorf("打开搜索页失败: %w", err)
}
```

与 #839 不冲突：#839 改的是导航之后的等待方式，本 PR 只改导航这一处；两个都合并时只需要一次简单的 rebase。

## 效果（本机实测）

正常搜索不受影响（连跑 12 次 3.5–6 秒返回）。被拖住时：改前要么 60 秒 panic，要么拖 28–31 秒才回来；改后日志里能看到"导航超时（第 1 次，12s）"然后重试成功，整次搜索 19 秒返回正确结果。

## 测试

`go build ./...`、`go vet ./...`、`go test ./...`、五个平台交叉编译、`go test -tags integration -run '^$'` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
